### PR TITLE
chore(release): v2.35.0, panache-parser-v0.3.1, panache-code-v2.34.1, panache-zed-v2.34.1

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,0 +1,26 @@
+{
+  "manifest-version": 1,
+  "baseline-sha": "0291473726f830dda789d93508405180c43948d6",
+  "release-targets": [
+    {
+      "path": ".",
+      "version": "2.35.0",
+      "tag": "v2.35.0"
+    },
+    {
+      "path": "crates/panache-parser",
+      "version": "0.3.1",
+      "tag": "panache-parser-v0.3.1"
+    },
+    {
+      "path": "editors/code",
+      "version": "2.34.1",
+      "tag": "panache-code-v2.34.1"
+    },
+    {
+      "path": "editors/zed",
+      "version": "2.34.1",
+      "tag": "panache-zed-v2.34.1"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
-# Changelog
+## [2.35.0](https://github.com/jolars/panache/compare/v2.34.0...v2.35.0) (2026-04-16)
+
+### Features
+- add info-level debugging logs for external formatters ([`6228b55`](https://github.com/jolars/panache/commit/6228b5528121b2c2c27f51f1778b7a3e7bf024e4))
+
+### Bug Fixes
+- switch back to `v*` tagging for main program ([`9adc923`](https://github.com/jolars/panache/commit/9adc923ba70f396464cacf90dcaf50678a8c03b7))
+- **parser:** handle utf-8 properly ([`92da1cd`](https://github.com/jolars/panache/commit/92da1cd74108f1576a846287ee3c098c04614b1d)), closes [#164](https://github.com/jolars/panache/issues/164)
+- **lsp:** remove extra space in tasklist-bullet list action ([`6cc80b3`](https://github.com/jolars/panache/commit/6cc80b3eb8dd52a3b6e97a09133a8f54e905fb72))
+- **lsp:** convert to actual task list ([`233f47c`](https://github.com/jolars/panache/commit/233f47c9bd73f4b6db6bcbe0ea52cd10da75ddb3))
+- **parser:** handle utf-8 properly ([`92da1cd`](https://github.com/jolars/panache/commit/92da1cd74108f1576a846287ee3c098c04614b1d)), closes [#164](https://github.com/jolars/panache/issues/164)
+- switch back to `v*` tagging for main program ([`9adc923`](https://github.com/jolars/panache/commit/9adc923ba70f396464cacf90dcaf50678a8c03b7))
+- switch back to `v*` tagging for main program ([`9adc923`](https://github.com/jolars/panache/commit/9adc923ba70f396464cacf90dcaf50678a8c03b7))
 
 ## [2.34.0](https://github.com/jolars/panache/compare/panache-v2.33.1...panache-v2.34.0) (2026-04-14)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,7 +1029,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "panache"
-version = "2.34.0"
+version = "2.35.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.1.1"
+version = "2.35.0"
 dependencies = [
  "insta",
  "log",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "insta",
  "log",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "panache-wasm"
-version = "0.1.3"
+version = "2.35.0"
 dependencies = [
  "panache-formatter",
  "panache-parser",
@@ -1905,9 +1905,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -2390,7 +2390,7 @@ dependencies = [
 
 [[package]]
 name = "zed_panache"
-version = "2.34.0"
+version = "2.34.1"
 dependencies = [
  "zed_extension_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "2.34.0"
+version = "2.35.0"
 edition.workspace = true
 readme = "README.md"
 description = "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown"
@@ -40,7 +40,7 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-parser = { path = "crates/panache-parser", version = "0.3.0", features = [
+panache-parser = { path = "crates/panache-parser", version = "0.3.1", features = [
     "serde",
 ] }
 annotate-snippets = "0.12.15"

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.1.1"
+version = "2.35.0"
 edition.workspace = true
 publish = false
 license.workspace = true

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 readme = "README.md"
 description = "Lossless CST parser and syntax wrappers for Pandoc markdown, Quarto, and RMarkdown"

--- a/crates/panache-wasm/Cargo.toml
+++ b/crates/panache-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-wasm"
-version = "0.1.3"
+version = "2.35.0"
 edition = "2024"
 publish = false
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "2.34.0",
+  "version": "2.34.1",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_panache"
-version = "2.34.0"
+version = "2.34.1"
 edition = "2021"
 license = "MIT"
 publish = false

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,7 +1,7 @@
 id = "panache-language-server"
 name = "Panache"
 description = "Language server for Pandoc, Quarto, and R Markdown"
-version = "2.32.1"
+version = "2.34.1"
 schema_version = 1
 authors = ["Johan Larsson <johan@jolars.co>"]
 repository = "https://github.com/jolars/panache"


### PR DESCRIPTION
## [panache: 2.35.0](https://github.com/jolars/panache/compare/v2.34.0...v2.35.0) (2026-04-16)

### Features
- add info-level debugging logs for external formatters ([`6228b55`](https://github.com/jolars/panache/commit/6228b5528121b2c2c27f51f1778b7a3e7bf024e4))

### Bug Fixes
- switch back to `v*` tagging for main program ([`9adc923`](https://github.com/jolars/panache/commit/9adc923ba70f396464cacf90dcaf50678a8c03b7))
- **parser:** handle utf-8 properly ([`92da1cd`](https://github.com/jolars/panache/commit/92da1cd74108f1576a846287ee3c098c04614b1d)), closes [#164](https://github.com/jolars/panache/issues/164)
- **lsp:** remove extra space in tasklist-bullet list action ([`6cc80b3`](https://github.com/jolars/panache/commit/6cc80b3eb8dd52a3b6e97a09133a8f54e905fb72))
- **lsp:** convert to actual task list ([`233f47c`](https://github.com/jolars/panache/commit/233f47c9bd73f4b6db6bcbe0ea52cd10da75ddb3))


## [crates/panache-parser: 0.3.1](https://github.com/jolars/panache/compare/v0.3.0...v0.3.1) (2026-04-16)

### Bug Fixes
- **parser:** handle utf-8 properly ([`92da1cd`](https://github.com/jolars/panache/commit/92da1cd74108f1576a846287ee3c098c04614b1d)), closes [#164](https://github.com/jolars/panache/issues/164)


## [editors/code: 2.34.1](https://github.com/jolars/panache/compare/v2.34.0...v2.34.1) (2026-04-16)

### Bug Fixes
- switch back to `v*` tagging for main program ([`9adc923`](https://github.com/jolars/panache/commit/9adc923ba70f396464cacf90dcaf50678a8c03b7))


## [editors/zed: 2.34.1](https://github.com/jolars/panache/compare/v2.34.0...v2.34.1) (2026-04-16)

### Bug Fixes
- switch back to `v*` tagging for main program ([`9adc923`](https://github.com/jolars/panache/commit/9adc923ba70f396464cacf90dcaf50678a8c03b7))


This PR was generated by Versionary.