### PR TITLE
chore(release): v2.43.1 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "a9b17a432ccf3ab96a63b9513e2a78a4bd8a67c0",
+  "baseline-sha": "a0d602c4203cf7cf202d013ceef60ae38c3aa835",
   "release-targets": [
     {
       "path": ".",
-      "version": "2.43.0",
-      "tag": "v2.43.0"
+      "version": "2.43.1",
+      "tag": "v2.43.1"
     },
     {
       "path": "crates/panache-formatter",
@@ -19,8 +19,8 @@
     },
     {
       "path": "editors/code",
-      "version": "2.36.0",
-      "tag": "panache-code-v2.36.0"
+      "version": "2.36.1",
+      "tag": "panache-code-v2.36.1"
     },
     {
       "path": "editors/zed",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.43.1](https://github.com/jolars/panache/compare/v2.43.0...v2.43.1) (2026-05-06)
+
+### Bug Fixes
+- **editors:** vsix publishing step ([`a0d602c`](https://github.com/jolars/panache/commit/a0d602c4203cf7cf202d013ceef60ae38c3aa835))
 ## [2.43.0](https://github.com/jolars/panache/compare/v2.42.0...v2.43.0) (2026-05-06)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,7 +858,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "panache"
-version = "2.43.0"
+version = "2.43.1"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "2.43.0"
+version = "2.43.1"
 edition.workspace = true
 readme = "README.md"
 description = "An LSP, formatter, and linter for Markdown, Quarto, and R Markdown"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.36.1](https://github.com/jolars/panache/compare/panache-code-v2.36.0...panache-code-v2.36.1) (2026-05-06)
+
+### Dependencies
+- updated . to v2.43.1
+
 ## [2.36.0](https://github.com/jolars/panache/compare/panache-code-v2.35.1...panache-code-v2.36.0) (2026-05-06)
 
 ### Features

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "2.36.0",
+  "version": "2.36.1",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "2.43.0",
+  "version": "2.43.1",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "2.43.0",
-    "@panache-cli/linux-arm64-gnu": "2.43.0",
-    "@panache-cli/linux-x64-musl": "2.43.0",
-    "@panache-cli/linux-arm64-musl": "2.43.0",
-    "@panache-cli/darwin-x64": "2.43.0",
-    "@panache-cli/darwin-arm64": "2.43.0",
-    "@panache-cli/win32-x64": "2.43.0",
-    "@panache-cli/win32-arm64": "2.43.0"
+    "@panache-cli/linux-x64-gnu": "2.43.1",
+    "@panache-cli/linux-arm64-gnu": "2.43.1",
+    "@panache-cli/linux-x64-musl": "2.43.1",
+    "@panache-cli/linux-arm64-musl": "2.43.1",
+    "@panache-cli/darwin-x64": "2.43.1",
+    "@panache-cli/darwin-arm64": "2.43.1",
+    "@panache-cli/win32-x64": "2.43.1",
+    "@panache-cli/win32-arm64": "2.43.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panache-pre-commit",
-  "version": "2.43.0",
+  "version": "2.43.1",
   "description": "pre-commit hook wrapper for panache",
   "private": true,
   "license": "MIT",
@@ -12,7 +12,7 @@
     ".pre-commit-hooks.yaml"
   ],
   "dependencies": {
-    "@panache-cli/panache": "2.43.0"
+    "@panache-cli/panache": "2.43.1"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## [panache: 2.43.1](https://github.com/jolars/panache/compare/v2.43.0...v2.43.1) (2026-05-06)

### Bug Fixes
- **editors:** vsix publishing step ([`a0d602c`](https://github.com/jolars/panache/commit/a0d602c4203cf7cf202d013ceef60ae38c3aa835))

## [editors/code: 2.36.1](https://github.com/jolars/panache/compare/v2.36.0...v2.36.1) (2026-05-06)

### Dependencies
- updated panache to v2.43.1

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).