### PR TITLE
chore(release): v2.39.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "6e51f14377597b8c145354823c066ab567ead64d",
+  "baseline-sha": "85ed34d02eb1b8cf16c4e417cc267c1c7bf43858",
   "release-targets": [
     {
       "path": ".",
-      "version": "2.38.0",
-      "tag": "v2.38.0"
+      "version": "2.39.0",
+      "tag": "v2.39.0"
     },
     {
       "path": "crates/panache-formatter",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.39.0](https://github.com/jolars/panache/compare/v2.38.0...v2.39.0) (2026-04-26)
+
+### Features
+- **cli:** add `--quiet` command to suppress output ([`78818a1`](https://github.com/jolars/panache/commit/78818a18caace649d8eb064c1d5530c78b69a4e4)), closes [#221](https://github.com/jolars/panache/issues/221)
+- **cli:** lint and format in parallel ([`c7560a0`](https://github.com/jolars/panache/commit/c7560a0fc3b68b694c7193dcb1a871537be1f1d4))
+
+### Bug Fixes
+- **cli:** disable color mode when `TERM=dumb` ([`eb8f12a`](https://github.com/jolars/panache/commit/eb8f12ab66e77d894cfe7c6b4488dfadcfb6f643)), fixes [#222](https://github.com/jolars/panache/issues/222)
 ## [2.38.0](https://github.com/jolars/panache/compare/v2.37.0...v2.38.0) (2026-04-24)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,7 +841,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "panache"
-version = "2.38.0"
+version = "2.39.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "2.38.0"
+version = "2.39.0"
 edition.workspace = true
 readme = "README.md"
 description = "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown"


### PR DESCRIPTION
## [panache: 2.39.0](https://github.com/jolars/panache/compare/v2.38.0...v2.39.0) (2026-04-26)

### Features
- **cli:** add `--quiet` command to suppress output ([`78818a1`](https://github.com/jolars/panache/commit/78818a18caace649d8eb064c1d5530c78b69a4e4)), closes [#221](https://github.com/jolars/panache/issues/221)
- **cli:** lint and format in parallel ([`c7560a0`](https://github.com/jolars/panache/commit/c7560a0fc3b68b694c7193dcb1a871537be1f1d4))

### Bug Fixes
- **cli:** disable color mode when `TERM=dumb` ([`eb8f12a`](https://github.com/jolars/panache/commit/eb8f12ab66e77d894cfe7c6b4488dfadcfb6f643)), fixes [#222](https://github.com/jolars/panache/issues/222)

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).