### PR TITLE
chore(release): v2.39.0 (+2 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,21 +1,21 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "6e51f14377597b8c145354823c066ab567ead64d",
+  "baseline-sha": "8442f269bad83ffb80648ebc6ece127c2c29419b",
   "release-targets": [
     {
       "path": ".",
-      "version": "2.38.0",
-      "tag": "v2.38.0"
+      "version": "2.39.0",
+      "tag": "v2.39.0"
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.2.1",
-      "tag": "panache-formatter-v0.2.1"
+      "version": "0.3.0",
+      "tag": "panache-formatter-v0.3.0"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.4.2",
-      "tag": "panache-parser-v0.4.2"
+      "version": "0.5.0",
+      "tag": "panache-parser-v0.5.0"
     },
     {
       "path": "editors/code",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [2.39.0](https://github.com/jolars/panache/compare/v2.38.0...v2.39.0) (2026-04-27)
+
+### Features
+- **cli:** make `--debug` actually useful in release builds ([`92a54ec`](https://github.com/jolars/panache/commit/92a54ecc087a10347a94fccfb7210dfdc345220f))
+- **cli:** add `--quiet` command to suppress output ([`78818a1`](https://github.com/jolars/panache/commit/78818a18caace649d8eb064c1d5530c78b69a4e4)), closes [#221](https://github.com/jolars/panache/issues/221)
+- **cli:** lint and format in parallel ([`c7560a0`](https://github.com/jolars/panache/commit/c7560a0fc3b68b694c7193dcb1a871537be1f1d4))
+
+### Bug Fixes
+- **formatter:** avoid quote character collisions ([`3c04c34`](https://github.com/jolars/panache/commit/3c04c3406eb4c84d1e1ef9a4dfe4051b33a6d111)), closes [#225](https://github.com/jolars/panache/issues/225)
+- **cli:** disable color mode when `TERM=dumb` ([`eb8f12a`](https://github.com/jolars/panache/commit/eb8f12ab66e77d894cfe7c6b4488dfadcfb6f643)), fixes [#222](https://github.com/jolars/panache/issues/222)
+- **parser:** emit empty cells for degenerate cells ([`095ada7`](https://github.com/jolars/panache/commit/095ada7da13f020de9856ae0ac06d2d441d451cd)), fixes [#224](https://github.com/jolars/panache/issues/224)
+
+### Dependencies
+- updated crates/panache-formatter to v0.3.0
+- updated crates/panache-parser to v0.5.0
 ## [2.38.0](https://github.com/jolars/panache/compare/v2.37.0...v2.38.0) (2026-04-24)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,7 +841,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "panache"
-version = "2.38.0"
+version = "2.39.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "insta",
  "log",
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "insta",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "2.38.0"
+version = "2.39.0"
 edition.workspace = true
 readme = "README.md"
 description = "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown"
@@ -39,8 +39,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.2.1" }
-panache-parser = { path = "crates/panache-parser", version = "0.4.2", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.3.0" }
+panache-parser = { path = "crates/panache-parser", version = "0.5.0", features = [
     "serde",
 ] }
 annotate-snippets = "0.12.15"

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.0](https://github.com/jolars/panache/compare/panache-formatter-v0.2.1...panache-formatter-v0.3.0) (2026-04-27)
+
+### Features
+- **cli:** make `--debug` actually useful in release builds ([`92a54ec`](https://github.com/jolars/panache/commit/92a54ecc087a10347a94fccfb7210dfdc345220f))
+
+### Bug Fixes
+- **formatter:** avoid quote character collisions ([`3c04c34`](https://github.com/jolars/panache/commit/3c04c3406eb4c84d1e1ef9a4dfe4051b33a6d111)), closes [#225](https://github.com/jolars/panache/issues/225)
+
 ## [0.2.1](https://github.com/jolars/panache/compare/panache-formatter-v0.2.0...panache-formatter-v0.2.1) (2026-04-24)
 
 ### Bug Fixes

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.2.1"
+version = "0.3.0"
 edition.workspace = true
 description = "Core formatting engine for Pandoc markdown, Quarto, and RMarkdown"
 license.workspace = true
@@ -13,7 +13,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.4.2" }
+panache-parser = { path = "../panache-parser", version = "0.5.0" }
 log = { version = "0.4.28", features = ["release_max_level_debug"] }
 rowan = "0.16.1"
 yaml_parser = "0.3.0"

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.5.0](https://github.com/jolars/panache/compare/panache-parser-v0.4.2...panache-parser-v0.5.0) (2026-04-27)
+
+### Features
+- **cli:** make `--debug` actually useful in release builds ([`92a54ec`](https://github.com/jolars/panache/commit/92a54ecc087a10347a94fccfb7210dfdc345220f))
+
+### Bug Fixes
+- **parser:** emit empty cells for degenerate cells ([`095ada7`](https://github.com/jolars/panache/commit/095ada7da13f020de9856ae0ac06d2d441d451cd)), fixes [#224](https://github.com/jolars/panache/issues/224)
+
 ## [0.4.2](https://github.com/jolars/panache/compare/panache-parser-v0.4.1...panache-parser-v0.4.2) (2026-04-24)
 
 ### Bug Fixes

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.4.2"
+version = "0.5.0"
 edition.workspace = true
 readme = "README.md"
 description = "Lossless CST parser and syntax wrappers for Pandoc markdown, Quarto, and RMarkdown"


### PR DESCRIPTION
## [panache: 2.39.0](https://github.com/jolars/panache/compare/v2.38.0...v2.39.0) (2026-04-27)

### Features
- **cli:** make `--debug` actually useful in release builds ([`92a54ec`](https://github.com/jolars/panache/commit/92a54ecc087a10347a94fccfb7210dfdc345220f))
- **cli:** add `--quiet` command to suppress output ([`78818a1`](https://github.com/jolars/panache/commit/78818a18caace649d8eb064c1d5530c78b69a4e4)), closes [#221](https://github.com/jolars/panache/issues/221)
- **cli:** lint and format in parallel ([`c7560a0`](https://github.com/jolars/panache/commit/c7560a0fc3b68b694c7193dcb1a871537be1f1d4))

### Bug Fixes
- **formatter:** avoid quote character collisions ([`3c04c34`](https://github.com/jolars/panache/commit/3c04c3406eb4c84d1e1ef9a4dfe4051b33a6d111)), closes [#225](https://github.com/jolars/panache/issues/225)
- **cli:** disable color mode when `TERM=dumb` ([`eb8f12a`](https://github.com/jolars/panache/commit/eb8f12ab66e77d894cfe7c6b4488dfadcfb6f643)), fixes [#222](https://github.com/jolars/panache/issues/222)
- **parser:** emit empty cells for degenerate cells ([`095ada7`](https://github.com/jolars/panache/commit/095ada7da13f020de9856ae0ac06d2d441d451cd)), fixes [#224](https://github.com/jolars/panache/issues/224)

### Dependencies
- updated crates/panache-formatter to v0.3.0
- updated crates/panache-parser to v0.5.0

## [crates/panache-formatter: 0.3.0](https://github.com/jolars/panache/compare/v0.2.1...v0.3.0) (2026-04-27)

### Features
- **cli:** make `--debug` actually useful in release builds ([`92a54ec`](https://github.com/jolars/panache/commit/92a54ecc087a10347a94fccfb7210dfdc345220f))

### Bug Fixes
- **formatter:** avoid quote character collisions ([`3c04c34`](https://github.com/jolars/panache/commit/3c04c3406eb4c84d1e1ef9a4dfe4051b33a6d111)), closes [#225](https://github.com/jolars/panache/issues/225)

### Dependencies
- updated crates/panache-parser to v0.5.0

## [crates/panache-parser: 0.5.0](https://github.com/jolars/panache/compare/v0.4.2...v0.5.0) (2026-04-27)

### Features
- **cli:** make `--debug` actually useful in release builds ([`92a54ec`](https://github.com/jolars/panache/commit/92a54ecc087a10347a94fccfb7210dfdc345220f))

### Bug Fixes
- **parser:** emit empty cells for degenerate cells ([`095ada7`](https://github.com/jolars/panache/commit/095ada7da13f020de9856ae0ac06d2d441d451cd)), fixes [#224](https://github.com/jolars/panache/issues/224)

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).