### PR TITLE
chore(release): v2.47.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "d3aed2123faa296b54b37eeaf1e32c5b2b31d6ff",
+  "baseline-sha": "fa78bfa0e98a86f6aa254326fe378c7a9addff1d",
   "release-targets": [
     {
       "path": ".",
-      "version": "2.46.0",
-      "tag": "v2.46.0"
+      "version": "2.47.0",
+      "tag": "v2.47.0"
     },
     {
       "path": "crates/panache-dprint",
@@ -14,18 +14,18 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.5.1",
-      "tag": "panache-formatter-v0.5.1"
+      "version": "0.6.0",
+      "tag": "panache-formatter-v0.6.0"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.9.0",
-      "tag": "panache-parser-v0.9.0"
+      "version": "0.10.0",
+      "tag": "panache-parser-v0.10.0"
     },
     {
       "path": "editors/code",
-      "version": "2.39.0",
-      "tag": "panache-code-v2.39.0"
+      "version": "2.40.0",
+      "tag": "panache-code-v2.40.0"
     },
     {
       "path": "editors/zed",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## [2.47.0](https://github.com/jolars/panache/compare/v2.46.0...v2.47.0) (2026-05-17)
+
+### Features
+- **linter:** add `footnote-ref-in-footnote-def` rule ([`5976e68`](https://github.com/jolars/panache/commit/5976e68fff3f18c85d70e0f88b9ced51ad0fbda2)), closes [#290](https://github.com/jolars/panache/issues/290)
+- **linter:** add `heading-eaten-attrs` + `heading-strip-comments-residue` ([`966135d`](https://github.com/jolars/panache/commit/966135da659ecf8be64127c34dd26649941d958f)), closes [#288](https://github.com/jolars/panache/issues/288)
+- **formatter:** trim trailing blanklines in fenced divs ([`6d2fe6c`](https://github.com/jolars/panache/commit/6d2fe6c55643fcffac29cfa3cda7b96198b71a7b))
+- **formatter:** add `{lang}` and `{ext}` placeholders ([`b00c479`](https://github.com/jolars/panache/commit/b00c47954770af2e9b55fa2d65ef6fceee0d0904))
+- **formatter:** add `""` as configurable external formatter ([`31c0bcb`](https://github.com/jolars/panache/commit/31c0bcb7c1b8d3434bcef78444a6a6ec356c79ad)), closes [#287](https://github.com/jolars/panache/issues/287)
+- **linter:** add `crossref-as-link-target` rule ([`c2e649c`](https://github.com/jolars/panache/commit/c2e649c6f76e171a86c72e9e0b9053836b17ed7a)), closes [#285](https://github.com/jolars/panache/issues/285)
+- **cli:** revert `--line-width` etc, add `--option`/`-o` ([`cd49506`](https://github.com/jolars/panache/commit/cd49506f4ab0f3408f3dcd9b1115b6bc1951736d))
+- remove unused `blank-lines` option ([`c23da16`](https://github.com/jolars/panache/commit/c23da165baca58a69df2d124be3bd3eecf2a87cc))
+- **cli:** add line width, wrap, and blankline to format ([`2f3e593`](https://github.com/jolars/panache/commit/2f3e593990a8ff98d7fed4ab45f97e04005a15b3))
+- **cli:** add and honor `PANACHE_CACHE_HOME` env variable ([`96d3cd6`](https://github.com/jolars/panache/commit/96d3cd6ec7362bae29693f06f46aadd67bdbd432))
+
+### Bug Fixes
+- **parser:** treat footnote refs inside footnote-def bodies as text ([`1f37425`](https://github.com/jolars/panache/commit/1f37425d4d4007594ad43b54b05837e72702499e)), ref [#290](https://github.com/jolars/panache/issues/290)
+- **formatter:** reflow `BRACKETED_SPAN` content ([`0aac341`](https://github.com/jolars/panache/commit/0aac3414f34136b92b834c55a01effca9a0f0784)), closes [#291](https://github.com/jolars/panache/issues/291)
+- **parser:** lift bq + multi-line `<div>` open + same-line close ([`259241a`](https://github.com/jolars/panache/commit/259241a95794ec18165a53c4290a98d629a4b415))
+- **parser:** lift multi-line `<div>` open + same-line close ([`61e1df1`](https://github.com/jolars/panache/commit/61e1df126ff0e1c6462ed420d874c8fad688acff))
+- **parser:** widen `<div>` lift for depth-aware and unclosed shapes ([`c7e4830`](https://github.com/jolars/panache/commit/c7e483040224f355235d325e57147e13f468cddc))
+- **parser:** lift same-line HTML block with trailing text ([`add805e`](https://github.com/jolars/panache/commit/add805e75b3845291cfe3a53df342ee68cd2a20c))
+- **formatter:** collapse blank lines inside fenced divs ([`eb52b1e`](https://github.com/jolars/panache/commit/eb52b1ead93b6bf24a4b44f12a055f09a4d0ba56)), fixes [#286](https://github.com/jolars/panache/issues/286)
+- **parser:** lift list-item Comment/PI trailing-text split ([`50b4b45`](https://github.com/jolars/panache/commit/50b4b45db76bbab613322fb8fb71e8ae3ceefa66))
+- **parser:** demote indented isInlineTag to RawInline ([`c0cf92b`](https://github.com/jolars/panache/commit/c0cf92bb36876c433bd72968457453f15d77b5be))
+- **projector:** strip RawBlock first-line indent ([`926096e`](https://github.com/jolars/panache/commit/926096e9e7e1ce23b0c4de5b2de07ab125d1d1b3))
+- **parser:** bq-wrapped HTML comment/PI trailing split ([`af26bdd`](https://github.com/jolars/panache/commit/af26bdd9fa741d403da1596aa68b5651c4f8ddad))
+- **parser:** split Pandoc HTML comment / PI trailing-text ([`3171eae`](https://github.com/jolars/panache/commit/3171eae255db17ce1cc0ae5e106b9d6f6689393a))
+- **parser:** strip list-item indent for HTML-block lift ([`f19ec57`](https://github.com/jolars/panache/commit/f19ec57d3c074308d4160164c32fda0550e45116))
+- **parser:** lift multi-line HTML blocks as list-item ([`faf5c85`](https://github.com/jolars/panache/commit/faf5c851d82f56022e9b8ce19683fffb17c0cb79))
+- **parser:** lift same-line HTML block as sole list-item content ([`cb0a2c1`](https://github.com/jolars/panache/commit/cb0a2c1bc707b49a837ce20202eb6b4b59b6b76f))
+- **parser:** route indented HTML close-tag bytes ([`82bc43d`](https://github.com/jolars/panache/commit/82bc43d54d10ac743c42a797c5f988229ff1af56))
+- **parser:** keep HTML_BLOCK on standalone </div> close form ([`fe1cd9c`](https://github.com/jolars/panache/commit/fe1cd9c7bc4728bf1549da3037b15abe087d0fe6))
+- **parser:** lift mutliline html tags with trailing bytes ([`ea463f3`](https://github.com/jolars/panache/commit/ea463f34fc935746a825ec8119433c37e96496cf))
+- **parser:** structurally lift multi-line HTML opens ([`5d65a02`](https://github.com/jolars/panache/commit/5d65a02d996b350dd4b36b8eeb744228e828a5e0))
+- **parser:** avoid HTML_BLOCK_DIV panic on multi-line div ([`5613174`](https://github.com/jolars/panache/commit/561317490a03a2ef439e51481273397515d6c179))
+- **parser:** let blockquotes close lists properly ([`88ca2c2`](https://github.com/jolars/panache/commit/88ca2c22bb7eecee8383282a4488b764009c00cd)), closes [#292](https://github.com/jolars/panache/issues/292)
+- **parser:** handle `:`-captions directly before `:::` ([`2f6a3ca`](https://github.com/jolars/panache/commit/2f6a3ca8c1c239101eddf409342e8dc6659d1fd6))
+
+### Dependencies
+- updated crates/panache-formatter to v0.6.0
+- updated crates/panache-parser to v0.10.0
 ## [2.46.0](https://github.com/jolars/panache/compare/v2.45.0...v2.46.0) (2026-05-12)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,7 +858,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "panache"
-version = "2.46.0"
+version = "2.47.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "insta",
  "log",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "entities",
  "insta",
@@ -1535,7 +1535,7 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -1553,7 +1553,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -1828,9 +1828,9 @@ dependencies = [
 
 [[package]]
 name = "wincode"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c754f1fc41250f2f742a27ba0fcc9f73df1dec23f6878490770855d43c322d"
+checksum = "37095eb18dd6254c66217edc61a29d83d51f8818de8a2ffe88e4584ad73fb5f9"
 dependencies = [
  "pastey",
  "proc-macro2",
@@ -1841,9 +1841,9 @@ dependencies = [
 
 [[package]]
 name = "wincode-derive"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e070787599c7c067b89598cd3eda440cca1b69eda9e0ff7c725fc8679ce9eb4"
+checksum = "e262d55d1261f31e2cfe49cc6385a421d14d99faa0526bbe3cc1bda0d3005c62"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1877,9 +1877,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "2.46.0"
+version = "2.47.0"
 edition.workspace = true
 readme = "README.md"
 description = "An LSP, formatter, and linter for Markdown, Quarto, and R Markdown"
@@ -47,8 +47,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.5.1" }
-panache-parser = { path = "crates/panache-parser", version = "0.9.0", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.6.0" }
+panache-parser = { path = "crates/panache-parser", version = "0.10.0", features = [
     "serde",
 ] }
 annotate-snippets = "0.12.15"

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.6.0](https://github.com/jolars/panache/compare/panache-formatter-v0.5.1...panache-formatter-v0.6.0) (2026-05-17)
+
+### Features
+- **formatter:** trim trailing blanklines in fenced divs ([`6d2fe6c`](https://github.com/jolars/panache/commit/6d2fe6c55643fcffac29cfa3cda7b96198b71a7b))
+- **formatter:** add `""` as configurable external formatter ([`31c0bcb`](https://github.com/jolars/panache/commit/31c0bcb7c1b8d3434bcef78444a6a6ec356c79ad)), closes [#287](https://github.com/jolars/panache/issues/287)
+
+### Bug Fixes
+- **formatter:** reflow `BRACKETED_SPAN` content ([`0aac341`](https://github.com/jolars/panache/commit/0aac3414f34136b92b834c55a01effca9a0f0784)), closes [#291](https://github.com/jolars/panache/issues/291)
+- **formatter:** collapse blank lines inside fenced divs ([`eb52b1e`](https://github.com/jolars/panache/commit/eb52b1ead93b6bf24a4b44f12a055f09a4d0ba56)), fixes [#286](https://github.com/jolars/panache/issues/286)
+- **parser:** lift list-item Comment/PI trailing-text split ([`50b4b45`](https://github.com/jolars/panache/commit/50b4b45db76bbab613322fb8fb71e8ae3ceefa66))
+- **parser:** lift same-line HTML block as sole list-item content ([`cb0a2c1`](https://github.com/jolars/panache/commit/cb0a2c1bc707b49a837ce20202eb6b4b59b6b76f))
+
+### Dependencies
+- updated crates/panache-parser to v0.10.0
 ## [0.5.1](https://github.com/jolars/panache/compare/panache-formatter-v0.5.0...panache-formatter-v0.5.1) (2026-05-12)
 
 ### Bug Fixes

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.5.1"
+version = "0.6.0"
 edition.workspace = true
 description = "Core formatting engine for Pandoc markdown, Quarto, and RMarkdown"
 license.workspace = true
@@ -13,7 +13,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.9.0" }
+panache-parser = { path = "../panache-parser", version = "0.10.0" }
 log = { version = "0.4.28", features = ["release_max_level_debug"] }
 rowan = "0.16.1"
 yaml_parser = "0.3.0"

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [0.10.0](https://github.com/jolars/panache/compare/panache-parser-v0.9.0...panache-parser-v0.10.0) (2026-05-17)
+
+### Features
+- **linter:** add `heading-eaten-attrs` + `heading-strip-comments-residue` ([`966135d`](https://github.com/jolars/panache/commit/966135da659ecf8be64127c34dd26649941d958f)), closes [#288](https://github.com/jolars/panache/issues/288)
+
+### Bug Fixes
+- **parser:** let blockquotes close lists properly ([`88ca2c2`](https://github.com/jolars/panache/commit/88ca2c22bb7eecee8383282a4488b764009c00cd)), closes [#292](https://github.com/jolars/panache/issues/292)
+- **parser:** treat footnote refs inside footnote-def bodies as text ([`1f37425`](https://github.com/jolars/panache/commit/1f37425d4d4007594ad43b54b05837e72702499e)), ref [#290](https://github.com/jolars/panache/issues/290)
+- **parser:** lift bq + multi-line `<div>` open + same-line close ([`259241a`](https://github.com/jolars/panache/commit/259241a95794ec18165a53c4290a98d629a4b415))
+- **parser:** lift multi-line `<div>` open + same-line close ([`61e1df1`](https://github.com/jolars/panache/commit/61e1df126ff0e1c6462ed420d874c8fad688acff))
+- **parser:** widen `<div>` lift for depth-aware and unclosed shapes ([`c7e4830`](https://github.com/jolars/panache/commit/c7e483040224f355235d325e57147e13f468cddc))
+- **parser:** handle `:`-captions directly before `:::` ([`2f6a3ca`](https://github.com/jolars/panache/commit/2f6a3ca8c1c239101eddf409342e8dc6659d1fd6))
+- **parser:** lift same-line HTML block with trailing text ([`add805e`](https://github.com/jolars/panache/commit/add805e75b3845291cfe3a53df342ee68cd2a20c))
+- **parser:** lift list-item Comment/PI trailing-text split ([`50b4b45`](https://github.com/jolars/panache/commit/50b4b45db76bbab613322fb8fb71e8ae3ceefa66))
+- **parser:** demote indented isInlineTag to RawInline ([`c0cf92b`](https://github.com/jolars/panache/commit/c0cf92bb36876c433bd72968457453f15d77b5be))
+- **projector:** strip RawBlock first-line indent ([`926096e`](https://github.com/jolars/panache/commit/926096e9e7e1ce23b0c4de5b2de07ab125d1d1b3))
+- **parser:** bq-wrapped HTML comment/PI trailing split ([`af26bdd`](https://github.com/jolars/panache/commit/af26bdd9fa741d403da1596aa68b5651c4f8ddad))
+- **parser:** split Pandoc HTML comment / PI trailing-text ([`3171eae`](https://github.com/jolars/panache/commit/3171eae255db17ce1cc0ae5e106b9d6f6689393a))
+- **parser:** strip list-item indent for HTML-block lift ([`f19ec57`](https://github.com/jolars/panache/commit/f19ec57d3c074308d4160164c32fda0550e45116))
+- **parser:** lift multi-line HTML blocks as list-item ([`faf5c85`](https://github.com/jolars/panache/commit/faf5c851d82f56022e9b8ce19683fffb17c0cb79))
+- **parser:** lift same-line HTML block as sole list-item content ([`cb0a2c1`](https://github.com/jolars/panache/commit/cb0a2c1bc707b49a837ce20202eb6b4b59b6b76f))
+- **parser:** route indented HTML close-tag bytes ([`82bc43d`](https://github.com/jolars/panache/commit/82bc43d54d10ac743c42a797c5f988229ff1af56))
+- **parser:** keep HTML_BLOCK on standalone </div> close form ([`fe1cd9c`](https://github.com/jolars/panache/commit/fe1cd9c7bc4728bf1549da3037b15abe087d0fe6))
+- **parser:** lift mutliline html tags with trailing bytes ([`ea463f3`](https://github.com/jolars/panache/commit/ea463f34fc935746a825ec8119433c37e96496cf))
+- **parser:** structurally lift multi-line HTML opens ([`5d65a02`](https://github.com/jolars/panache/commit/5d65a02d996b350dd4b36b8eeb744228e828a5e0))
+- **parser:** avoid HTML_BLOCK_DIV panic on multi-line div ([`5613174`](https://github.com/jolars/panache/commit/561317490a03a2ef439e51481273397515d6c179))
 ## [0.9.0](https://github.com/jolars/panache/compare/panache-parser-v0.8.0...panache-parser-v0.9.0) (2026-05-12)
 
 ### Features

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 readme = "README.md"
 description = "Lossless CST parser and syntax wrappers for Pandoc markdown, Quarto, and RMarkdown"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.40.0](https://github.com/jolars/panache/compare/panache-code-v2.39.0...panache-code-v2.40.0) (2026-05-17)
+
+### Dependencies
+- updated panache to v2.47.0
 ## [2.39.0](https://github.com/jolars/panache/compare/panache-code-v2.38.0...panache-code-v2.39.0) (2026-05-12)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "2.39.0",
+  "version": "2.40.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "2.46.0",
+  "version": "2.47.0",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "2.46.0",
-    "@panache-cli/linux-arm64-gnu": "2.46.0",
-    "@panache-cli/linux-x64-musl": "2.46.0",
-    "@panache-cli/linux-arm64-musl": "2.46.0",
-    "@panache-cli/darwin-x64": "2.46.0",
-    "@panache-cli/darwin-arm64": "2.46.0",
-    "@panache-cli/win32-x64": "2.46.0",
-    "@panache-cli/win32-arm64": "2.46.0"
+    "@panache-cli/linux-x64-gnu": "2.47.0",
+    "@panache-cli/linux-arm64-gnu": "2.47.0",
+    "@panache-cli/linux-x64-musl": "2.47.0",
+    "@panache-cli/linux-arm64-musl": "2.47.0",
+    "@panache-cli/darwin-x64": "2.47.0",
+    "@panache-cli/darwin-arm64": "2.47.0",
+    "@panache-cli/win32-x64": "2.47.0",
+    "@panache-cli/win32-arm64": "2.47.0"
   }
 }


### PR DESCRIPTION
## [panache: 2.47.0](https://github.com/jolars/panache/compare/v2.46.0...v2.47.0) (2026-05-17)

### Features
- **linter:** add `footnote-ref-in-footnote-def` rule ([`5976e68`](https://github.com/jolars/panache/commit/5976e68fff3f18c85d70e0f88b9ced51ad0fbda2)), closes [#290](https://github.com/jolars/panache/issues/290)
- **linter:** add `heading-eaten-attrs` + `heading-strip-comments-residue` ([`966135d`](https://github.com/jolars/panache/commit/966135da659ecf8be64127c34dd26649941d958f)), closes [#288](https://github.com/jolars/panache/issues/288)
- **formatter:** trim trailing blanklines in fenced divs ([`6d2fe6c`](https://github.com/jolars/panache/commit/6d2fe6c55643fcffac29cfa3cda7b96198b71a7b))
- **formatter:** add `{lang}` and `{ext}` placeholders ([`b00c479`](https://github.com/jolars/panache/commit/b00c47954770af2e9b55fa2d65ef6fceee0d0904))
- **formatter:** add `""` as configurable external formatter ([`31c0bcb`](https://github.com/jolars/panache/commit/31c0bcb7c1b8d3434bcef78444a6a6ec356c79ad)), closes [#287](https://github.com/jolars/panache/issues/287)
- **linter:** add `crossref-as-link-target` rule ([`c2e649c`](https://github.com/jolars/panache/commit/c2e649c6f76e171a86c72e9e0b9053836b17ed7a)), closes [#285](https://github.com/jolars/panache/issues/285)
- **cli:** revert `--line-width` etc, add `--option`/`-o` ([`cd49506`](https://github.com/jolars/panache/commit/cd49506f4ab0f3408f3dcd9b1115b6bc1951736d))
- remove unused `blank-lines` option ([`c23da16`](https://github.com/jolars/panache/commit/c23da165baca58a69df2d124be3bd3eecf2a87cc))
- **cli:** add line width, wrap, and blankline to format ([`2f3e593`](https://github.com/jolars/panache/commit/2f3e593990a8ff98d7fed4ab45f97e04005a15b3))
- **cli:** add and honor `PANACHE_CACHE_HOME` env variable ([`96d3cd6`](https://github.com/jolars/panache/commit/96d3cd6ec7362bae29693f06f46aadd67bdbd432))

### Bug Fixes
- **parser:** treat footnote refs inside footnote-def bodies as text ([`1f37425`](https://github.com/jolars/panache/commit/1f37425d4d4007594ad43b54b05837e72702499e)), ref [#290](https://github.com/jolars/panache/issues/290)
- **formatter:** reflow `BRACKETED_SPAN` content ([`0aac341`](https://github.com/jolars/panache/commit/0aac3414f34136b92b834c55a01effca9a0f0784)), closes [#291](https://github.com/jolars/panache/issues/291)
- **parser:** lift bq + multi-line `<div>` open + same-line close ([`259241a`](https://github.com/jolars/panache/commit/259241a95794ec18165a53c4290a98d629a4b415))
- **parser:** lift multi-line `<div>` open + same-line close ([`61e1df1`](https://github.com/jolars/panache/commit/61e1df126ff0e1c6462ed420d874c8fad688acff))
- **parser:** widen `<div>` lift for depth-aware and unclosed shapes ([`c7e4830`](https://github.com/jolars/panache/commit/c7e483040224f355235d325e57147e13f468cddc))
- **parser:** lift same-line HTML block with trailing text ([`add805e`](https://github.com/jolars/panache/commit/add805e75b3845291cfe3a53df342ee68cd2a20c))
- **formatter:** collapse blank lines inside fenced divs ([`eb52b1e`](https://github.com/jolars/panache/commit/eb52b1ead93b6bf24a4b44f12a055f09a4d0ba56)), fixes [#286](https://github.com/jolars/panache/issues/286)
- **parser:** lift list-item Comment/PI trailing-text split ([`50b4b45`](https://github.com/jolars/panache/commit/50b4b45db76bbab613322fb8fb71e8ae3ceefa66))
- **parser:** demote indented isInlineTag to RawInline ([`c0cf92b`](https://github.com/jolars/panache/commit/c0cf92bb36876c433bd72968457453f15d77b5be))
- **projector:** strip RawBlock first-line indent ([`926096e`](https://github.com/jolars/panache/commit/926096e9e7e1ce23b0c4de5b2de07ab125d1d1b3))
- **parser:** bq-wrapped HTML comment/PI trailing split ([`af26bdd`](https://github.com/jolars/panache/commit/af26bdd9fa741d403da1596aa68b5651c4f8ddad))
- **parser:** split Pandoc HTML comment / PI trailing-text ([`3171eae`](https://github.com/jolars/panache/commit/3171eae255db17ce1cc0ae5e106b9d6f6689393a))
- **parser:** strip list-item indent for HTML-block lift ([`f19ec57`](https://github.com/jolars/panache/commit/f19ec57d3c074308d4160164c32fda0550e45116))
- **parser:** lift multi-line HTML blocks as list-item ([`faf5c85`](https://github.com/jolars/panache/commit/faf5c851d82f56022e9b8ce19683fffb17c0cb79))
- **parser:** lift same-line HTML block as sole list-item content ([`cb0a2c1`](https://github.com/jolars/panache/commit/cb0a2c1bc707b49a837ce20202eb6b4b59b6b76f))
- **parser:** route indented HTML close-tag bytes ([`82bc43d`](https://github.com/jolars/panache/commit/82bc43d54d10ac743c42a797c5f988229ff1af56))
- **parser:** keep HTML_BLOCK on standalone </div> close form ([`fe1cd9c`](https://github.com/jolars/panache/commit/fe1cd9c7bc4728bf1549da3037b15abe087d0fe6))
- **parser:** lift mutliline html tags with trailing bytes ([`ea463f3`](https://github.com/jolars/panache/commit/ea463f34fc935746a825ec8119433c37e96496cf))
- **parser:** structurally lift multi-line HTML opens ([`5d65a02`](https://github.com/jolars/panache/commit/5d65a02d996b350dd4b36b8eeb744228e828a5e0))
- **parser:** avoid HTML_BLOCK_DIV panic on multi-line div ([`5613174`](https://github.com/jolars/panache/commit/561317490a03a2ef439e51481273397515d6c179))
- **parser:** let blockquotes close lists properly ([`88ca2c2`](https://github.com/jolars/panache/commit/88ca2c22bb7eecee8383282a4488b764009c00cd)), closes [#292](https://github.com/jolars/panache/issues/292)
- **parser:** handle `:`-captions directly before `:::` ([`2f6a3ca`](https://github.com/jolars/panache/commit/2f6a3ca8c1c239101eddf409342e8dc6659d1fd6))

### Dependencies
- updated crates/panache-formatter to v0.6.0
- updated crates/panache-parser to v0.10.0

## [crates/panache-formatter: 0.6.0](https://github.com/jolars/panache/compare/panache-formatter-v0.5.1...panache-formatter-v0.6.0) (2026-05-17)

### Features
- **formatter:** trim trailing blanklines in fenced divs ([`6d2fe6c`](https://github.com/jolars/panache/commit/6d2fe6c55643fcffac29cfa3cda7b96198b71a7b))
- **formatter:** add `""` as configurable external formatter ([`31c0bcb`](https://github.com/jolars/panache/commit/31c0bcb7c1b8d3434bcef78444a6a6ec356c79ad)), closes [#287](https://github.com/jolars/panache/issues/287)

### Bug Fixes
- **formatter:** reflow `BRACKETED_SPAN` content ([`0aac341`](https://github.com/jolars/panache/commit/0aac3414f34136b92b834c55a01effca9a0f0784)), closes [#291](https://github.com/jolars/panache/issues/291)
- **formatter:** collapse blank lines inside fenced divs ([`eb52b1e`](https://github.com/jolars/panache/commit/eb52b1ead93b6bf24a4b44f12a055f09a4d0ba56)), fixes [#286](https://github.com/jolars/panache/issues/286)
- **parser:** lift list-item Comment/PI trailing-text split ([`50b4b45`](https://github.com/jolars/panache/commit/50b4b45db76bbab613322fb8fb71e8ae3ceefa66))
- **parser:** lift same-line HTML block as sole list-item content ([`cb0a2c1`](https://github.com/jolars/panache/commit/cb0a2c1bc707b49a837ce20202eb6b4b59b6b76f))

### Dependencies
- updated crates/panache-parser to v0.10.0

## [crates/panache-parser: 0.10.0](https://github.com/jolars/panache/compare/panache-parser-v0.9.0...panache-parser-v0.10.0) (2026-05-17)

### Features
- **linter:** add `heading-eaten-attrs` + `heading-strip-comments-residue` ([`966135d`](https://github.com/jolars/panache/commit/966135da659ecf8be64127c34dd26649941d958f)), closes [#288](https://github.com/jolars/panache/issues/288)

### Bug Fixes
- **parser:** let blockquotes close lists properly ([`88ca2c2`](https://github.com/jolars/panache/commit/88ca2c22bb7eecee8383282a4488b764009c00cd)), closes [#292](https://github.com/jolars/panache/issues/292)
- **parser:** treat footnote refs inside footnote-def bodies as text ([`1f37425`](https://github.com/jolars/panache/commit/1f37425d4d4007594ad43b54b05837e72702499e)), ref [#290](https://github.com/jolars/panache/issues/290)
- **parser:** lift bq + multi-line `<div>` open + same-line close ([`259241a`](https://github.com/jolars/panache/commit/259241a95794ec18165a53c4290a98d629a4b415))
- **parser:** lift multi-line `<div>` open + same-line close ([`61e1df1`](https://github.com/jolars/panache/commit/61e1df126ff0e1c6462ed420d874c8fad688acff))
- **parser:** widen `<div>` lift for depth-aware and unclosed shapes ([`c7e4830`](https://github.com/jolars/panache/commit/c7e483040224f355235d325e57147e13f468cddc))
- **parser:** handle `:`-captions directly before `:::` ([`2f6a3ca`](https://github.com/jolars/panache/commit/2f6a3ca8c1c239101eddf409342e8dc6659d1fd6))
- **parser:** lift same-line HTML block with trailing text ([`add805e`](https://github.com/jolars/panache/commit/add805e75b3845291cfe3a53df342ee68cd2a20c))
- **parser:** lift list-item Comment/PI trailing-text split ([`50b4b45`](https://github.com/jolars/panache/commit/50b4b45db76bbab613322fb8fb71e8ae3ceefa66))
- **parser:** demote indented isInlineTag to RawInline ([`c0cf92b`](https://github.com/jolars/panache/commit/c0cf92bb36876c433bd72968457453f15d77b5be))
- **projector:** strip RawBlock first-line indent ([`926096e`](https://github.com/jolars/panache/commit/926096e9e7e1ce23b0c4de5b2de07ab125d1d1b3))
- **parser:** bq-wrapped HTML comment/PI trailing split ([`af26bdd`](https://github.com/jolars/panache/commit/af26bdd9fa741d403da1596aa68b5651c4f8ddad))
- **parser:** split Pandoc HTML comment / PI trailing-text ([`3171eae`](https://github.com/jolars/panache/commit/3171eae255db17ce1cc0ae5e106b9d6f6689393a))
- **parser:** strip list-item indent for HTML-block lift ([`f19ec57`](https://github.com/jolars/panache/commit/f19ec57d3c074308d4160164c32fda0550e45116))
- **parser:** lift multi-line HTML blocks as list-item ([`faf5c85`](https://github.com/jolars/panache/commit/faf5c851d82f56022e9b8ce19683fffb17c0cb79))
- **parser:** lift same-line HTML block as sole list-item content ([`cb0a2c1`](https://github.com/jolars/panache/commit/cb0a2c1bc707b49a837ce20202eb6b4b59b6b76f))
- **parser:** route indented HTML close-tag bytes ([`82bc43d`](https://github.com/jolars/panache/commit/82bc43d54d10ac743c42a797c5f988229ff1af56))
- **parser:** keep HTML_BLOCK on standalone </div> close form ([`fe1cd9c`](https://github.com/jolars/panache/commit/fe1cd9c7bc4728bf1549da3037b15abe087d0fe6))
- **parser:** lift mutliline html tags with trailing bytes ([`ea463f3`](https://github.com/jolars/panache/commit/ea463f34fc935746a825ec8119433c37e96496cf))
- **parser:** structurally lift multi-line HTML opens ([`5d65a02`](https://github.com/jolars/panache/commit/5d65a02d996b350dd4b36b8eeb744228e828a5e0))
- **parser:** avoid HTML_BLOCK_DIV panic on multi-line div ([`5613174`](https://github.com/jolars/panache/commit/561317490a03a2ef439e51481273397515d6c179))

## [editors/code: 2.40.0](https://github.com/jolars/panache/compare/panache-code-v2.39.0...panache-code-v2.40.0) (2026-05-17)

### Dependencies
- updated panache to v2.47.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).