### PR TITLE
chore(release): panache-code-v2.34.2

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "0291473726f830dda789d93508405180c43948d6",
+  "baseline-sha": "f7dbff405a02a484a4af93ea57031e7084b233dd",
   "release-targets": [
     {
       "path": ".",
@@ -14,8 +14,8 @@
     },
     {
       "path": "editors/code",
-      "version": "2.34.1",
-      "tag": "panache-code-v2.34.1"
+      "version": "2.34.2",
+      "tag": "panache-code-v2.34.2"
     },
     {
       "path": "editors/zed",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Changelog
+
+## [2.35.1](https://github.com/jolars/panache/compare/v2.35.0...v2.35.1) (2026-04-16)
+
+### Bug Fixes
+- **editors:** trigger patch bump ([`388c1d8`](https://github.com/jolars/panache/commit/388c1d8edfdfdd23764e0f2853d33d3a6494c33e))
+
 ## [2.35.0](https://github.com/jolars/panache/compare/v2.34.0...v2.35.0) (2026-04-16)
 
 ### Features

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "2.34.1",
+  "version": "2.34.2",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
## [editors/code: 2.34.2](https://github.com/jolars/panache/compare/v2.34.1...v2.34.2) (2026-04-16)

### Bug Fixes
- **editors:** trigger patch bump ([`388c1d8`](https://github.com/jolars/panache/commit/388c1d8edfdfdd23764e0f2853d33d3a6494c33e))


This PR was generated by Versionary.