### PR TITLE
feat(cli): add translate command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -75,7 +75,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -100,10 +100,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -147,10 +159,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cc"
+version = "1.2.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -234,7 +262,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -350,7 +378,18 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -410,7 +449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -418,6 +457,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "float-cmp"
@@ -450,6 +495,15 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures"
@@ -534,8 +588,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -546,7 +616,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -603,10 +673,185 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
 
 [[package]]
 name = "id-arena"
@@ -619,6 +864,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "ignore"
@@ -680,6 +946,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +1003,8 @@ version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -753,6 +1037,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,6 +1056,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "ls-types"
@@ -803,7 +1099,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -860,6 +1156,7 @@ dependencies = [
  "pretty_yaml",
  "rayon",
  "regex",
+ "reqwest",
  "rowan",
  "salsa",
  "serde",
@@ -960,6 +1257,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "predicates"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1020,6 +1335,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,9 +1400,44 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "rayon"
@@ -1124,6 +1529,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "roff"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,7 +1622,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1171,6 +1665,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "salsa"
@@ -1289,6 +1789,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1343,10 +1861,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1364,6 +1904,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -1386,7 +1929,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1434,6 +1977,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650d82e943da333637be9f1567d33d605e76810a26464edfd7ae74f7ef181e95"
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1444,8 +2012,9 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1457,6 +2026,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -1521,6 +2100,25 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -1589,6 +2187,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1611,6 +2215,30 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1649,6 +2277,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,6 +2320,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1752,6 +2399,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "which"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1766,7 +2442,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1802,12 +2478,159 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -1913,6 +2736,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "yaml_parser"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1920,6 +2749,109 @@ checksum = "71ebb04c72edf699612d543f6c421142527b85ac180156017fa26be49dc0762f"
 dependencies = [
  "rowan",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ predicates = "3.0"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rayon = "1.10.0"
 which = "8.0"
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 
 [features]
 default = ["cli", "lsp"]

--- a/docs/guide/configuration.qmd
+++ b/docs/guide/configuration.qmd
@@ -162,6 +162,44 @@ version. When any of these change, Panache recomputes and refreshes entries. Use
 invocation. Use `--no-cache` (or `RUFF_NO_CACHE`) to bypass cache reads/writes
 for a single CLI invocation.
 
+## Translation
+
+Configure provider defaults for `panache translate` with `[translate]`:
+
+```toml
+[translate]
+provider = "libretranslate"
+source-lang = "en"
+target-lang = "fr"
+endpoint = "https://libretranslate.example.com/translate"
+api-key = "your-api-key"
+```
+
+`provider`
+
+:   Translation backend to use. Supported values:
+
+    - `libretranslate` - `deepl`
+
+`source-lang`
+:   Optional source language code. If omitted, provider defaults apply (for
+    LibreTranslate this typically means auto-detect).
+
+`target-lang`
+:   Target language code for translations. Required unless passed via
+    `panache translate --target-lang`.
+
+`endpoint`
+:   Optional provider endpoint override. Useful for custom LibreTranslate
+    instances or DeepL endpoint routing.
+
+`api-key`
+:   Provider API key. Required for DeepL and optional/instance-dependent for
+    LibreTranslate.
+
+CLI flags (`--provider`, `--source-lang`, `--target-lang`, `--endpoint`,
+`--api-key`) override values configured in `[translate]`.
+
 ## Formatting Style
 
 Formatting style preferences are organized under the `[format]` section:

--- a/docs/reference/cli.qmd
+++ b/docs/reference/cli.qmd
@@ -22,6 +22,7 @@ For help with a specific command, see: `panache help <command>`.
 * `parse` — Parse and display the CST tree for debugging
 * `lsp` — Start the Language Server Protocol server
 * `lint` — Lint a Quarto, Pandoc, or Markdown document
+* `translate` — Translate human-readable text while preserving document structure
 * `debug` — Debug utilities for parser/formatter diagnostics
 
 ###### **Options:**
@@ -122,6 +123,31 @@ Configure rules in panache.toml with [lint] section.
 
   Possible values: `human`, `short`
 
+* `--force-exclude` — Apply exclude patterns to explicitly provided files
+
+
+
+## `panache translate`
+
+Translate human-readable text in Quarto, Pandoc, or Markdown documents while preserving syntax and structure. With a single input path, translates in place by default. With two input paths, treats them as input and output paths (`in.md out.md`). Stdin input always outputs to stdout.
+
+**Usage:** `panache translate [OPTIONS] [FILES]...`
+
+###### **Arguments:**
+
+* `<FILES>` — Path arguments for translation. If omitted, reads from stdin and writes to stdout. If one path is provided and it is a file, translation is applied in place. If two file paths are provided, the first is input and the second is output. Directory traversal supports .qmd, .md, .Rmd, and other Markdown-based formats.
+
+###### **Options:**
+
+* `--provider <PROVIDER>` — Translation provider to use
+
+  Possible values: `deepl`, `libretranslate`
+
+* `--source-lang <LANG>` — Source language code
+* `--target-lang <LANG>` — Target language code
+* `--api-key <KEY>` — Provider API key
+* `--endpoint <URL>` — Provider endpoint URL
+* `--stdout` — Output translated content to stdout
 * `--force-exclude` — Apply exclude patterns to explicitly provided files
 
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -264,6 +264,59 @@ For editor configuration examples, see: https://github.com/jolars/panache#editor
         #[arg(help = "Apply exclude patterns to explicitly provided files")]
         force_exclude: bool,
     },
+    /// Translate human-readable text while preserving document structure
+    #[command(
+        long_about = "Translate human-readable text in Quarto, Pandoc, or Markdown documents \
+        while preserving syntax and structure. With a single input path, translates in place by default. \
+        With two input paths, treats them as input and output paths (`in.md out.md`). \
+        Stdin input always outputs to stdout."
+    )]
+    Translate {
+        /// Input path(s) (stdin if not provided)
+        #[arg(help = "Input path(s) or input/output file pair")]
+        #[arg(
+            long_help = "Path arguments for translation. If omitted, reads from stdin and writes to stdout. \
+            If one path is provided and it is a file, translation is applied in place. \
+            If two file paths are provided, the first is input and the second is output. \
+            Directory traversal supports .qmd, .md, .Rmd, and other Markdown-based formats."
+        )]
+        files: Vec<PathBuf>,
+
+        /// Translation provider backend
+        #[arg(long, value_enum)]
+        #[arg(help = "Translation provider to use")]
+        provider: Option<TranslateProviderArg>,
+
+        /// Source language code (e.g. en, fr, de). Use auto where supported.
+        #[arg(long, value_name = "LANG")]
+        #[arg(help = "Source language code")]
+        source_lang: Option<String>,
+
+        /// Target language code (e.g. en, fr, de)
+        #[arg(long, value_name = "LANG")]
+        #[arg(help = "Target language code")]
+        target_lang: Option<String>,
+
+        /// Provider API key (overrides config)
+        #[arg(long, value_name = "KEY")]
+        #[arg(help = "Provider API key")]
+        api_key: Option<String>,
+
+        /// Provider endpoint URL (overrides config)
+        #[arg(long, value_name = "URL")]
+        #[arg(help = "Provider endpoint URL")]
+        endpoint: Option<String>,
+
+        /// Print translated output to stdout instead of writing files in place
+        #[arg(long)]
+        #[arg(help = "Output translated content to stdout")]
+        stdout: bool,
+
+        /// Enforce exclude patterns even for explicitly provided files
+        #[arg(long)]
+        #[arg(help = "Apply exclude patterns to explicitly provided files")]
+        force_exclude: bool,
+    },
     /// Debug utilities for parser/formatter diagnostics
     #[command(
         long_about = "Debugging utilities for parse/format workflows. These commands are intended \
@@ -326,4 +379,10 @@ pub enum ColorMode {
 pub enum MessageFormat {
     Human,
     Short,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum TranslateProviderArg {
+    Deepl,
+    Libretranslate,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -908,6 +908,29 @@ impl ParserConfig {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum TranslateProvider {
+    Deepl,
+    Libretranslate,
+}
+
+/// Translation configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct TranslateSettings {
+    /// Translation provider backend.
+    pub provider: Option<TranslateProvider>,
+    /// Source language code (for providers that support explicit source).
+    pub source_lang: Option<String>,
+    /// Target language code.
+    pub target_lang: Option<String>,
+    /// Provider API key.
+    pub api_key: Option<String>,
+    /// Optional custom provider endpoint URL.
+    pub endpoint: Option<String>,
+}
+
 /// Linter configuration.
 /// Preferred shape is `[lint.rules] rule-name = true/false`.
 /// Legacy `[lint] rule-name = true/false` is still supported (deprecated).
@@ -1028,6 +1051,8 @@ struct RawConfig {
     // Parser configuration (deprecated home for pandoc-compat)
     #[serde(default)]
     parser: Option<ParserConfig>,
+    #[serde(default)]
+    translate: Option<TranslateSettings>,
 
     // NEW: Language → Formatter(s) mapping
     // This will be a raw Value that we'll parse manually to handle both formats
@@ -1356,6 +1381,7 @@ impl RawConfig {
             parser: ParserConfig {
                 pandoc_compat: resolved_pandoc_compat,
             },
+            translate: self.translate.unwrap_or_default(),
             built_in_greedy_wrap: style.built_in_greedy_wrap,
             exclude: self.exclude,
             extend_exclude: self.extend_exclude,
@@ -1638,6 +1664,8 @@ pub struct Config {
     pub external_max_parallel: usize,
     /// Parser configuration (experimental)
     pub parser: ParserConfig,
+    /// Translation command configuration.
+    pub translate: TranslateSettings,
     /// Linter rule toggles.
     pub lint: LintConfig,
     /// Optional CLI cache directory override.
@@ -1677,6 +1705,7 @@ impl Default for Config {
             linters: HashMap::new(),    // Opt-in: empty by default
             external_max_parallel: default_external_max_parallel(),
             parser: ParserConfig::default(),
+            translate: TranslateSettings::default(),
             lint: LintConfig::default(),
             cache_dir: None,
             built_in_greedy_wrap: true,
@@ -4139,4 +4168,39 @@ fn test_formatter_prepend_append_args_kebab_case() {
 
     assert_eq!(fmt.cmd, "test");
     assert_eq!(fmt.args, vec!["--before", "--middle", "--after"]);
+}
+
+#[test]
+fn test_translate_section_parses_kebab_case_fields() {
+    let toml_str = r#"
+        [translate]
+        provider = "libretranslate"
+        source-lang = "en"
+        target-lang = "fr"
+        api-key = "secret"
+        endpoint = "https://example.test/translate"
+    "#;
+
+    let cfg = toml::from_str::<Config>(toml_str).unwrap();
+    assert_eq!(
+        cfg.translate.provider,
+        Some(TranslateProvider::Libretranslate)
+    );
+    assert_eq!(cfg.translate.source_lang.as_deref(), Some("en"));
+    assert_eq!(cfg.translate.target_lang.as_deref(), Some("fr"));
+    assert_eq!(cfg.translate.api_key.as_deref(), Some("secret"));
+    assert_eq!(
+        cfg.translate.endpoint.as_deref(),
+        Some("https://example.test/translate")
+    );
+}
+
+#[test]
+fn test_translate_section_defaults_to_none() {
+    let cfg = Config::default();
+    assert_eq!(cfg.translate.provider, None);
+    assert_eq!(cfg.translate.source_lang, None);
+    assert_eq!(cfg.translate.target_lang, None);
+    assert_eq!(cfg.translate.api_key, None);
+    assert_eq!(cfg.translate.endpoint, None);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ pub mod parser;
 pub mod range_utils;
 pub mod salsa;
 pub mod syntax;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod translate;
 mod utils;
 mod yaml_engine;
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ mod cache;
 mod cli;
 mod diagnostic_renderer;
 use cache::{CachedLintDocument, CliCache, FormatCacheMode, FormatStoreArgs};
-use cli::{Cli, ColorMode, Commands, DebugChecks, DebugCommands};
+use cli::{Cli, ColorMode, Commands, DebugChecks, DebugCommands, TranslateProviderArg};
 use diagnostic_renderer::print_diagnostics;
 
 /// Supported file extensions for formatting
@@ -1259,6 +1259,146 @@ fn main() -> io::Result<()> {
                 std::process::exit(1);
             }
 
+            Ok(())
+        }
+        Commands::Translate {
+            files,
+            provider,
+            source_lang,
+            target_lang,
+            api_key,
+            endpoint,
+            stdout,
+            force_exclude,
+        } => {
+            let provider = provider.map(|p| match p {
+                TranslateProviderArg::Deepl => panache::config::TranslateProvider::Deepl,
+                TranslateProviderArg::Libretranslate => {
+                    panache::config::TranslateProvider::Libretranslate
+                }
+            });
+
+            let overrides = panache::translate::TranslateOverrides {
+                provider,
+                source_lang,
+                target_lang,
+                api_key,
+                endpoint,
+            };
+
+            if files.is_empty() {
+                let start_dir = start_dir_for(cli.stdin_filename.as_deref())?;
+                let (cfg, cfg_path) = load_config_for_cli(
+                    cli.config.as_deref(),
+                    cli.isolated,
+                    cli.cache_dir.as_deref(),
+                    &start_dir,
+                    cli.stdin_filename.as_deref(),
+                )?;
+                if let Some(path) = &cfg_path {
+                    log::debug!("Using config from: {}", path.display());
+                } else {
+                    log::debug!("Using default config");
+                }
+                let input = read_all(None)?;
+                let output = panache::translate::translate_document(&input, &cfg, &overrides)
+                    .map_err(|e| io::Error::other(e.to_string()))?;
+                print!("{output}");
+                return Ok(());
+            }
+
+            if files.len() == 2 && files[0].is_file() && !files[1].is_dir() {
+                let input_path = &files[0];
+                let output_path = &files[1];
+                let start_dir = input_path.parent().unwrap_or(Path::new(".")).to_path_buf();
+                let (cfg, cfg_path) = load_config_for_cli(
+                    cli.config.as_deref(),
+                    cli.isolated,
+                    cli.cache_dir.as_deref(),
+                    &start_dir,
+                    Some(input_path),
+                )?;
+                if let Some(path) = &cfg_path {
+                    log::debug!("Using config from: {}", path.display());
+                } else {
+                    log::debug!("Using default config");
+                }
+                let input = fs::read_to_string(input_path)?;
+                let output = panache::translate::translate_document(&input, &cfg, &overrides)
+                    .map_err(|e| io::Error::other(e.to_string()))?;
+                fs::write(output_path, output)?;
+                println!(
+                    "Translated {} -> {}",
+                    input_path.display(),
+                    output_path.display()
+                );
+                return Ok(());
+            }
+
+            let traversal_anchor = files.first().map(PathBuf::as_path);
+            let traversal_start_dir = if let Some(anchor) = traversal_anchor {
+                if anchor.is_dir() {
+                    anchor.to_path_buf()
+                } else {
+                    start_dir_for(Some(anchor))?
+                }
+            } else {
+                start_dir_for(None)?
+            };
+            let (traversal_cfg, traversal_cfg_path) = load_config_for_cli(
+                cli.config.as_deref(),
+                cli.isolated,
+                cli.cache_dir.as_deref(),
+                &traversal_start_dir,
+                traversal_anchor,
+            )?;
+            let matching_root = path_matching_root(
+                cli.config.as_deref(),
+                traversal_cfg_path.as_deref(),
+                &traversal_start_dir,
+            )?;
+            let expanded_files =
+                expand_paths(&files, &traversal_cfg, &matching_root, force_exclude)?;
+
+            if expanded_files.is_empty() {
+                if force_exclude {
+                    return Ok(());
+                }
+                if has_explicit_file_targets(&files) {
+                    eprintln!("Error: No supported files found");
+                    std::process::exit(1);
+                }
+                println!("No supported files found");
+                return Ok(());
+            }
+
+            for file_path in &expanded_files {
+                let start_dir = file_path.parent().unwrap_or(Path::new(".")).to_path_buf();
+                let (cfg, cfg_path) = load_config_for_cli(
+                    cli.config.as_deref(),
+                    cli.isolated,
+                    cli.cache_dir.as_deref(),
+                    &start_dir,
+                    Some(file_path),
+                )?;
+
+                if let Some(path) = &cfg_path {
+                    log::debug!("Using config from: {}", path.display());
+                } else {
+                    log::debug!("Using default config");
+                }
+
+                let input = fs::read_to_string(file_path)?;
+                let output = panache::translate::translate_document(&input, &cfg, &overrides)
+                    .map_err(|e| io::Error::other(e.to_string()))?;
+
+                if stdout {
+                    print!("{output}");
+                } else {
+                    fs::write(file_path, &output)?;
+                    println!("Translated {}", file_path.display());
+                }
+            }
             Ok(())
         }
     }

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -1,0 +1,695 @@
+use crate::config::{Config, TranslateProvider, TranslateSettings};
+use crate::parser::parse;
+use crate::syntax::{SyntaxKind, SyntaxNode};
+use reqwest::blocking::Client;
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE};
+use serde_json::{Value, json};
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug, Clone)]
+pub struct TranslateOverrides {
+    pub provider: Option<TranslateProvider>,
+    pub source_lang: Option<String>,
+    pub target_lang: Option<String>,
+    pub api_key: Option<String>,
+    pub endpoint: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedTranslateSettings {
+    provider: TranslateProvider,
+    source_lang: Option<String>,
+    target_lang: String,
+    api_key: Option<String>,
+    endpoint: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct SpanReplacement {
+    start: usize,
+    end: usize,
+    text: String,
+    continuation_indent: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum TranslateError {
+    MissingProvider,
+    MissingTargetLanguage,
+    MissingApiKey(&'static str),
+    Http(String),
+    InvalidResponse(String),
+    Internal(String),
+}
+
+impl Display for TranslateError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingProvider => write!(
+                f,
+                "Translation provider not configured. Set [translate].provider or pass --provider."
+            ),
+            Self::MissingTargetLanguage => write!(
+                f,
+                "Target language not configured. Set [translate].target-lang or pass --target-lang."
+            ),
+            Self::MissingApiKey(provider) => write!(
+                f,
+                "Missing API key for {provider}. Set [translate].api-key or pass --api-key."
+            ),
+            Self::Http(msg) => write!(f, "{msg}"),
+            Self::InvalidResponse(msg) => write!(f, "{msg}"),
+            Self::Internal(msg) => write!(f, "{msg}"),
+        }
+    }
+}
+
+impl Error for TranslateError {}
+
+pub fn translate_document(
+    input: &str,
+    cfg: &Config,
+    overrides: &TranslateOverrides,
+) -> Result<String, TranslateError> {
+    let settings = resolve_settings(&cfg.translate, overrides)?;
+    let tree = parse(input, Some(cfg.clone()));
+    let spans = collect_translatable_spans(input, &tree);
+    if spans.is_empty() {
+        return Ok(input.to_string());
+    }
+
+    let source_texts = spans.iter().map(|s| s.text.clone()).collect::<Vec<_>>();
+    let translated = match settings.provider {
+        TranslateProvider::Deepl => translate_deepl(&settings, &source_texts)?,
+        TranslateProvider::Libretranslate => translate_libretranslate(&settings, &source_texts)?,
+    };
+
+    if translated.len() != spans.len() {
+        return Err(TranslateError::Internal(format!(
+            "translation result count mismatch: got {}, expected {}",
+            translated.len(),
+            spans.len()
+        )));
+    }
+
+    let mut output = input.to_string();
+    apply_replacements(&mut output, &spans, &translated)?;
+    Ok(output)
+}
+
+fn resolve_settings(
+    cfg: &TranslateSettings,
+    overrides: &TranslateOverrides,
+) -> Result<ResolvedTranslateSettings, TranslateError> {
+    let provider = overrides
+        .provider
+        .or(cfg.provider)
+        .ok_or(TranslateError::MissingProvider)?;
+    let target_lang = overrides
+        .target_lang
+        .clone()
+        .or_else(|| cfg.target_lang.clone())
+        .ok_or(TranslateError::MissingTargetLanguage)?;
+    let source_lang = overrides
+        .source_lang
+        .clone()
+        .or_else(|| cfg.source_lang.clone());
+    let api_key = overrides.api_key.clone().or_else(|| cfg.api_key.clone());
+    let endpoint = overrides.endpoint.clone().or_else(|| cfg.endpoint.clone());
+    Ok(ResolvedTranslateSettings {
+        provider,
+        source_lang,
+        target_lang,
+        api_key,
+        endpoint,
+    })
+}
+
+fn collect_translatable_spans(input: &str, tree: &SyntaxNode) -> Vec<SpanReplacement> {
+    let mut spans = Vec::new();
+    let mut in_yaml_block_scalar = false;
+    for token in tree
+        .descendants_with_tokens()
+        .filter_map(|e| e.into_token())
+    {
+        let kind = token.kind();
+        if !matches!(kind, SyntaxKind::TEXT | SyntaxKind::YAML_SCALAR) {
+            continue;
+        }
+        if is_excluded_token(&token) {
+            continue;
+        }
+
+        if is_yaml_metadata_token(&token) {
+            collect_yaml_metadata_spans(input, &token, &mut spans, &mut in_yaml_block_scalar);
+            continue;
+        }
+
+        if kind == SyntaxKind::YAML_SCALAR {
+            collect_yaml_scalar_spans(input, &token, &mut spans);
+            continue;
+        }
+
+        let range = token.text_range();
+        let start = u32::from(range.start()) as usize;
+        let end = u32::from(range.end()) as usize;
+        maybe_push_span(input, start, end, None, &mut spans);
+    }
+    spans
+}
+
+fn contains_translatable_chars(s: &str) -> bool {
+    s.chars().any(|c| c.is_alphabetic()) && !looks_like_non_natural_language(s)
+}
+
+fn looks_like_non_natural_language(s: &str) -> bool {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return true;
+    }
+    if trimmed.contains("://") {
+        return true;
+    }
+
+    let no_spaces = !trimmed.chars().any(char::is_whitespace);
+    let pathish_chars_only = trimmed
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '/' | '\\' | '_' | '-' | '@'));
+
+    if no_spaces && pathish_chars_only {
+        if trimmed.contains('/') || trimmed.contains('\\') {
+            return true;
+        }
+        if trimmed.starts_with('@') && trimmed.contains('.') {
+            return true;
+        }
+        let is_single_word = !trimmed.contains([' ', '\t', '\n']);
+        if is_single_word
+            && trimmed.contains('.')
+            && !trimmed.ends_with('.')
+            && !trimmed.starts_with('.')
+            && trimmed.split('.').all(|part| !part.is_empty())
+        {
+            return true;
+        }
+    }
+    false
+}
+
+fn maybe_push_span(
+    input: &str,
+    start: usize,
+    end: usize,
+    continuation_indent: Option<String>,
+    spans: &mut Vec<SpanReplacement>,
+) {
+    if start >= end || end > input.len() {
+        return;
+    }
+    let text = &input[start..end];
+    if !contains_translatable_chars(text) {
+        return;
+    }
+    spans.push(SpanReplacement {
+        start,
+        end,
+        text: text.to_string(),
+        continuation_indent,
+    });
+}
+
+fn collect_yaml_scalar_spans(
+    input: &str,
+    token: &crate::syntax::SyntaxToken,
+    spans: &mut Vec<SpanReplacement>,
+) {
+    let range = token.text_range();
+    let base_start = u32::from(range.start()) as usize;
+    let base_end = u32::from(range.end()) as usize;
+    if base_start >= base_end || base_end > input.len() {
+        return;
+    }
+
+    let scalar = &input[base_start..base_end];
+    let mut line_offset = 0usize;
+    for line in scalar.split_inclusive('\n') {
+        let line_body = line.strip_suffix('\n').unwrap_or(line);
+        let leading_ws = line_body.len() - line_body.trim_start().len();
+        let trailing_trimmed_len = line_body.trim_end().len();
+        if leading_ws < trailing_trimmed_len {
+            let start = base_start + line_offset + leading_ws;
+            let end = base_start + line_offset + trailing_trimmed_len;
+            maybe_push_span(input, start, end, None, spans);
+        }
+        line_offset += line.len();
+    }
+}
+
+fn is_yaml_metadata_token(token: &crate::syntax::SyntaxToken) -> bool {
+    token
+        .parent_ancestors()
+        .any(|node| node.kind() == SyntaxKind::YAML_METADATA_CONTENT)
+}
+
+fn collect_yaml_metadata_spans(
+    input: &str,
+    token: &crate::syntax::SyntaxToken,
+    spans: &mut Vec<SpanReplacement>,
+    in_block_scalar: &mut bool,
+) {
+    let range = token.text_range();
+    let start = u32::from(range.start()) as usize;
+    let end = u32::from(range.end()) as usize;
+    if start >= end || end > input.len() {
+        return;
+    }
+
+    let line = &input[start..end];
+    let trimmed_end_len = line.trim_end().len();
+    if trimmed_end_len == 0 {
+        return;
+    }
+    let line_no_trailing = &line[..trimmed_end_len];
+    let leading_ws = line_no_trailing.len() - line_no_trailing.trim_start().len();
+
+    if *in_block_scalar {
+        if leading_ws > 0 {
+            let scalar_start = start + leading_ws;
+            let scalar_end = start + line_no_trailing.len();
+            let indent = Some(input[start..start + leading_ws].to_string());
+            maybe_push_span(input, scalar_start, scalar_end, indent, spans);
+            return;
+        }
+        *in_block_scalar = false;
+    }
+
+    if let Some(colon_idx) = line_no_trailing.find(':') {
+        let key = line_no_trailing[..colon_idx].trim();
+        if !looks_like_yaml_key(key) {
+            return;
+        }
+        let after_colon = &line_no_trailing[colon_idx + 1..];
+        let value_trimmed = after_colon.trim_start();
+        if value_trimmed.is_empty() {
+            return;
+        }
+
+        if is_yaml_block_scalar_indicator(value_trimmed) {
+            *in_block_scalar = true;
+            return;
+        }
+
+        let value_leading_ws = after_colon.len() - value_trimmed.len();
+        let value_start = start + colon_idx + 1 + value_leading_ws;
+        let value_end = start + line_no_trailing.len();
+        maybe_push_span(input, value_start, value_end, None, spans);
+    }
+}
+
+fn looks_like_yaml_key(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.'))
+}
+
+fn is_yaml_block_scalar_indicator(s: &str) -> bool {
+    if let Some(first) = s.chars().next() {
+        first == '>' || first == '|'
+    } else {
+        false
+    }
+}
+
+fn apply_replacements(
+    output: &mut String,
+    spans: &[SpanReplacement],
+    translated: &[String],
+) -> Result<(), TranslateError> {
+    if spans.len() != translated.len() {
+        return Err(TranslateError::Internal(format!(
+            "replacement count mismatch: got {}, expected {}",
+            translated.len(),
+            spans.len()
+        )));
+    }
+    for (span, replacement) in spans.iter().zip(translated.iter()).rev() {
+        let replacement = if let Some(indent) = &span.continuation_indent {
+            apply_yaml_continuation_indent(replacement, indent)
+        } else {
+            replacement.to_string()
+        };
+        output.replace_range(span.start..span.end, &replacement);
+    }
+    Ok(())
+}
+
+fn apply_yaml_continuation_indent(text: &str, indent: &str) -> String {
+    if !text.contains('\n') {
+        return text.to_string();
+    }
+    let mut lines = text.split('\n');
+    let first = lines.next().unwrap_or_default();
+    let mut out = String::from(first);
+    for line in lines {
+        out.push('\n');
+        if !line.is_empty() {
+            out.push_str(indent);
+        }
+        out.push_str(line);
+    }
+    out
+}
+
+fn is_excluded_token(token: &crate::syntax::SyntaxToken) -> bool {
+    token.parent_ancestors().any(|node| {
+        matches!(
+            node.kind(),
+            SyntaxKind::CODE_SPAN
+                | SyntaxKind::INLINE_EXECUTABLE_CODE
+                | SyntaxKind::CODE_BLOCK
+                | SyntaxKind::CODE_CONTENT
+                | SyntaxKind::INLINE_MATH
+                | SyntaxKind::DISPLAY_MATH
+                | SyntaxKind::MATH_CONTENT
+                | SyntaxKind::RAW_INLINE
+                | SyntaxKind::RAW_INLINE_CONTENT
+                | SyntaxKind::TEX_BLOCK
+                | SyntaxKind::HTML_BLOCK
+                | SyntaxKind::HTML_BLOCK_CONTENT
+                | SyntaxKind::SHORTCODE
+                | SyntaxKind::SHORTCODE_CONTENT
+        )
+    })
+}
+
+fn translate_deepl(
+    settings: &ResolvedTranslateSettings,
+    texts: &[String],
+) -> Result<Vec<String>, TranslateError> {
+    let api_key = settings
+        .api_key
+        .clone()
+        .ok_or(TranslateError::MissingApiKey("DeepL"))?;
+    let endpoint = settings
+        .endpoint
+        .clone()
+        .unwrap_or_else(|| "https://api-free.deepl.com/v2/translate".to_string());
+    let target_lang = settings.target_lang.to_uppercase();
+    let source_lang = settings.source_lang.as_ref().map(|s| s.to_uppercase());
+
+    let mut params = vec![("target_lang".to_string(), target_lang)];
+    if let Some(src) = source_lang {
+        params.push(("source_lang".to_string(), src));
+    }
+    for text in texts {
+        params.push(("text".to_string(), text.clone()));
+    }
+
+    let client = Client::new();
+    let response = client
+        .post(endpoint)
+        .header(AUTHORIZATION, format!("DeepL-Auth-Key {api_key}"))
+        .form(&params)
+        .send()
+        .map_err(|e| TranslateError::Http(format!("DeepL request failed: {e}")))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response
+            .text()
+            .unwrap_or_else(|_| "<unable to read response body>".to_string());
+        return Err(TranslateError::Http(format!(
+            "DeepL request failed with status {status}: {body}"
+        )));
+    }
+
+    let value: Value = response
+        .json()
+        .map_err(|e| TranslateError::InvalidResponse(format!("DeepL JSON parse failed: {e}")))?;
+    parse_deepl_translations(&value)
+}
+
+fn parse_deepl_translations(value: &Value) -> Result<Vec<String>, TranslateError> {
+    let translations = value
+        .get("translations")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            TranslateError::InvalidResponse("DeepL response missing `translations` array".into())
+        })?;
+
+    let mut out = Vec::with_capacity(translations.len());
+    for item in translations {
+        let text = item.get("text").and_then(Value::as_str).ok_or_else(|| {
+            TranslateError::InvalidResponse("DeepL translation entry missing `text`".into())
+        })?;
+        out.push(text.to_string());
+    }
+    Ok(out)
+}
+
+fn translate_libretranslate(
+    settings: &ResolvedTranslateSettings,
+    texts: &[String],
+) -> Result<Vec<String>, TranslateError> {
+    let endpoint = settings
+        .endpoint
+        .clone()
+        .unwrap_or_else(|| "https://libretranslate.com/translate".to_string());
+    let source = settings
+        .source_lang
+        .clone()
+        .unwrap_or_else(|| "auto".to_string())
+        .to_lowercase();
+    let target = settings.target_lang.to_lowercase();
+    let mut payload = json!({
+        "q": texts,
+        "source": source,
+        "target": target,
+        "format": "text",
+    });
+    if let Some(api_key) = &settings.api_key {
+        payload["api_key"] = Value::String(api_key.clone());
+    }
+
+    let client = Client::new();
+    let response = client
+        .post(endpoint)
+        .header(CONTENT_TYPE, "application/json")
+        .json(&payload)
+        .send()
+        .map_err(|e| TranslateError::Http(format!("LibreTranslate request failed: {e}")))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response
+            .text()
+            .unwrap_or_else(|_| "<unable to read response body>".to_string());
+        return Err(TranslateError::Http(format!(
+            "LibreTranslate request failed with status {status}: {body}"
+        )));
+    }
+
+    let value: Value = response.json().map_err(|e| {
+        TranslateError::InvalidResponse(format!("LibreTranslate JSON parse failed: {e}"))
+    })?;
+    parse_libretranslate_translations(&value)
+}
+
+fn parse_libretranslate_translations(value: &Value) -> Result<Vec<String>, TranslateError> {
+    if let Some(text) = value.get("translatedText").and_then(Value::as_str) {
+        return Ok(vec![text.to_string()]);
+    }
+    if let Some(texts) = value.get("translatedText").and_then(Value::as_array) {
+        let mut out = Vec::with_capacity(texts.len());
+        for text in texts {
+            let text = text.as_str().ok_or_else(|| {
+                TranslateError::InvalidResponse(
+                    "LibreTranslate `translatedText` array item must be a string".into(),
+                )
+            })?;
+            out.push(text.to_string());
+        }
+        return Ok(out);
+    }
+    if let Some(entries) = value.get("translations").and_then(Value::as_array) {
+        let mut out = Vec::with_capacity(entries.len());
+        for entry in entries {
+            let text = entry
+                .get("translatedText")
+                .or_else(|| entry.get("text"))
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    TranslateError::InvalidResponse(
+                        "LibreTranslate `translations` entry missing text".into(),
+                    )
+                })?;
+            out.push(text.to_string());
+        }
+        return Ok(out);
+    }
+    if let Some(entries) = value.as_array() {
+        let mut out = Vec::with_capacity(entries.len());
+        for entry in entries {
+            let text = entry
+                .get("translatedText")
+                .or_else(|| entry.get("text"))
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    TranslateError::InvalidResponse(
+                        "LibreTranslate array item missing translation text".into(),
+                    )
+                })?;
+            out.push(text.to_string());
+        }
+        return Ok(out);
+    }
+    Err(TranslateError::InvalidResponse(format!(
+        "Unsupported LibreTranslate response shape: {}",
+        value
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        SpanReplacement, TranslateError, apply_replacements, collect_translatable_spans,
+        contains_translatable_chars, parse_deepl_translations, parse_libretranslate_translations,
+    };
+    use serde_json::json;
+
+    #[test]
+    fn parse_deepl_translations_accepts_expected_shape() {
+        let value = json!({
+            "translations": [
+                {"text": "Bonjour"},
+                {"text": "Monde"}
+            ]
+        });
+        let out = parse_deepl_translations(&value).expect("deepl response should parse");
+        assert_eq!(out, vec!["Bonjour".to_string(), "Monde".to_string()]);
+    }
+
+    #[test]
+    fn parse_libretranslate_translations_accepts_array_shape() {
+        let value = json!([
+            {"translatedText": "Bonjour"},
+            {"translatedText": "Monde"}
+        ]);
+        let out = parse_libretranslate_translations(&value)
+            .expect("libretranslate response should parse");
+        assert_eq!(out, vec!["Bonjour".to_string(), "Monde".to_string()]);
+    }
+
+    #[test]
+    fn parse_libretranslate_translations_accepts_translated_text_array_shape() {
+        let value = json!({
+            "translatedText": ["Bonjour", "Monde"]
+        });
+        let out = parse_libretranslate_translations(&value)
+            .expect("libretranslate translatedText array should parse");
+        assert_eq!(out, vec!["Bonjour".to_string(), "Monde".to_string()]);
+    }
+
+    #[test]
+    fn parse_libretranslate_translations_accepts_translations_key_shape() {
+        let value = json!({
+            "translations": [
+                {"text": "Bonjour"},
+                {"translatedText": "Monde"}
+            ]
+        });
+        let out = parse_libretranslate_translations(&value)
+            .expect("libretranslate translations array should parse");
+        assert_eq!(out, vec!["Bonjour".to_string(), "Monde".to_string()]);
+    }
+
+    #[test]
+    fn parse_libretranslate_translations_rejects_invalid_shape() {
+        let value = json!({"unexpected": true});
+        let err = parse_libretranslate_translations(&value).expect_err("invalid shape should fail");
+        assert!(matches!(err, TranslateError::InvalidResponse(_)));
+    }
+
+    #[test]
+    fn contains_translatable_chars_requires_alphabetic_content() {
+        assert!(!contains_translatable_chars("12345"));
+        assert!(contains_translatable_chars("Hello"));
+        assert!(!contains_translatable_chars("@test.qmd"));
+        assert!(!contains_translatable_chars("docs/index.qmd"));
+        assert!(!contains_translatable_chars("https://example.com/page"));
+    }
+
+    #[test]
+    fn collects_yaml_scalar_content_without_indentation() {
+        use crate::config::Config;
+        use crate::parser::parse;
+
+        let input =
+            "---\ntitle: Hello World\ndescription: >\n  Multi line text\n---\n\nParagraph.\n";
+        let tree = parse(input, Some(Config::default()));
+        let spans = collect_translatable_spans(input, &tree);
+
+        assert!(
+            spans.iter().any(|s| s.text.contains("Hello World")),
+            "YAML scalar values should be collected"
+        );
+        assert!(
+            spans.iter().any(|s| s.text == "Multi line text"),
+            "Folded YAML block text should be collected without indentation"
+        );
+        assert!(
+            spans.iter().any(|s| s.text == "Paragraph."),
+            "Body paragraph text should still be translated"
+        );
+    }
+
+    #[test]
+    fn yaml_replacement_preserves_indentation() {
+        let mut output = "---\ndescription: >\n  Multi line text\n---\n".to_string();
+        let start = output.find("Multi line text").expect("text exists");
+        let end = start + "Multi line text".len();
+        let spans = vec![SpanReplacement {
+            start,
+            end,
+            text: "Multi line text".to_string(),
+            continuation_indent: Some("  ".to_string()),
+        }];
+        let translated = vec!["Texte multi ligne".to_string()];
+        apply_replacements(&mut output, &spans, &translated).expect("replacement should succeed");
+        assert_eq!(output, "---\ndescription: >\n  Texte multi ligne\n---\n");
+    }
+
+    #[test]
+    fn yaml_replacement_reindents_multiline_translations() {
+        let mut output = "---\ndescription: >\n  Multi line text\n---\n".to_string();
+        let start = output.find("Multi line text").expect("text exists");
+        let end = start + "Multi line text".len();
+        let spans = vec![SpanReplacement {
+            start,
+            end,
+            text: "Multi line text".to_string(),
+            continuation_indent: Some("  ".to_string()),
+        }];
+        let translated = vec!["Ligne une\nLigne deux".to_string()];
+        apply_replacements(&mut output, &spans, &translated).expect("replacement should succeed");
+        assert_eq!(
+            output,
+            "---\ndescription: >\n  Ligne une\n  Ligne deux\n---\n"
+        );
+    }
+
+    #[test]
+    fn yaml_inline_value_is_collected_without_key_prefix() {
+        use crate::config::Config;
+        use crate::parser::parse;
+
+        let input = "---\ntitle: Hello World\npath: @test.qmd\n---\n";
+        let tree = parse(input, Some(Config::default()));
+        let spans = collect_translatable_spans(input, &tree);
+
+        assert!(spans.iter().any(|s| s.text == "Hello World"));
+        assert!(!spans.iter().any(|s| s.text.contains("title:")));
+        assert!(!spans.iter().any(|s| s.text.contains("@test.qmd")));
+    }
+}

--- a/tests/cli/main.rs
+++ b/tests/cli/main.rs
@@ -12,6 +12,7 @@ mod debug;
 mod format;
 mod lint;
 mod parse;
+mod translate;
 
 #[cfg(feature = "lsp")]
 mod lsp;

--- a/tests/cli/translate.rs
+++ b/tests/cli/translate.rs
@@ -1,0 +1,132 @@
+//! Translate subcommand tests
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+#[test]
+fn test_translate_requires_provider() {
+    cargo_bin_cmd!("panache")
+        .arg("translate")
+        .arg("--isolated")
+        .args(["--target-lang", "fr"])
+        .write_stdin("# Heading\n\nParagraph.")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Translation provider not configured",
+        ));
+}
+
+#[test]
+fn test_translate_requires_target_language() {
+    cargo_bin_cmd!("panache")
+        .arg("translate")
+        .arg("--isolated")
+        .args(["--provider", "libretranslate"])
+        .write_stdin("# Heading\n\nParagraph.")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Target language not configured"));
+}
+
+#[test]
+fn test_translate_uses_config_for_provider_and_target() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_file = temp_dir.path().join(".panache.toml");
+    fs::write(
+        &config_file,
+        r#"
+        [translate]
+        provider = "libretranslate"
+        target-lang = "fr"
+        endpoint = "http://127.0.0.1:1/translate"
+    "#,
+    )
+    .unwrap();
+
+    cargo_bin_cmd!("panache")
+        .current_dir(temp_dir.path())
+        .arg("translate")
+        .write_stdin("# Heading\n\nParagraph.")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("LibreTranslate request failed"));
+}
+
+#[test]
+fn test_translate_force_exclude_noops_when_all_filtered() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = temp_dir.path().join(".panache.toml");
+    let excluded_dir = temp_dir.path().join("tests");
+    let excluded = excluded_dir.join("snapshot.md");
+    fs::create_dir_all(&excluded_dir).unwrap();
+    fs::write(
+        &config,
+        r#"
+exclude = ["tests/"]
+[translate]
+provider = "libretranslate"
+target-lang = "fr"
+endpoint = "http://127.0.0.1:1/translate"
+"#,
+    )
+    .unwrap();
+    fs::write(&excluded, "# Excluded\n\nParagraph.\n").unwrap();
+
+    cargo_bin_cmd!("panache")
+        .current_dir(temp_dir.path())
+        .args(["translate", "--force-exclude", excluded.to_str().unwrap()])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_translate_directory_with_no_supported_files_is_noop() {
+    let temp_dir = TempDir::new().unwrap();
+    let test_file = temp_dir.path().join("note.txt");
+    fs::write(&test_file, "content\n").unwrap();
+
+    cargo_bin_cmd!("panache")
+        .args(["translate", temp_dir.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No supported files found"));
+}
+
+#[test]
+fn test_translate_two_file_args_writes_to_output_file() {
+    let temp_dir = TempDir::new().unwrap();
+    let input = temp_dir.path().join("in.qmd");
+    let output = temp_dir.path().join("out.qmd");
+    let config_file = temp_dir.path().join(".panache.toml");
+
+    fs::write(
+        &config_file,
+        r#"
+        [translate]
+        provider = "libretranslate"
+        target-lang = "fr"
+        endpoint = "http://127.0.0.1:1/translate"
+    "#,
+    )
+    .unwrap();
+    fs::write(&input, "# Heading\n\nParagraph.\n").unwrap();
+
+    cargo_bin_cmd!("panache")
+        .current_dir(temp_dir.path())
+        .args([
+            "translate",
+            input.to_str().unwrap(),
+            output.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("LibreTranslate request failed"));
+
+    assert!(
+        !output.exists(),
+        "output file should not be created when translation fails"
+    );
+}


### PR DESCRIPTION
## Summary

Adds a `panache translate` command.

This is a very basic implementation, only tested with LibreTranslate so far and works for at least simple examples.

The more and more I got into this, however, I started to wonder if this feature really belongs in Panache. I am a bit weary of letting the project grow too much outside its current formatter + linter + language server boundary.

I'll think about this a bit more, but I am maybe now thinking that this probably should be its own project and separate CLI tool. Do you have any thoughts, @maelle?

## Related issue

Closes #128 

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Commit messages follow [Conventional
      Commits](https://www.conventionalcommits.org)
- [x] Added or updated tests for behavior changes
- [x] Ran `cargo check`
- [x] Ran `cargo test`
- [x] Ran `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Ran `cargo fmt -- --check`
- [x] Updated docs or README if needed
- [x] Did not manually edit `CHANGELOG.md`
