### PR TITLE
chore(release): v2.46.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "a92d4411ab609e11f2ce5e877b945d552e4a88ee",
+  "baseline-sha": "d3aed2123faa296b54b37eeaf1e32c5b2b31d6ff",
   "release-targets": [
     {
       "path": ".",
-      "version": "2.45.0",
-      "tag": "v2.45.0"
+      "version": "2.46.0",
+      "tag": "v2.46.0"
     },
     {
       "path": "crates/panache-dprint",
@@ -14,18 +14,18 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.5.0",
-      "tag": "panache-formatter-v0.5.0"
+      "version": "0.5.1",
+      "tag": "panache-formatter-v0.5.1"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.8.0",
-      "tag": "panache-parser-v0.8.0"
+      "version": "0.9.0",
+      "tag": "panache-parser-v0.9.0"
     },
     {
       "path": "editors/code",
-      "version": "2.38.0",
-      "tag": "panache-code-v2.38.0"
+      "version": "2.39.0",
+      "tag": "panache-code-v2.39.0"
     },
     {
       "path": "editors/zed",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## [2.46.0](https://github.com/jolars/panache/compare/v2.45.0...v2.46.0) (2026-05-12)
+
+### Features
+- stop project root discovery walk on `.git` ([`b370865`](https://github.com/jolars/panache/commit/b370865bcae7c59be0c177d6b89404e7baec21d0))
+- **lsp:** initiate root-dir walk from current file ([`52f52b7`](https://github.com/jolars/panache/commit/52f52b7857553afd2bfe57f4b4525b2412cf77d3))
+- **lsp:** add completion for shortcodes ([`42280e5`](https://github.com/jolars/panache/commit/42280e5b791d362506c8da3353a238a5798d7d5f))
+- **lsp:** add file path completion in `![]()` and `[]()` ([`1081475`](https://github.com/jolars/panache/commit/1081475a8fa3b67d0afb1ae2d850abd82039d7fb))
+- **parser:** handle multi-line div tag blocks ([`5f350b4`](https://github.com/jolars/panache/commit/5f350b42111bcea7636c8a7283bc1c4fbe32c40e))
+
+### Bug Fixes
+- **cli+windows:** cleanly handle tmp file removal ([`d3aed21`](https://github.com/jolars/panache/commit/d3aed2123faa296b54b37eeaf1e32c5b2b31d6ff))
+- **formatter:** don't strip `!expr` in hashpipe yaml ([`f03ca70`](https://github.com/jolars/panache/commit/f03ca702815cbafb54c0066b685ec6497ca968e4)), closes [#280](https://github.com/jolars/panache/issues/280)
+- **parser:** lift bq messy-shape HTML bodies into CST ([`e923d7c`](https://github.com/jolars/panache/commit/e923d7c4ee8ca936a5a9d34a8b9190c35a28d7c9))
+- **parser:** lift bq same-line HTML body into CST ([`1ba1b1e`](https://github.com/jolars/panache/commit/1ba1b1ea37dcdf7ecea15ecdf3ad7bb31af9ff33))
+- **parser:** expose HTML_ATTRS for non-div strict-block tags in bq ([`2bd4542`](https://github.com/jolars/panache/commit/2bd4542bb8c7144523c6ec9894584b3038670315))
+- **parser:** extend bq HTML lift to non-div and inline-block ([`8b88578`](https://github.com/jolars/panache/commit/8b8857897dd972b34aaacec47caa29477b155ed6))
+- **parser:** lift bq-wrapped clean `<div>` body into CST ([`4bc4612`](https://github.com/jolars/panache/commit/4bc4612c08347607c605971e852fd3199dc850e6))
+- **parser:** lift matched-pair inline-block HTML bodies into CST ([`f335b42`](https://github.com/jolars/panache/commit/f335b4218f39a99ba185ec27e0296ab67dc1bcad)), fix [#4](https://github.com/jolars/panache/issues/4)
+- **parser:** lift multi-line non-div strict-block HTML opens into CST ([`59a5f91`](https://github.com/jolars/panache/commit/59a5f91aa763ec29cd1ccfca03b753d8ff106fb0))
+- **parser:** lift non-div strict-block butted-close shapes into CST ([`98767ab`](https://github.com/jolars/panache/commit/98767ab92f3376e2eae79634c80bdaa4d868fecf)), fix [#4](https://github.com/jolars/panache/issues/4)
+- **parser:** lift inner strict-block HTML elements into CST ([`3f6f644`](https://github.com/jolars/panache/commit/3f6f6448cb87154f2b8cb363a747fb50cc496a95))
+- **projector:** lift empty `<div>` into structural CST walk ([`179a681`](https://github.com/jolars/panache/commit/179a681b12eedc54704d5e42826e36a0d8812ebf)), fix [#4](https://github.com/jolars/panache/issues/4)
+- **projector:** strip blockquote markers from HTML block bodies ([`47e6c38`](https://github.com/jolars/panache/commit/47e6c386527daff8dff4ca30fed708ff2c762418))
+- **parser:** lift same-line `<div>` shapes into CST ([`33b6297`](https://github.com/jolars/panache/commit/33b6297ffae9711a8459d1f0e0e60b2a2a2926c5))
+- **parser:** lift messy `<div>` shapes into CST ([`4c03405`](https://github.com/jolars/panache/commit/4c034054f52275e33903e9b3f066e7fdf175743a))
+- **parser:** lift inner `<div>` elements into CST ([`1b37801`](https://github.com/jolars/panache/commit/1b37801fc12e12dd57a239bc6a643527df640c27))
+- **parser:** mirror Pandoc's `isInlineTag` for `<script>` ([`ba9c96f`](https://github.com/jolars/panache/commit/ba9c96f39e338300dac97347ea0bb8583e813a66))
+- **parser,formatter:** don't escape `[`, `]` ([`26bbb1c`](https://github.com/jolars/panache/commit/26bbb1c5bd539c85108f63e79dbe7c29d24b5222))
+- **parser:** capture citation inside reference ([`c6685f4`](https://github.com/jolars/panache/commit/c6685f48d886d014831e83a30c71593a5692687e)), closes [#278](https://github.com/jolars/panache/issues/278)
+- **parser:** correctly merge unevenly indented lists ([`b661b61`](https://github.com/jolars/panache/commit/b661b61a50a72d302713e0fd5a50d3a1ab66e87f)), fixes [#277](https://github.com/jolars/panache/issues/277)
+- **parser:** closer cannot interrupt under pandoc ([`74d333a`](https://github.com/jolars/panache/commit/74d333a0e473cfda655a92104584afb6a1df9f17))
+- **parser:** don't let `<style>` tags interrupt under pandoc ([`b77db95`](https://github.com/jolars/panache/commit/b77db958480be7e049232860d6df10a961c980ce))
+- **parser:** fix plain/paragraph handling for html in parser ([`d7745dd`](https://github.com/jolars/panache/commit/d7745ddcb720f8464225c16397c1c3ba4c51889f))
+- **parser:** accept correct tags for Pandoc's closing-forms ([`7ab94d1`](https://github.com/jolars/panache/commit/7ab94d183cb794362acbe84f63eb6278063d8454))
+- **parser:** match Pandoc on closing forms of inline blocks ([`525cdf4`](https://github.com/jolars/panache/commit/525cdf40b22e56d2cbcfd6c6bce146a1874c453d))
+- **parser:** handle multi-line void open tag ([`05b369d`](https://github.com/jolars/panache/commit/05b369d072d2d243f59261b955c67672079561d5))
+- **parser:** handle infinite recursion in incomplete tags ([`95c95bf`](https://github.com/jolars/panache/commit/95c95bfe918d786142bc18f2290c301518fe15c9))
+- **parser:** handle Pandoc's void block tags ([`a327162`](https://github.com/jolars/panache/commit/a32716225851593bb1caa9308f24112ab18c660a))
+- **parser:** handle context-aware block/inline dispatcher ([`1b8330d`](https://github.com/jolars/panache/commit/1b8330da6017c53a83ab460af4e9ecefeedcba96))
+- **parser:** don't hardcode `<div` into CST ([`7c6515e`](https://github.com/jolars/panache/commit/7c6515e058b5df4eec014b2d1c604674d025d846))
+- **parser:** fix dialect-divergence in pandoc/commonmark ([`3a81ac2`](https://github.com/jolars/panache/commit/3a81ac245dc758d41ce0682c8bab01e52b04f54d))
+- **formatter:** don't skip `PLAIN` in second pass ([`a693f40`](https://github.com/jolars/panache/commit/a693f40488b6fa53726e70260cb66dce2853b5f9)), closes [#279](https://github.com/jolars/panache/issues/279)
+
+### Dependencies
+- updated crates/panache-formatter to v0.5.1
+- updated crates/panache-parser to v0.9.0
 ## [2.45.0](https://github.com/jolars/panache/compare/v2.44.0...v2.45.0) (2026-05-09)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,9 +86,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
 dependencies = [
  "anstyle",
  "bstr",
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.3"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
 dependencies = [
  "clap",
 ]
@@ -361,9 +361,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "emojis"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afd562179989ec12b5c82f63a9423be4d4f0c5651930837074488ef4d07f2886"
+checksum = "0a4d5d50b0b58df5173d8ff1192b4d1422ceae5d981b30d4b6f8ed1d673a2bc4"
 dependencies = [
  "phf",
 ]
@@ -858,7 +858,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "panache"
-version = "2.45.0"
+version = "2.46.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "insta",
  "log",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "entities",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "2.45.0"
+version = "2.46.0"
 edition.workspace = true
 readme = "README.md"
 description = "An LSP, formatter, and linter for Markdown, Quarto, and R Markdown"
@@ -47,8 +47,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.5.0" }
-panache-parser = { path = "crates/panache-parser", version = "0.8.0", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.5.1" }
+panache-parser = { path = "crates/panache-parser", version = "0.9.0", features = [
     "serde",
 ] }
 annotate-snippets = "0.12.15"

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.5.1](https://github.com/jolars/panache/compare/panache-formatter-v0.5.0...panache-formatter-v0.5.1) (2026-05-12)
+
+### Bug Fixes
+- **formatter:** don't strip `!expr` in hashpipe yaml ([`f03ca70`](https://github.com/jolars/panache/commit/f03ca702815cbafb54c0066b685ec6497ca968e4)), closes [#280](https://github.com/jolars/panache/issues/280)
+- **formatter:** don't skip `PLAIN` in second pass ([`a693f40`](https://github.com/jolars/panache/commit/a693f40488b6fa53726e70260cb66dce2853b5f9)), closes [#279](https://github.com/jolars/panache/issues/279)
+- **parser,formatter:** don't escape `[`, `]` ([`26bbb1c`](https://github.com/jolars/panache/commit/26bbb1c5bd539c85108f63e79dbe7c29d24b5222))
+
+### Dependencies
+- updated crates/panache-parser to v0.9.0
 ## [0.5.0](https://github.com/jolars/panache/compare/panache-formatter-v0.4.3...panache-formatter-v0.5.0) (2026-05-09)
 
 ### Features

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 description = "Core formatting engine for Pandoc markdown, Quarto, and RMarkdown"
 license.workspace = true
@@ -13,7 +13,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.8.0" }
+panache-parser = { path = "../panache-parser", version = "0.9.0" }
 log = { version = "0.4.28", features = ["release_max_level_debug"] }
 rowan = "0.16.1"
 yaml_parser = "0.3.0"

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## [0.9.0](https://github.com/jolars/panache/compare/panache-parser-v0.8.0...panache-parser-v0.9.0) (2026-05-12)
+
+### Features
+- **parser:** handle multi-line div tag blocks ([`5f350b4`](https://github.com/jolars/panache/commit/5f350b42111bcea7636c8a7283bc1c4fbe32c40e))
+
+### Bug Fixes
+- **parser:** lift bq messy-shape HTML bodies into CST ([`e923d7c`](https://github.com/jolars/panache/commit/e923d7c4ee8ca936a5a9d34a8b9190c35a28d7c9))
+- **parser:** lift bq same-line HTML body into CST ([`1ba1b1e`](https://github.com/jolars/panache/commit/1ba1b1ea37dcdf7ecea15ecdf3ad7bb31af9ff33))
+- **parser:** expose HTML_ATTRS for non-div strict-block tags in bq ([`2bd4542`](https://github.com/jolars/panache/commit/2bd4542bb8c7144523c6ec9894584b3038670315))
+- **parser:** extend bq HTML lift to non-div and inline-block ([`8b88578`](https://github.com/jolars/panache/commit/8b8857897dd972b34aaacec47caa29477b155ed6))
+- **parser:** lift bq-wrapped clean `<div>` body into CST ([`4bc4612`](https://github.com/jolars/panache/commit/4bc4612c08347607c605971e852fd3199dc850e6))
+- **parser:** lift matched-pair inline-block HTML bodies into CST ([`f335b42`](https://github.com/jolars/panache/commit/f335b4218f39a99ba185ec27e0296ab67dc1bcad)), fix [#4](https://github.com/jolars/panache/issues/4)
+- **parser:** lift multi-line non-div strict-block HTML opens into CST ([`59a5f91`](https://github.com/jolars/panache/commit/59a5f91aa763ec29cd1ccfca03b753d8ff106fb0))
+- **parser:** lift non-div strict-block butted-close shapes into CST ([`98767ab`](https://github.com/jolars/panache/commit/98767ab92f3376e2eae79634c80bdaa4d868fecf)), fix [#4](https://github.com/jolars/panache/issues/4)
+- **parser:** lift inner strict-block HTML elements into CST ([`3f6f644`](https://github.com/jolars/panache/commit/3f6f6448cb87154f2b8cb363a747fb50cc496a95))
+- **projector:** lift empty `<div>` into structural CST walk ([`179a681`](https://github.com/jolars/panache/commit/179a681b12eedc54704d5e42826e36a0d8812ebf)), fix [#4](https://github.com/jolars/panache/issues/4)
+- **projector:** strip blockquote markers from HTML block bodies ([`47e6c38`](https://github.com/jolars/panache/commit/47e6c386527daff8dff4ca30fed708ff2c762418))
+- **parser:** lift same-line `<div>` shapes into CST ([`33b6297`](https://github.com/jolars/panache/commit/33b6297ffae9711a8459d1f0e0e60b2a2a2926c5))
+- **parser:** lift messy `<div>` shapes into CST ([`4c03405`](https://github.com/jolars/panache/commit/4c034054f52275e33903e9b3f066e7fdf175743a))
+- **parser:** lift inner `<div>` elements into CST ([`1b37801`](https://github.com/jolars/panache/commit/1b37801fc12e12dd57a239bc6a643527df640c27))
+- **parser:** mirror Pandoc's `isInlineTag` for `<script>` ([`ba9c96f`](https://github.com/jolars/panache/commit/ba9c96f39e338300dac97347ea0bb8583e813a66))
+- **parser,formatter:** don't escape `[`, `]` ([`26bbb1c`](https://github.com/jolars/panache/commit/26bbb1c5bd539c85108f63e79dbe7c29d24b5222))
+- **parser:** capture citation inside reference ([`c6685f4`](https://github.com/jolars/panache/commit/c6685f48d886d014831e83a30c71593a5692687e)), closes [#278](https://github.com/jolars/panache/issues/278)
+- **parser:** correctly merge unevenly indented lists ([`b661b61`](https://github.com/jolars/panache/commit/b661b61a50a72d302713e0fd5a50d3a1ab66e87f)), fixes [#277](https://github.com/jolars/panache/issues/277)
+- **parser:** closer cannot interrupt under pandoc ([`74d333a`](https://github.com/jolars/panache/commit/74d333a0e473cfda655a92104584afb6a1df9f17))
+- **parser:** don't let `<style>` tags interrupt under pandoc ([`b77db95`](https://github.com/jolars/panache/commit/b77db958480be7e049232860d6df10a961c980ce))
+- **parser:** fix plain/paragraph handling for html in parser ([`d7745dd`](https://github.com/jolars/panache/commit/d7745ddcb720f8464225c16397c1c3ba4c51889f))
+- **parser:** accept correct tags for Pandoc's closing-forms ([`7ab94d1`](https://github.com/jolars/panache/commit/7ab94d183cb794362acbe84f63eb6278063d8454))
+- **parser:** match Pandoc on closing forms of inline blocks ([`525cdf4`](https://github.com/jolars/panache/commit/525cdf40b22e56d2cbcfd6c6bce146a1874c453d))
+- **parser:** handle multi-line void open tag ([`05b369d`](https://github.com/jolars/panache/commit/05b369d072d2d243f59261b955c67672079561d5))
+- **parser:** handle infinite recursion in incomplete tags ([`95c95bf`](https://github.com/jolars/panache/commit/95c95bfe918d786142bc18f2290c301518fe15c9))
+- **parser:** handle Pandoc's void block tags ([`a327162`](https://github.com/jolars/panache/commit/a32716225851593bb1caa9308f24112ab18c660a))
+- **parser:** handle context-aware block/inline dispatcher ([`1b8330d`](https://github.com/jolars/panache/commit/1b8330da6017c53a83ab460af4e9ecefeedcba96))
+- **parser:** don't hardcode `<div` into CST ([`7c6515e`](https://github.com/jolars/panache/commit/7c6515e058b5df4eec014b2d1c604674d025d846))
+- **parser:** fix dialect-divergence in pandoc/commonmark ([`3a81ac2`](https://github.com/jolars/panache/commit/3a81ac245dc758d41ce0682c8bab01e52b04f54d))
 ## [0.8.0](https://github.com/jolars/panache/compare/panache-parser-v0.7.1...panache-parser-v0.8.0) (2026-05-09)
 
 ### Features

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 readme = "README.md"
 description = "Lossless CST parser and syntax wrappers for Pandoc markdown, Quarto, and RMarkdown"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.39.0](https://github.com/jolars/panache/compare/panache-code-v2.38.0...panache-code-v2.39.0) (2026-05-12)
+
+### Dependencies
+- updated panache to v2.46.0
 ## [2.38.0](https://github.com/jolars/panache/compare/panache-code-v2.37.0...panache-code-v2.38.0) (2026-05-09)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "2.38.0",
+  "version": "2.39.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -758,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "2.45.0",
+  "version": "2.46.0",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "2.45.0",
-    "@panache-cli/linux-arm64-gnu": "2.45.0",
-    "@panache-cli/linux-x64-musl": "2.45.0",
-    "@panache-cli/linux-arm64-musl": "2.45.0",
-    "@panache-cli/darwin-x64": "2.45.0",
-    "@panache-cli/darwin-arm64": "2.45.0",
-    "@panache-cli/win32-x64": "2.45.0",
-    "@panache-cli/win32-arm64": "2.45.0"
+    "@panache-cli/linux-x64-gnu": "2.46.0",
+    "@panache-cli/linux-arm64-gnu": "2.46.0",
+    "@panache-cli/linux-x64-musl": "2.46.0",
+    "@panache-cli/linux-arm64-musl": "2.46.0",
+    "@panache-cli/darwin-x64": "2.46.0",
+    "@panache-cli/darwin-arm64": "2.46.0",
+    "@panache-cli/win32-x64": "2.46.0",
+    "@panache-cli/win32-arm64": "2.46.0"
   }
 }


### PR DESCRIPTION
## [panache: 2.46.0](https://github.com/jolars/panache/compare/v2.45.0...v2.46.0) (2026-05-12)

### Features
- stop project root discovery walk on `.git` ([`b370865`](https://github.com/jolars/panache/commit/b370865bcae7c59be0c177d6b89404e7baec21d0))
- **lsp:** initiate root-dir walk from current file ([`52f52b7`](https://github.com/jolars/panache/commit/52f52b7857553afd2bfe57f4b4525b2412cf77d3))
- **lsp:** add completion for shortcodes ([`42280e5`](https://github.com/jolars/panache/commit/42280e5b791d362506c8da3353a238a5798d7d5f))
- **lsp:** add file path completion in `![]()` and `[]()` ([`1081475`](https://github.com/jolars/panache/commit/1081475a8fa3b67d0afb1ae2d850abd82039d7fb))
- **parser:** handle multi-line div tag blocks ([`5f350b4`](https://github.com/jolars/panache/commit/5f350b42111bcea7636c8a7283bc1c4fbe32c40e))

### Bug Fixes
- **cli+windows:** cleanly handle tmp file removal ([`d3aed21`](https://github.com/jolars/panache/commit/d3aed2123faa296b54b37eeaf1e32c5b2b31d6ff))
- **formatter:** don't strip `!expr` in hashpipe yaml ([`f03ca70`](https://github.com/jolars/panache/commit/f03ca702815cbafb54c0066b685ec6497ca968e4)), closes [#280](https://github.com/jolars/panache/issues/280)
- **parser:** lift bq messy-shape HTML bodies into CST ([`e923d7c`](https://github.com/jolars/panache/commit/e923d7c4ee8ca936a5a9d34a8b9190c35a28d7c9))
- **parser:** lift bq same-line HTML body into CST ([`1ba1b1e`](https://github.com/jolars/panache/commit/1ba1b1ea37dcdf7ecea15ecdf3ad7bb31af9ff33))
- **parser:** expose HTML_ATTRS for non-div strict-block tags in bq ([`2bd4542`](https://github.com/jolars/panache/commit/2bd4542bb8c7144523c6ec9894584b3038670315))
- **parser:** extend bq HTML lift to non-div and inline-block ([`8b88578`](https://github.com/jolars/panache/commit/8b8857897dd972b34aaacec47caa29477b155ed6))
- **parser:** lift bq-wrapped clean `<div>` body into CST ([`4bc4612`](https://github.com/jolars/panache/commit/4bc4612c08347607c605971e852fd3199dc850e6))
- **parser:** lift matched-pair inline-block HTML bodies into CST ([`f335b42`](https://github.com/jolars/panache/commit/f335b4218f39a99ba185ec27e0296ab67dc1bcad)), fix [#4](https://github.com/jolars/panache/issues/4)
- **parser:** lift multi-line non-div strict-block HTML opens into CST ([`59a5f91`](https://github.com/jolars/panache/commit/59a5f91aa763ec29cd1ccfca03b753d8ff106fb0))
- **parser:** lift non-div strict-block butted-close shapes into CST ([`98767ab`](https://github.com/jolars/panache/commit/98767ab92f3376e2eae79634c80bdaa4d868fecf)), fix [#4](https://github.com/jolars/panache/issues/4)
- **parser:** lift inner strict-block HTML elements into CST ([`3f6f644`](https://github.com/jolars/panache/commit/3f6f6448cb87154f2b8cb363a747fb50cc496a95))
- **projector:** lift empty `<div>` into structural CST walk ([`179a681`](https://github.com/jolars/panache/commit/179a681b12eedc54704d5e42826e36a0d8812ebf)), fix [#4](https://github.com/jolars/panache/issues/4)
- **projector:** strip blockquote markers from HTML block bodies ([`47e6c38`](https://github.com/jolars/panache/commit/47e6c386527daff8dff4ca30fed708ff2c762418))
- **parser:** lift same-line `<div>` shapes into CST ([`33b6297`](https://github.com/jolars/panache/commit/33b6297ffae9711a8459d1f0e0e60b2a2a2926c5))
- **parser:** lift messy `<div>` shapes into CST ([`4c03405`](https://github.com/jolars/panache/commit/4c034054f52275e33903e9b3f066e7fdf175743a))
- **parser:** lift inner `<div>` elements into CST ([`1b37801`](https://github.com/jolars/panache/commit/1b37801fc12e12dd57a239bc6a643527df640c27))
- **parser:** mirror Pandoc's `isInlineTag` for `<script>` ([`ba9c96f`](https://github.com/jolars/panache/commit/ba9c96f39e338300dac97347ea0bb8583e813a66))
- **parser,formatter:** don't escape `[`, `]` ([`26bbb1c`](https://github.com/jolars/panache/commit/26bbb1c5bd539c85108f63e79dbe7c29d24b5222))
- **parser:** capture citation inside reference ([`c6685f4`](https://github.com/jolars/panache/commit/c6685f48d886d014831e83a30c71593a5692687e)), closes [#278](https://github.com/jolars/panache/issues/278)
- **parser:** correctly merge unevenly indented lists ([`b661b61`](https://github.com/jolars/panache/commit/b661b61a50a72d302713e0fd5a50d3a1ab66e87f)), fixes [#277](https://github.com/jolars/panache/issues/277)
- **parser:** closer cannot interrupt under pandoc ([`74d333a`](https://github.com/jolars/panache/commit/74d333a0e473cfda655a92104584afb6a1df9f17))
- **parser:** don't let `<style>` tags interrupt under pandoc ([`b77db95`](https://github.com/jolars/panache/commit/b77db958480be7e049232860d6df10a961c980ce))
- **parser:** fix plain/paragraph handling for html in parser ([`d7745dd`](https://github.com/jolars/panache/commit/d7745ddcb720f8464225c16397c1c3ba4c51889f))
- **parser:** accept correct tags for Pandoc's closing-forms ([`7ab94d1`](https://github.com/jolars/panache/commit/7ab94d183cb794362acbe84f63eb6278063d8454))
- **parser:** match Pandoc on closing forms of inline blocks ([`525cdf4`](https://github.com/jolars/panache/commit/525cdf40b22e56d2cbcfd6c6bce146a1874c453d))
- **parser:** handle multi-line void open tag ([`05b369d`](https://github.com/jolars/panache/commit/05b369d072d2d243f59261b955c67672079561d5))
- **parser:** handle infinite recursion in incomplete tags ([`95c95bf`](https://github.com/jolars/panache/commit/95c95bfe918d786142bc18f2290c301518fe15c9))
- **parser:** handle Pandoc's void block tags ([`a327162`](https://github.com/jolars/panache/commit/a32716225851593bb1caa9308f24112ab18c660a))
- **parser:** handle context-aware block/inline dispatcher ([`1b8330d`](https://github.com/jolars/panache/commit/1b8330da6017c53a83ab460af4e9ecefeedcba96))
- **parser:** don't hardcode `<div` into CST ([`7c6515e`](https://github.com/jolars/panache/commit/7c6515e058b5df4eec014b2d1c604674d025d846))
- **parser:** fix dialect-divergence in pandoc/commonmark ([`3a81ac2`](https://github.com/jolars/panache/commit/3a81ac245dc758d41ce0682c8bab01e52b04f54d))
- **formatter:** don't skip `PLAIN` in second pass ([`a693f40`](https://github.com/jolars/panache/commit/a693f40488b6fa53726e70260cb66dce2853b5f9)), closes [#279](https://github.com/jolars/panache/issues/279)

### Dependencies
- updated crates/panache-formatter to v0.5.1
- updated crates/panache-parser to v0.9.0

## [crates/panache-formatter: 0.5.1](https://github.com/jolars/panache/compare/panache-formatter-v0.5.0...panache-formatter-v0.5.1) (2026-05-12)

### Bug Fixes
- **formatter:** don't strip `!expr` in hashpipe yaml ([`f03ca70`](https://github.com/jolars/panache/commit/f03ca702815cbafb54c0066b685ec6497ca968e4)), closes [#280](https://github.com/jolars/panache/issues/280)
- **formatter:** don't skip `PLAIN` in second pass ([`a693f40`](https://github.com/jolars/panache/commit/a693f40488b6fa53726e70260cb66dce2853b5f9)), closes [#279](https://github.com/jolars/panache/issues/279)
- **parser,formatter:** don't escape `[`, `]` ([`26bbb1c`](https://github.com/jolars/panache/commit/26bbb1c5bd539c85108f63e79dbe7c29d24b5222))

### Dependencies
- updated crates/panache-parser to v0.9.0

## [crates/panache-parser: 0.9.0](https://github.com/jolars/panache/compare/panache-parser-v0.8.0...panache-parser-v0.9.0) (2026-05-12)

### Features
- **parser:** handle multi-line div tag blocks ([`5f350b4`](https://github.com/jolars/panache/commit/5f350b42111bcea7636c8a7283bc1c4fbe32c40e))

### Bug Fixes
- **parser:** lift bq messy-shape HTML bodies into CST ([`e923d7c`](https://github.com/jolars/panache/commit/e923d7c4ee8ca936a5a9d34a8b9190c35a28d7c9))
- **parser:** lift bq same-line HTML body into CST ([`1ba1b1e`](https://github.com/jolars/panache/commit/1ba1b1ea37dcdf7ecea15ecdf3ad7bb31af9ff33))
- **parser:** expose HTML_ATTRS for non-div strict-block tags in bq ([`2bd4542`](https://github.com/jolars/panache/commit/2bd4542bb8c7144523c6ec9894584b3038670315))
- **parser:** extend bq HTML lift to non-div and inline-block ([`8b88578`](https://github.com/jolars/panache/commit/8b8857897dd972b34aaacec47caa29477b155ed6))
- **parser:** lift bq-wrapped clean `<div>` body into CST ([`4bc4612`](https://github.com/jolars/panache/commit/4bc4612c08347607c605971e852fd3199dc850e6))
- **parser:** lift matched-pair inline-block HTML bodies into CST ([`f335b42`](https://github.com/jolars/panache/commit/f335b4218f39a99ba185ec27e0296ab67dc1bcad)), fix [#4](https://github.com/jolars/panache/issues/4)
- **parser:** lift multi-line non-div strict-block HTML opens into CST ([`59a5f91`](https://github.com/jolars/panache/commit/59a5f91aa763ec29cd1ccfca03b753d8ff106fb0))
- **parser:** lift non-div strict-block butted-close shapes into CST ([`98767ab`](https://github.com/jolars/panache/commit/98767ab92f3376e2eae79634c80bdaa4d868fecf)), fix [#4](https://github.com/jolars/panache/issues/4)
- **parser:** lift inner strict-block HTML elements into CST ([`3f6f644`](https://github.com/jolars/panache/commit/3f6f6448cb87154f2b8cb363a747fb50cc496a95))
- **projector:** lift empty `<div>` into structural CST walk ([`179a681`](https://github.com/jolars/panache/commit/179a681b12eedc54704d5e42826e36a0d8812ebf)), fix [#4](https://github.com/jolars/panache/issues/4)
- **projector:** strip blockquote markers from HTML block bodies ([`47e6c38`](https://github.com/jolars/panache/commit/47e6c386527daff8dff4ca30fed708ff2c762418))
- **parser:** lift same-line `<div>` shapes into CST ([`33b6297`](https://github.com/jolars/panache/commit/33b6297ffae9711a8459d1f0e0e60b2a2a2926c5))
- **parser:** lift messy `<div>` shapes into CST ([`4c03405`](https://github.com/jolars/panache/commit/4c034054f52275e33903e9b3f066e7fdf175743a))
- **parser:** lift inner `<div>` elements into CST ([`1b37801`](https://github.com/jolars/panache/commit/1b37801fc12e12dd57a239bc6a643527df640c27))
- **parser:** mirror Pandoc's `isInlineTag` for `<script>` ([`ba9c96f`](https://github.com/jolars/panache/commit/ba9c96f39e338300dac97347ea0bb8583e813a66))
- **parser,formatter:** don't escape `[`, `]` ([`26bbb1c`](https://github.com/jolars/panache/commit/26bbb1c5bd539c85108f63e79dbe7c29d24b5222))
- **parser:** capture citation inside reference ([`c6685f4`](https://github.com/jolars/panache/commit/c6685f48d886d014831e83a30c71593a5692687e)), closes [#278](https://github.com/jolars/panache/issues/278)
- **parser:** correctly merge unevenly indented lists ([`b661b61`](https://github.com/jolars/panache/commit/b661b61a50a72d302713e0fd5a50d3a1ab66e87f)), fixes [#277](https://github.com/jolars/panache/issues/277)
- **parser:** closer cannot interrupt under pandoc ([`74d333a`](https://github.com/jolars/panache/commit/74d333a0e473cfda655a92104584afb6a1df9f17))
- **parser:** don't let `<style>` tags interrupt under pandoc ([`b77db95`](https://github.com/jolars/panache/commit/b77db958480be7e049232860d6df10a961c980ce))
- **parser:** fix plain/paragraph handling for html in parser ([`d7745dd`](https://github.com/jolars/panache/commit/d7745ddcb720f8464225c16397c1c3ba4c51889f))
- **parser:** accept correct tags for Pandoc's closing-forms ([`7ab94d1`](https://github.com/jolars/panache/commit/7ab94d183cb794362acbe84f63eb6278063d8454))
- **parser:** match Pandoc on closing forms of inline blocks ([`525cdf4`](https://github.com/jolars/panache/commit/525cdf40b22e56d2cbcfd6c6bce146a1874c453d))
- **parser:** handle multi-line void open tag ([`05b369d`](https://github.com/jolars/panache/commit/05b369d072d2d243f59261b955c67672079561d5))
- **parser:** handle infinite recursion in incomplete tags ([`95c95bf`](https://github.com/jolars/panache/commit/95c95bfe918d786142bc18f2290c301518fe15c9))
- **parser:** handle Pandoc's void block tags ([`a327162`](https://github.com/jolars/panache/commit/a32716225851593bb1caa9308f24112ab18c660a))
- **parser:** handle context-aware block/inline dispatcher ([`1b8330d`](https://github.com/jolars/panache/commit/1b8330da6017c53a83ab460af4e9ecefeedcba96))
- **parser:** don't hardcode `<div` into CST ([`7c6515e`](https://github.com/jolars/panache/commit/7c6515e058b5df4eec014b2d1c604674d025d846))
- **parser:** fix dialect-divergence in pandoc/commonmark ([`3a81ac2`](https://github.com/jolars/panache/commit/3a81ac245dc758d41ce0682c8bab01e52b04f54d))

## [editors/code: 2.39.0](https://github.com/jolars/panache/compare/panache-code-v2.38.0...panache-code-v2.39.0) (2026-05-12)

### Dependencies
- updated panache to v2.46.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).