### PR TITLE
chore(release): v2.44.0 (+2 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,16 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "a0d602c4203cf7cf202d013ceef60ae38c3aa835",
+  "baseline-sha": "84364a4abfcf10193f57e416d32a8b7685790da0",
   "release-targets": [
     {
       "path": ".",
-      "version": "2.43.1",
-      "tag": "v2.43.1"
+      "version": "2.44.0",
+      "tag": "v2.44.0"
+    },
+    {
+      "path": "crates/panache-dprint",
+      "version": "0.1.0",
+      "tag": "dprint-plugin-panache-v0.1.0"
     },
     {
       "path": "crates/panache-formatter",
@@ -19,8 +24,8 @@
     },
     {
       "path": "editors/code",
-      "version": "2.36.1",
-      "tag": "panache-code-v2.36.1"
+      "version": "2.37.0",
+      "tag": "panache-code-v2.37.0"
     },
     {
       "path": "editors/zed",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [2.44.0](https://github.com/jolars/panache/compare/v2.43.1...v2.44.0) (2026-05-07)
+
+### Features
+- **linter:** add `undefined-achor` rule ([`729d6be`](https://github.com/jolars/panache/commit/729d6be461ab981285fb07406a46091735cec894)), closes [#263](https://github.com/jolars/panache/issues/263)
+- **cli:** report if no autofix is available with `--fix` ([`fb8e20b`](https://github.com/jolars/panache/commit/fb8e20bab922f831976e20e87bab834185bcf196))
+- add dprint plugin crate ([`d4b5fc5`](https://github.com/jolars/panache/commit/d4b5fc5df454e89a54c0b9fb5bd9e7518fe35f2d))
+- **cli:** add `--flavor` argument to set flavor ([`7d84561`](https://github.com/jolars/panache/commit/7d84561ac869c1321fc97a11ecd1fdaf630623e8)), closes [#262](https://github.com/jolars/panache/issues/262)
+- **cli:** allow `-` as argument for stdin ([`c720c2e`](https://github.com/jolars/panache/commit/c720c2e920d078fa16fd8b987b54dc1c23881447))
+
+### Bug Fixes
+- **cli,linter:** only report and write if there are fixes ([`b8255b7`](https://github.com/jolars/panache/commit/b8255b7f8d9f92df511f2a448848e667152cbb32))
+- don't overwrite flavor ([`84364a4`](https://github.com/jolars/panache/commit/84364a4abfcf10193f57e416d32a8b7685790da0))
 ## [2.43.1](https://github.com/jolars/panache/compare/v2.43.0...v2.43.1) (2026-05-06)
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "annotate-snippets"
-version = "0.12.15"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92570a3f9c98e7e84df84b71d0965ac99b1871fcd75a3773a3bd1bad13f64cf7"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
 dependencies = [
  "anstyle",
  "memchr",
@@ -732,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -858,7 +858,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "panache"
-version = "2.43.1"
+version = "2.44.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -1731,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1744,9 +1744,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1754,9 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1767,9 +1767,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "2.43.1"
+version = "2.44.0"
 edition.workspace = true
 readme = "README.md"
 description = "An LSP, formatter, and linter for Markdown, Quarto, and R Markdown"

--- a/crates/panache-dprint/CHANGELOG.md
+++ b/crates/panache-dprint/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [0.1.0](https://github.com/jolars/panache/compare/dprint-plugin-panache-v0.0.1...dprint-plugin-panache-v0.1.0) (2026-05-07)
+
+### Features
+- add dprint plugin crate ([`d4b5fc5`](https://github.com/jolars/panache/commit/d4b5fc5df454e89a54c0b9fb5bd9e7518fe35f2d))
+
+### Bug Fixes
+- don't overwrite flavor ([`84364a4`](https://github.com/jolars/panache/commit/84364a4abfcf10193f57e416d32a8b7685790da0))

--- a/crates/panache-dprint/Cargo.toml
+++ b/crates/panache-dprint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dprint-plugin-panache"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/jolars/panache"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.37.0](https://github.com/jolars/panache/compare/panache-code-v2.36.1...panache-code-v2.37.0) (2026-05-07)
+
+### Dependencies
+- updated . to v2.44.0
 ## [2.36.1](https://github.com/jolars/panache/compare/panache-code-v2.36.0...panache-code-v2.36.1) (2026-05-06)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "2.36.1",
+  "version": "2.37.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "2.43.1",
+  "version": "2.44.0",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "2.43.1",
-    "@panache-cli/linux-arm64-gnu": "2.43.1",
-    "@panache-cli/linux-x64-musl": "2.43.1",
-    "@panache-cli/linux-arm64-musl": "2.43.1",
-    "@panache-cli/darwin-x64": "2.43.1",
-    "@panache-cli/darwin-arm64": "2.43.1",
-    "@panache-cli/win32-x64": "2.43.1",
-    "@panache-cli/win32-arm64": "2.43.1"
+    "@panache-cli/linux-x64-gnu": "2.44.0",
+    "@panache-cli/linux-arm64-gnu": "2.44.0",
+    "@panache-cli/linux-x64-musl": "2.44.0",
+    "@panache-cli/linux-arm64-musl": "2.44.0",
+    "@panache-cli/darwin-x64": "2.44.0",
+    "@panache-cli/darwin-arm64": "2.44.0",
+    "@panache-cli/win32-x64": "2.44.0",
+    "@panache-cli/win32-arm64": "2.44.0"
   }
 }


### PR DESCRIPTION
## [panache: 2.44.0](https://github.com/jolars/panache/compare/v2.43.1...v2.44.0) (2026-05-07)

### Features
- **linter:** add `undefined-achor` rule ([`729d6be`](https://github.com/jolars/panache/commit/729d6be461ab981285fb07406a46091735cec894)), closes [#263](https://github.com/jolars/panache/issues/263)
- **cli:** report if no autofix is available with `--fix` ([`fb8e20b`](https://github.com/jolars/panache/commit/fb8e20bab922f831976e20e87bab834185bcf196))
- add dprint plugin crate ([`d4b5fc5`](https://github.com/jolars/panache/commit/d4b5fc5df454e89a54c0b9fb5bd9e7518fe35f2d))
- **cli:** add `--flavor` argument to set flavor ([`7d84561`](https://github.com/jolars/panache/commit/7d84561ac869c1321fc97a11ecd1fdaf630623e8)), closes [#262](https://github.com/jolars/panache/issues/262)
- **cli:** allow `-` as argument for stdin ([`c720c2e`](https://github.com/jolars/panache/commit/c720c2e920d078fa16fd8b987b54dc1c23881447))

### Bug Fixes
- **cli,linter:** only report and write if there are fixes ([`b8255b7`](https://github.com/jolars/panache/commit/b8255b7f8d9f92df511f2a448848e667152cbb32))
- don't overwrite flavor ([`84364a4`](https://github.com/jolars/panache/commit/84364a4abfcf10193f57e416d32a8b7685790da0))

## [crates/panache-dprint: 0.1.0](https://github.com/jolars/panache/compare/dprint-plugin-panache-v0.0.1...dprint-plugin-panache-v0.1.0) (2026-05-07)

### Features
- add dprint plugin crate ([`d4b5fc5`](https://github.com/jolars/panache/commit/d4b5fc5df454e89a54c0b9fb5bd9e7518fe35f2d))

### Bug Fixes
- don't overwrite flavor ([`84364a4`](https://github.com/jolars/panache/commit/84364a4abfcf10193f57e416d32a8b7685790da0))

## [editors/code: 2.37.0](https://github.com/jolars/panache/compare/panache-code-v2.36.1...panache-code-v2.37.0) (2026-05-07)

### Dependencies
- updated . to v2.44.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).