### PR TITLE
chore(release): v2.43.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,26 +1,26 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "89ce11d1121845530fd0ade7cb4c85829a2bb49c",
+  "baseline-sha": "a9b17a432ccf3ab96a63b9513e2a78a4bd8a67c0",
   "release-targets": [
     {
       "path": ".",
-      "version": "2.42.0",
-      "tag": "v2.42.0"
+      "version": "2.43.0",
+      "tag": "v2.43.0"
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.4.2",
-      "tag": "panache-formatter-v0.4.2"
+      "version": "0.4.3",
+      "tag": "panache-formatter-v0.4.3"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.7.0",
-      "tag": "panache-parser-v0.7.0"
+      "version": "0.7.1",
+      "tag": "panache-parser-v0.7.1"
     },
     {
       "path": "editors/code",
-      "version": "2.35.1",
-      "tag": "panache-code-v2.35.1"
+      "version": "2.36.0",
+      "tag": "panache-code-v2.36.0"
     },
     {
       "path": "editors/zed",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [2.43.0](https://github.com/jolars/panache/compare/v2.42.0...v2.43.0) (2026-05-06)
+
+### Features
+- **linter:** add rule for stray fenced div markers ([`3b6ebe9`](https://github.com/jolars/panache/commit/3b6ebe9a12f99adefeba1452eec681a54fc20e88)), closes [#255](https://github.com/jolars/panache/issues/255)
+- **linter:** flag near-misses too in html entity rule ([`ce47752`](https://github.com/jolars/panache/commit/ce477525b03f52927cd7c0ef5b89747df6069984)), closes [#251](https://github.com/jolars/panache/issues/251)
+- **editors:** bundle binaries in VSIX extension ([`8a98d01`](https://github.com/jolars/panache/commit/8a98d014aaa6d50779bf944656b0350cd445a2d5))
+
+### Bug Fixes
+- enable `autolinks` for GFM ([`aeda13c`](https://github.com/jolars/panache/commit/aeda13cdc71a002bf0326cab9c1354abec321b2a)), closes [#258](https://github.com/jolars/panache/issues/258)
+
+### Dependencies
+- updated crates/panache-parser to v0.7.1
 ## [2.42.1](https://github.com/jolars/panache/compare/v2.42.0...v2.42.1) (2026-05-05)
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,7 +858,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "panache"
-version = "2.42.0"
+version = "2.43.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "insta",
  "log",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "entities",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "2.42.0"
+version = "2.43.0"
 edition.workspace = true
 readme = "README.md"
 description = "An LSP, formatter, and linter for Markdown, Quarto, and R Markdown"
@@ -39,8 +39,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.4.2" }
-panache-parser = { path = "crates/panache-parser", version = "0.7.0", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.4.3" }
+panache-parser = { path = "crates/panache-parser", version = "0.7.1", features = [
     "serde",
 ] }
 annotate-snippets = "0.12.15"

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.3](https://github.com/jolars/panache/compare/panache-formatter-v0.4.2...panache-formatter-v0.4.3) (2026-05-06)
+
+### Dependencies
+- updated crates/panache-parser to v0.7.1
+
 ## [0.4.2](https://github.com/jolars/panache/compare/panache-formatter-v0.4.1...panache-formatter-v0.4.2) (2026-05-05)
 
 ### Bug Fixes

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.4.2"
+version = "0.4.3"
 edition.workspace = true
 description = "Core formatting engine for Pandoc markdown, Quarto, and RMarkdown"
 license.workspace = true
@@ -13,7 +13,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.7.0" }
+panache-parser = { path = "../panache-parser", version = "0.7.1" }
 log = { version = "0.4.28", features = ["release_max_level_debug"] }
 rowan = "0.16.1"
 yaml_parser = "0.3.0"

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.7.1](https://github.com/jolars/panache/compare/panache-parser-v0.7.0...panache-parser-v0.7.1) (2026-05-06)
+
+### Bug Fixes
+- enable `autolinks` for GFM ([`aeda13c`](https://github.com/jolars/panache/commit/aeda13cdc71a002bf0326cab9c1354abec321b2a)), closes [#258](https://github.com/jolars/panache/issues/258)
+
 ## [0.7.0](https://github.com/jolars/panache/compare/panache-parser-v0.6.1...panache-parser-v0.7.0) (2026-05-05)
 
 ### Features

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.7.0"
+version = "0.7.1"
 edition.workspace = true
 readme = "README.md"
 description = "Lossless CST parser and syntax wrappers for Pandoc markdown, Quarto, and RMarkdown"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.36.0](https://github.com/jolars/panache/compare/panache-code-v2.35.1...panache-code-v2.36.0) (2026-05-06)
+
+### Features
+- **editors:** bundle binaries in VSIX extension ([`8a98d01`](https://github.com/jolars/panache/commit/8a98d014aaa6d50779bf944656b0350cd445a2d5))
+
+### Dependencies
+- updated . to v2.43.0
+
 ## [2.35.1](https://github.com/jolars/panache/compare/panache-code-v2.35.0...panache-code-v2.35.1) (2026-05-05)
 
 ### Bug Fixes

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "2.35.1",
+  "version": "2.36.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "2.42.0",
+  "version": "2.43.0",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "2.42.0",
-    "@panache-cli/linux-arm64-gnu": "2.42.0",
-    "@panache-cli/linux-x64-musl": "2.42.0",
-    "@panache-cli/linux-arm64-musl": "2.42.0",
-    "@panache-cli/darwin-x64": "2.42.0",
-    "@panache-cli/darwin-arm64": "2.42.0",
-    "@panache-cli/win32-x64": "2.42.0",
-    "@panache-cli/win32-arm64": "2.42.0"
+    "@panache-cli/linux-x64-gnu": "2.43.0",
+    "@panache-cli/linux-arm64-gnu": "2.43.0",
+    "@panache-cli/linux-x64-musl": "2.43.0",
+    "@panache-cli/linux-arm64-musl": "2.43.0",
+    "@panache-cli/darwin-x64": "2.43.0",
+    "@panache-cli/darwin-arm64": "2.43.0",
+    "@panache-cli/win32-x64": "2.43.0",
+    "@panache-cli/win32-arm64": "2.43.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panache-pre-commit",
-  "version": "2.42.0",
+  "version": "2.43.0",
   "description": "pre-commit hook wrapper for panache",
   "private": true,
   "license": "MIT",
@@ -12,7 +12,7 @@
     ".pre-commit-hooks.yaml"
   ],
   "dependencies": {
-    "@panache-cli/panache": "2.42.0"
+    "@panache-cli/panache": "2.43.0"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## [panache: 2.43.0](https://github.com/jolars/panache/compare/v2.42.0...v2.43.0) (2026-05-06)

### Features
- **linter:** add rule for stray fenced div markers ([`3b6ebe9`](https://github.com/jolars/panache/commit/3b6ebe9a12f99adefeba1452eec681a54fc20e88)), closes [#255](https://github.com/jolars/panache/issues/255)
- **linter:** flag near-misses too in html entity rule ([`ce47752`](https://github.com/jolars/panache/commit/ce477525b03f52927cd7c0ef5b89747df6069984)), closes [#251](https://github.com/jolars/panache/issues/251)
- **editors:** bundle binaries in VSIX extension ([`8a98d01`](https://github.com/jolars/panache/commit/8a98d014aaa6d50779bf944656b0350cd445a2d5))

### Bug Fixes
- enable `autolinks` for GFM ([`aeda13c`](https://github.com/jolars/panache/commit/aeda13cdc71a002bf0326cab9c1354abec321b2a)), closes [#258](https://github.com/jolars/panache/issues/258)

### Dependencies
- updated crates/panache-parser to v0.7.1

## [crates/panache-formatter: 0.4.3](https://github.com/jolars/panache/compare/v0.4.2...v0.4.3) (2026-05-06)

### Dependencies
- updated crates/panache-parser to v0.7.1

## [crates/panache-parser: 0.7.1](https://github.com/jolars/panache/compare/v0.7.0...v0.7.1) (2026-05-06)

### Bug Fixes
- enable `autolinks` for GFM ([`aeda13c`](https://github.com/jolars/panache/commit/aeda13cdc71a002bf0326cab9c1354abec321b2a)), closes [#258](https://github.com/jolars/panache/issues/258)

## [editors/code: 2.36.0](https://github.com/jolars/panache/compare/v2.35.1...v2.36.0) (2026-05-06)

### Features
- **editors:** bundle binaries in VSIX extension ([`8a98d01`](https://github.com/jolars/panache/commit/8a98d014aaa6d50779bf944656b0350cd445a2d5))

### Dependencies
- updated panache to v2.43.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).