### PR TITLE
chore(release): v2.45.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "84364a4abfcf10193f57e416d32a8b7685790da0",
+  "baseline-sha": "a92d4411ab609e11f2ce5e877b945d552e4a88ee",
   "release-targets": [
     {
       "path": ".",
-      "version": "2.44.0",
-      "tag": "v2.44.0"
+      "version": "2.45.0",
+      "tag": "v2.45.0"
     },
     {
       "path": "crates/panache-dprint",
@@ -14,18 +14,18 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.4.3",
-      "tag": "panache-formatter-v0.4.3"
+      "version": "0.5.0",
+      "tag": "panache-formatter-v0.5.0"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.7.1",
-      "tag": "panache-parser-v0.7.1"
+      "version": "0.8.0",
+      "tag": "panache-parser-v0.8.0"
     },
     {
       "path": "editors/code",
-      "version": "2.37.0",
-      "tag": "panache-code-v2.37.0"
+      "version": "2.38.0",
+      "tag": "panache-code-v2.38.0"
     },
     {
       "path": "editors/zed",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [2.45.0](https://github.com/jolars/panache/compare/v2.44.0...v2.45.0) (2026-05-09)
+
+### Features
+- **cli:** add `--verbose` flag and use it in `clean` ([`a92d441`](https://github.com/jolars/panache/commit/a92d4411ab609e11f2ce5e877b945d552e4a88ee)), closes [#272](https://github.com/jolars/panache/issues/272)
+- **cli:** add a `--to pandoc-json` argument ([`b3f3785`](https://github.com/jolars/panache/commit/b3f378558ef9dab11beb15c6e2ff85cfdbffec28)), closes [#269](https://github.com/jolars/panache/issues/269)
+- **parser:** gate html declarations on dialect ([`9e0b645`](https://github.com/jolars/panache/commit/9e0b64561f39ebf7856263058947a27c7022dde8))
+- **parser:** parser inline spans granularly ([`03333d2`](https://github.com/jolars/panache/commit/03333d241000a0cbea6648967bf08fd940b4e0ab))
+- **parser:** add depth-aware html block parsing ([`2a5dcac`](https://github.com/jolars/panache/commit/2a5dcace3361acb49c222b5bdcf3ef28d3dd8e8b))
+
+### Bug Fixes
+- **parser:** add commonmark-ascii fix ([`4cfcd1c`](https://github.com/jolars/panache/commit/4cfcd1cdcc4575906faffc21b86fa1f7f52a5cb9))
+- **parser,linter:** introduce `HTML_DIV_BLOCK` parsing ([`3962e03`](https://github.com/jolars/panache/commit/3962e0329a83feb5bfbdef84fd3bf52527e7af58)), closes [#263](https://github.com/jolars/panache/issues/263)
+- **linter:** fix undefined-anchor false positive on brackspans ([`0b1a15a`](https://github.com/jolars/panache/commit/0b1a15a5806a483b577cb6ad95aebf02898a5495)), ref [#263](https://github.com/jolars/panache/issues/263)
+- correctly parser trailing attributes in equations ([`492306f`](https://github.com/jolars/panache/commit/492306f2cdaa35ef64b6e43b914797555f5681d9))
+- **parser:** parse references in captions ([`eb29a9d`](https://github.com/jolars/panache/commit/eb29a9d1dfb44c6d9626570e2015eb7898ca166e))
+
+### Dependencies
+- updated crates/panache-formatter to v0.5.0
+- updated crates/panache-parser to v0.8.0
 ## [2.44.0](https://github.com/jolars/panache/compare/v2.43.1...v2.44.0) (2026-05-07)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -658,7 +658,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -858,7 +858,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "panache"
-version = "2.44.0"
+version = "2.45.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "insta",
  "log",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "entities",
  "insta",
@@ -1231,7 +1231,7 @@ dependencies = [
  "boxcar",
  "crossbeam-queue",
  "crossbeam-utils",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "hashlink",
  "indexmap",
  "intrusive-collections",
@@ -1486,9 +1486,9 @@ checksum = "650d82e943da333637be9f1567d33d605e76810a26464edfd7ae74f7ef181e95"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "2.44.0"
+version = "2.45.0"
 edition.workspace = true
 readme = "README.md"
 description = "An LSP, formatter, and linter for Markdown, Quarto, and R Markdown"
@@ -47,8 +47,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.4.3" }
-panache-parser = { path = "crates/panache-parser", version = "0.7.1", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.5.0" }
+panache-parser = { path = "crates/panache-parser", version = "0.8.0", features = [
     "serde",
 ] }
 annotate-snippets = "0.12.15"

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.5.0](https://github.com/jolars/panache/compare/panache-formatter-v0.4.3...panache-formatter-v0.5.0) (2026-05-09)
+
+### Features
+- **parser:** parser inline spans granularly ([`03333d2`](https://github.com/jolars/panache/commit/03333d241000a0cbea6648967bf08fd940b4e0ab))
+
+### Bug Fixes
+- **parser,linter:** introduce `HTML_DIV_BLOCK` parsing ([`3962e03`](https://github.com/jolars/panache/commit/3962e0329a83feb5bfbdef84fd3bf52527e7af58)), closes [#263](https://github.com/jolars/panache/issues/263)
+
+### Dependencies
+- updated crates/panache-parser to v0.8.0
 ## [0.4.3](https://github.com/jolars/panache/compare/panache-formatter-v0.4.2...panache-formatter-v0.4.3) (2026-05-06)
 
 ### Dependencies

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.4.3"
+version = "0.5.0"
 edition.workspace = true
 description = "Core formatting engine for Pandoc markdown, Quarto, and RMarkdown"
 license.workspace = true
@@ -13,7 +13,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.7.1" }
+panache-parser = { path = "../panache-parser", version = "0.8.0" }
 log = { version = "0.4.28", features = ["release_max_level_debug"] }
 rowan = "0.16.1"
 yaml_parser = "0.3.0"

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.8.0](https://github.com/jolars/panache/compare/panache-parser-v0.7.1...panache-parser-v0.8.0) (2026-05-09)
+
+### Features
+- **parser:** add depth-aware html block parsing ([`2a5dcac`](https://github.com/jolars/panache/commit/2a5dcace3361acb49c222b5bdcf3ef28d3dd8e8b))
+- **cli:** add a `--to pandoc-json` argument ([`b3f3785`](https://github.com/jolars/panache/commit/b3f378558ef9dab11beb15c6e2ff85cfdbffec28)), closes [#269](https://github.com/jolars/panache/issues/269)
+- **parser:** gate html declarations on dialect ([`9e0b645`](https://github.com/jolars/panache/commit/9e0b64561f39ebf7856263058947a27c7022dde8))
+- **parser:** parser inline spans granularly ([`03333d2`](https://github.com/jolars/panache/commit/03333d241000a0cbea6648967bf08fd940b4e0ab))
+
+### Bug Fixes
+- correctly parser trailing attributes in equations ([`492306f`](https://github.com/jolars/panache/commit/492306f2cdaa35ef64b6e43b914797555f5681d9))
+- **parser:** parse references in captions ([`eb29a9d`](https://github.com/jolars/panache/commit/eb29a9d1dfb44c6d9626570e2015eb7898ca166e))
+- **parser:** add commonmark-ascii fix ([`4cfcd1c`](https://github.com/jolars/panache/commit/4cfcd1cdcc4575906faffc21b86fa1f7f52a5cb9))
+- **parser,linter:** introduce `HTML_DIV_BLOCK` parsing ([`3962e03`](https://github.com/jolars/panache/commit/3962e0329a83feb5bfbdef84fd3bf52527e7af58)), closes [#263](https://github.com/jolars/panache/issues/263)
 ## [0.7.1](https://github.com/jolars/panache/compare/panache-parser-v0.7.0...panache-parser-v0.7.1) (2026-05-06)
 
 ### Bug Fixes

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 readme = "README.md"
 description = "Lossless CST parser and syntax wrappers for Pandoc markdown, Quarto, and RMarkdown"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.38.0](https://github.com/jolars/panache/compare/panache-code-v2.37.0...panache-code-v2.38.0) (2026-05-09)
+
+### Dependencies
+- updated . to v2.45.0
 ## [2.37.0](https://github.com/jolars/panache/compare/panache-code-v2.36.1...panache-code-v2.37.0) (2026-05-07)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "2.37.0",
+  "version": "2.38.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -314,7 +314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "2.44.0",
+  "version": "2.45.0",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "2.44.0",
-    "@panache-cli/linux-arm64-gnu": "2.44.0",
-    "@panache-cli/linux-x64-musl": "2.44.0",
-    "@panache-cli/linux-arm64-musl": "2.44.0",
-    "@panache-cli/darwin-x64": "2.44.0",
-    "@panache-cli/darwin-arm64": "2.44.0",
-    "@panache-cli/win32-x64": "2.44.0",
-    "@panache-cli/win32-arm64": "2.44.0"
+    "@panache-cli/linux-x64-gnu": "2.45.0",
+    "@panache-cli/linux-arm64-gnu": "2.45.0",
+    "@panache-cli/linux-x64-musl": "2.45.0",
+    "@panache-cli/linux-arm64-musl": "2.45.0",
+    "@panache-cli/darwin-x64": "2.45.0",
+    "@panache-cli/darwin-arm64": "2.45.0",
+    "@panache-cli/win32-x64": "2.45.0",
+    "@panache-cli/win32-arm64": "2.45.0"
   }
 }


### PR DESCRIPTION
## [panache: 2.45.0](https://github.com/jolars/panache/compare/v2.44.0...v2.45.0) (2026-05-09)

### Features
- **cli:** add `--verbose` flag and use it in `clean` ([`a92d441`](https://github.com/jolars/panache/commit/a92d4411ab609e11f2ce5e877b945d552e4a88ee)), closes [#272](https://github.com/jolars/panache/issues/272)
- **cli:** add a `--to pandoc-json` argument ([`b3f3785`](https://github.com/jolars/panache/commit/b3f378558ef9dab11beb15c6e2ff85cfdbffec28)), closes [#269](https://github.com/jolars/panache/issues/269)
- **parser:** gate html declarations on dialect ([`9e0b645`](https://github.com/jolars/panache/commit/9e0b64561f39ebf7856263058947a27c7022dde8))
- **parser:** parser inline spans granularly ([`03333d2`](https://github.com/jolars/panache/commit/03333d241000a0cbea6648967bf08fd940b4e0ab))
- **parser:** add depth-aware html block parsing ([`2a5dcac`](https://github.com/jolars/panache/commit/2a5dcace3361acb49c222b5bdcf3ef28d3dd8e8b))

### Bug Fixes
- **parser:** add commonmark-ascii fix ([`4cfcd1c`](https://github.com/jolars/panache/commit/4cfcd1cdcc4575906faffc21b86fa1f7f52a5cb9))
- **parser,linter:** introduce `HTML_DIV_BLOCK` parsing ([`3962e03`](https://github.com/jolars/panache/commit/3962e0329a83feb5bfbdef84fd3bf52527e7af58)), closes [#263](https://github.com/jolars/panache/issues/263)
- **linter:** fix undefined-anchor false positive on brackspans ([`0b1a15a`](https://github.com/jolars/panache/commit/0b1a15a5806a483b577cb6ad95aebf02898a5495)), ref [#263](https://github.com/jolars/panache/issues/263)
- correctly parser trailing attributes in equations ([`492306f`](https://github.com/jolars/panache/commit/492306f2cdaa35ef64b6e43b914797555f5681d9))
- **parser:** parse references in captions ([`eb29a9d`](https://github.com/jolars/panache/commit/eb29a9d1dfb44c6d9626570e2015eb7898ca166e))

### Dependencies
- updated crates/panache-formatter to v0.5.0
- updated crates/panache-parser to v0.8.0

## [crates/panache-formatter: 0.5.0](https://github.com/jolars/panache/compare/panache-formatter-v0.4.3...panache-formatter-v0.5.0) (2026-05-09)

### Features
- **parser:** parser inline spans granularly ([`03333d2`](https://github.com/jolars/panache/commit/03333d241000a0cbea6648967bf08fd940b4e0ab))

### Bug Fixes
- **parser,linter:** introduce `HTML_DIV_BLOCK` parsing ([`3962e03`](https://github.com/jolars/panache/commit/3962e0329a83feb5bfbdef84fd3bf52527e7af58)), closes [#263](https://github.com/jolars/panache/issues/263)

### Dependencies
- updated crates/panache-parser to v0.8.0

## [crates/panache-parser: 0.8.0](https://github.com/jolars/panache/compare/panache-parser-v0.7.1...panache-parser-v0.8.0) (2026-05-09)

### Features
- **parser:** add depth-aware html block parsing ([`2a5dcac`](https://github.com/jolars/panache/commit/2a5dcace3361acb49c222b5bdcf3ef28d3dd8e8b))
- **cli:** add a `--to pandoc-json` argument ([`b3f3785`](https://github.com/jolars/panache/commit/b3f378558ef9dab11beb15c6e2ff85cfdbffec28)), closes [#269](https://github.com/jolars/panache/issues/269)
- **parser:** gate html declarations on dialect ([`9e0b645`](https://github.com/jolars/panache/commit/9e0b64561f39ebf7856263058947a27c7022dde8))
- **parser:** parser inline spans granularly ([`03333d2`](https://github.com/jolars/panache/commit/03333d241000a0cbea6648967bf08fd940b4e0ab))

### Bug Fixes
- correctly parser trailing attributes in equations ([`492306f`](https://github.com/jolars/panache/commit/492306f2cdaa35ef64b6e43b914797555f5681d9))
- **parser:** parse references in captions ([`eb29a9d`](https://github.com/jolars/panache/commit/eb29a9d1dfb44c6d9626570e2015eb7898ca166e))
- **parser:** add commonmark-ascii fix ([`4cfcd1c`](https://github.com/jolars/panache/commit/4cfcd1cdcc4575906faffc21b86fa1f7f52a5cb9))
- **parser,linter:** introduce `HTML_DIV_BLOCK` parsing ([`3962e03`](https://github.com/jolars/panache/commit/3962e0329a83feb5bfbdef84fd3bf52527e7af58)), closes [#263](https://github.com/jolars/panache/issues/263)

## [editors/code: 2.38.0](https://github.com/jolars/panache/compare/panache-code-v2.37.0...panache-code-v2.38.0) (2026-05-09)

### Dependencies
- updated . to v2.45.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).