### PR TITLE
chore(release): v2.40.0 (+2 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,21 +1,21 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "8442f269bad83ffb80648ebc6ece127c2c29419b",
+  "baseline-sha": "7a5b408d1163ba49a1f9f5db53b4b7bae8110802",
   "release-targets": [
     {
       "path": ".",
-      "version": "2.39.0",
-      "tag": "v2.39.0"
+      "version": "2.40.0",
+      "tag": "v2.40.0"
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.3.0",
-      "tag": "panache-formatter-v0.3.0"
+      "version": "0.3.1",
+      "tag": "panache-formatter-v0.3.1"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.5.0",
-      "tag": "panache-parser-v0.5.0"
+      "version": "0.5.1",
+      "tag": "panache-parser-v0.5.1"
     },
     {
       "path": "editors/code",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [2.40.0](https://github.com/jolars/panache/compare/v2.39.0...v2.40.0) (2026-04-27)
+
+### Features
+- **linter:** add adjacents footnote lint ([`9729418`](https://github.com/jolars/panache/commit/972941810bc18fe251b606e9d82c46e790952f7d)), closes [#229](https://github.com/jolars/panache/issues/229)
+
+### Bug Fixes
+- **parser:** include `~` in set of escapables ([`cfc0bfc`](https://github.com/jolars/panache/commit/cfc0bfcd5cf1e02fd7ef16b712d666df61e260b6)), closes [#231](https://github.com/jolars/panache/issues/231)
+- **parser:** handle consecutive footnote definitions ([`e694627`](https://github.com/jolars/panache/commit/e694627654c497b66328d6062aa392af7337ce34))
+- **linter:** gate lints by extensions ([`1a03e9b`](https://github.com/jolars/panache/commit/1a03e9b6b838602bc0fcce5b68d22b04ceca773c))
+- **linter:** de-duplicate linter diagnostics ([`9c63e7e`](https://github.com/jolars/panache/commit/9c63e7ec8759759b9677c844528f82f12875c17d))
+- **linter:** de-duplicate parsing calls, avoid extra parses ([`45407fe`](https://github.com/jolars/panache/commit/45407fedf049c2b127d40c6c4df7263af4a8cad1))
+
+### Dependencies
+- updated crates/panache-parser to v0.5.1
 ## [2.39.0](https://github.com/jolars/panache/compare/v2.38.0...v2.39.0) (2026-04-27)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.2"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
+checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
 dependencies = [
  "clap",
 ]
@@ -841,7 +841,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "panache"
-version = "2.39.0"
+version = "2.40.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "insta",
  "log",
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "insta",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "2.39.0"
+version = "2.40.0"
 edition.workspace = true
 readme = "README.md"
 description = "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown"
@@ -39,8 +39,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.3.0" }
-panache-parser = { path = "crates/panache-parser", version = "0.5.0", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.3.1" }
+panache-parser = { path = "crates/panache-parser", version = "0.5.1", features = [
     "serde",
 ] }
 annotate-snippets = "0.12.15"

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [0.3.1](https://github.com/jolars/panache/compare/panache-formatter-v0.3.0...panache-formatter-v0.3.1) (2026-04-27)
+
 ## [0.3.0](https://github.com/jolars/panache/compare/panache-formatter-v0.2.1...panache-formatter-v0.3.0) (2026-04-27)
 
 ### Features

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 description = "Core formatting engine for Pandoc markdown, Quarto, and RMarkdown"
 license.workspace = true
@@ -13,7 +13,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.5.0" }
+panache-parser = { path = "../panache-parser", version = "0.5.1" }
 log = { version = "0.4.28", features = ["release_max_level_debug"] }
 rowan = "0.16.1"
 yaml_parser = "0.3.0"

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.5.1](https://github.com/jolars/panache/compare/panache-parser-v0.5.0...panache-parser-v0.5.1) (2026-04-27)
+
+### Bug Fixes
+- **parser:** include `~` in set of escapables ([`cfc0bfc`](https://github.com/jolars/panache/commit/cfc0bfcd5cf1e02fd7ef16b712d666df61e260b6)), closes [#231](https://github.com/jolars/panache/issues/231)
+- **parser:** handle consecutive footnote definitions ([`e694627`](https://github.com/jolars/panache/commit/e694627654c497b66328d6062aa392af7337ce34))
+
 ## [0.5.0](https://github.com/jolars/panache/compare/panache-parser-v0.4.2...panache-parser-v0.5.0) (2026-04-27)
 
 ### Features

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 readme = "README.md"
 description = "Lossless CST parser and syntax wrappers for Pandoc markdown, Quarto, and RMarkdown"

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -299,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",


### PR DESCRIPTION
## [panache: 2.40.0](https://github.com/jolars/panache/compare/v2.39.0...v2.40.0) (2026-04-27)

### Features
- **linter:** add adjacents footnote lint ([`9729418`](https://github.com/jolars/panache/commit/972941810bc18fe251b606e9d82c46e790952f7d)), closes [#229](https://github.com/jolars/panache/issues/229)

### Bug Fixes
- **parser:** include `~` in set of escapables ([`cfc0bfc`](https://github.com/jolars/panache/commit/cfc0bfcd5cf1e02fd7ef16b712d666df61e260b6)), closes [#231](https://github.com/jolars/panache/issues/231)
- **parser:** handle consecutive footnote definitions ([`e694627`](https://github.com/jolars/panache/commit/e694627654c497b66328d6062aa392af7337ce34))
- **linter:** gate lints by extensions ([`1a03e9b`](https://github.com/jolars/panache/commit/1a03e9b6b838602bc0fcce5b68d22b04ceca773c))
- **linter:** de-duplicate linter diagnostics ([`9c63e7e`](https://github.com/jolars/panache/commit/9c63e7ec8759759b9677c844528f82f12875c17d))
- **linter:** de-duplicate parsing calls, avoid extra parses ([`45407fe`](https://github.com/jolars/panache/commit/45407fedf049c2b127d40c6c4df7263af4a8cad1))

### Dependencies
- updated crates/panache-parser to v0.5.1

## [crates/panache-formatter: 0.3.1](https://github.com/jolars/panache/compare/v0.3.0...v0.3.1) (2026-04-27)

### Dependencies
- updated crates/panache-parser to v0.5.1

## [crates/panache-parser: 0.5.1](https://github.com/jolars/panache/compare/v0.5.0...v0.5.1) (2026-04-27)

### Bug Fixes
- **parser:** include `~` in set of escapables ([`cfc0bfc`](https://github.com/jolars/panache/commit/cfc0bfcd5cf1e02fd7ef16b712d666df61e260b6)), closes [#231](https://github.com/jolars/panache/issues/231)
- **parser:** handle consecutive footnote definitions ([`e694627`](https://github.com/jolars/panache/commit/e694627654c497b66328d6062aa392af7337ce34))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).