### PR TITLE
chore(release): panache-code-v2.35.1

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "884a3c4d851904b01f5644ad1ca350f013636247",
+  "baseline-sha": "89ce11d1121845530fd0ade7cb4c85829a2bb49c",
   "release-targets": [
     {
       "path": ".",
@@ -19,8 +19,8 @@
     },
     {
       "path": "editors/code",
-      "version": "2.35.0",
-      "tag": "panache-code-v2.35.0"
+      "version": "2.35.1",
+      "tag": "panache-code-v2.35.1"
     },
     {
       "path": "editors/zed",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.42.1](https://github.com/jolars/panache/compare/v2.42.0...v2.42.1) (2026-05-05)
+
+### Bug Fixes
+- **editors:** remove links in docs to pass vs code check ([`f9240fb`](https://github.com/jolars/panache/commit/f9240fb2b478ad136359625ed898c587bc82eaa0))
 ## [2.42.0](https://github.com/jolars/panache/compare/v2.41.1...v2.42.0) (2026-05-05)
 
 ### Features

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.35.1](https://github.com/jolars/panache/compare/panache-code-v2.35.0...panache-code-v2.35.1) (2026-05-05)
+
+### Bug Fixes
+- **editors:** remove links in docs to pass vs code check ([`f9240fb`](https://github.com/jolars/panache/commit/f9240fb2b478ad136359625ed898c587bc82eaa0))
+
 ## [2.35.0](https://github.com/jolars/panache/compare/panache-code-v2.34.2...panache-code-v2.35.0) (2026-05-05)
 
 ### Features

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "2.35.0",
+  "version": "2.35.1",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
## [editors/code: 2.35.1](https://github.com/jolars/panache/compare/v2.35.0...v2.35.1) (2026-05-05)

### Bug Fixes
- **editors:** remove links in docs to pass vs code check ([`f9240fb`](https://github.com/jolars/panache/commit/f9240fb2b478ad136359625ed898c587bc82eaa0))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).