### PR TITLE
chore(release): v2.48.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "fa78bfa0e98a86f6aa254326fe378c7a9addff1d",
+  "baseline-sha": "a1dfa9e8bb933d9286be32381c6869604fd70921",
   "release-targets": [
     {
       "path": ".",
-      "version": "2.47.0",
-      "tag": "v2.47.0"
+      "version": "2.48.0",
+      "tag": "v2.48.0"
     },
     {
       "path": "crates/panache-dprint",
@@ -14,18 +14,18 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.6.0",
-      "tag": "panache-formatter-v0.6.0"
+      "version": "0.6.1",
+      "tag": "panache-formatter-v0.6.1"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.10.0",
-      "tag": "panache-parser-v0.10.0"
+      "version": "0.11.0",
+      "tag": "panache-parser-v0.11.0"
     },
     {
       "path": "editors/code",
-      "version": "2.40.0",
-      "tag": "panache-code-v2.40.0"
+      "version": "2.41.0",
+      "tag": "panache-code-v2.41.0"
     },
     {
       "path": "editors/zed",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [2.48.0](https://github.com/jolars/panache/compare/v2.47.0...v2.48.0) (2026-05-20)
+
+### Features
+- **config:** add `anchor_dir` and `GlobMatcher` ([`4410951`](https://github.com/jolars/panache/commit/44109510e12c1e603d7340cdeb907756e977c2fc))
+- **config:** discover `.config/panache.toml` ([`0d9a44f`](https://github.com/jolars/panache/commit/0d9a44ffe8bcbeba8e6bf4985948d255dea483c0)), closes [#294](https://github.com/jolars/panache/issues/294)
+- add JSON schema for configuration ([`5ae80bf`](https://github.com/jolars/panache/commit/5ae80bf1ebb75c2e41b2cf8115f301406af10816)), closes [#295](https://github.com/jolars/panache/issues/295)
+- **editors:** toggle symbol publication via settings ([`fdf5a94`](https://github.com/jolars/panache/commit/fdf5a941dec8d51e6e1e9eafa4f9d34d3af1bff6)), closes [#297](https://github.com/jolars/panache/issues/297)
+
+### Bug Fixes
+- **ci:** pin linux-gnu binaries to a glibc 2.17 floor ([`a1dfa9e`](https://github.com/jolars/panache/commit/a1dfa9e8bb933d9286be32381c6869604fd70921)), fixes [#300](https://github.com/jolars/panache/issues/300)
+- **cli:** anchor exclude/include at the config's directory ([`24b948d`](https://github.com/jolars/panache/commit/24b948dda03ddcbe3a951d02a999694deabb78e2))
+- **config:** anchor flavor-overrides at the unified project dir ([`38f1a21`](https://github.com/jolars/panache/commit/38f1a21d194ddec0daff5925b98c576d810e14e9))
+- **lsp:** floor citation completion window to char boundary ([`8b79812`](https://github.com/jolars/panache/commit/8b798128ec654354f14ed136a74517424db728f5)), fixes [#298](https://github.com/jolars/panache/issues/298)
+- **parser:** strip list+bq prefix on line-block lookahead ([`280c6c1`](https://github.com/jolars/panache/commit/280c6c1774ab2b226c0018fcdc96bb03b4449643))
+- **parser:** use stripped content in def-list emit ([`a8ba276`](https://github.com/jolars/panache/commit/a8ba276990a2f73951017869c9846f6ed74299be))
+- **parser:** strip list+bq prefix on fenced-code lookahead ([`bc0efc3`](https://github.com/jolars/panache/commit/bc0efc35168cd2b70bf54a50841e598fc37b6b1c))
+- **linter:** resolve `#ref-<citekey>` anchors for cited keys ([`a0c0afd`](https://github.com/jolars/panache/commit/a0c0afd637fcb64d7c79ed430d7d42044e01af76)), closes [#296](https://github.com/jolars/panache/issues/296)
+- **parser:** dispatch bq-in-listitem first-line HTML blocks ([`bc32e49`](https://github.com/jolars/panache/commit/bc32e492b9ea09f6ffe37b3aa23ba330ed632a5c))
+- **parser:** dispatch bq-in-listitem first-line content ([`c1c0db5`](https://github.com/jolars/panache/commit/c1c0db50358dc02ae1ec6efe6f000e99eea89e35))
+- **parser:** emit `BLOCK_QUOTE_MARKER` for bq continuations in footnotes ([`f24b787`](https://github.com/jolars/panache/commit/f24b787f28e4cff6307f739daf400cadfe8cf0af))
+- interpret a-j alphabetical list as one list ([`bed78dd`](https://github.com/jolars/panache/commit/bed78dd0b42bd9dde99c60a2cc08be31b0f99507))
+
+### Dependencies
+- updated crates/panache-formatter to v0.6.1
+- updated crates/panache-parser to v0.11.0
 ## [2.47.0](https://github.com/jolars/panache/compare/v2.46.0...v2.47.0) (2026-05-17)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1189,7 +1189,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "panache"
-version = "2.47.0"
+version = "2.48.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "insta",
  "log",
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "entities",
  "insta",
@@ -1295,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "pastey"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "2.47.0"
+version = "2.48.0"
 edition.workspace = true
 readme = "README.md"
 description = "An LSP, formatter, and linter for Markdown, Quarto, and R Markdown"
@@ -47,8 +47,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.6.0" }
-panache-parser = { path = "crates/panache-parser", version = "0.10.0", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.6.1" }
+panache-parser = { path = "crates/panache-parser", version = "0.11.0", features = [
     "serde",
     "schema",
 ] }

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.6.1](https://github.com/jolars/panache/compare/panache-formatter-v0.6.0...panache-formatter-v0.6.1) (2026-05-20)
+
+### Bug Fixes
+- **parser:** strip list+bq prefix on line-block lookahead ([`280c6c1`](https://github.com/jolars/panache/commit/280c6c1774ab2b226c0018fcdc96bb03b4449643))
+
+### Dependencies
+- updated crates/panache-parser to v0.11.0
 ## [0.6.0](https://github.com/jolars/panache/compare/panache-formatter-v0.5.1...panache-formatter-v0.6.0) (2026-05-17)
 
 ### Features

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 description = "Core formatting engine for Pandoc markdown, Quarto, and RMarkdown"
 license.workspace = true
@@ -13,7 +13,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.10.0" }
+panache-parser = { path = "../panache-parser", version = "0.11.0" }
 log = { version = "0.4.28", features = ["release_max_level_debug"] }
 rowan = "0.16.1"
 yaml_parser = "0.3.0"

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.11.0](https://github.com/jolars/panache/compare/panache-parser-v0.10.0...panache-parser-v0.11.0) (2026-05-20)
+
+### Features
+- add JSON schema for configuration ([`5ae80bf`](https://github.com/jolars/panache/commit/5ae80bf1ebb75c2e41b2cf8115f301406af10816)), closes [#295](https://github.com/jolars/panache/issues/295)
+
+### Bug Fixes
+- **parser:** strip list+bq prefix on line-block lookahead ([`280c6c1`](https://github.com/jolars/panache/commit/280c6c1774ab2b226c0018fcdc96bb03b4449643))
+- **parser:** use stripped content in def-list emit ([`a8ba276`](https://github.com/jolars/panache/commit/a8ba276990a2f73951017869c9846f6ed74299be))
+- **parser:** strip list+bq prefix on fenced-code lookahead ([`bc0efc3`](https://github.com/jolars/panache/commit/bc0efc35168cd2b70bf54a50841e598fc37b6b1c))
+- **parser:** emit `BLOCK_QUOTE_MARKER` for bq continuations in footnotes ([`f24b787`](https://github.com/jolars/panache/commit/f24b787f28e4cff6307f739daf400cadfe8cf0af))
+- **parser:** dispatch bq-in-listitem first-line HTML blocks ([`bc32e49`](https://github.com/jolars/panache/commit/bc32e492b9ea09f6ffe37b3aa23ba330ed632a5c))
+- **parser:** dispatch bq-in-listitem first-line content ([`c1c0db5`](https://github.com/jolars/panache/commit/c1c0db50358dc02ae1ec6efe6f000e99eea89e35))
+- interpret a-j alphabetical list as one list ([`bed78dd`](https://github.com/jolars/panache/commit/bed78dd0b42bd9dde99c60a2cc08be31b0f99507))
 ## [0.10.0](https://github.com/jolars/panache/compare/panache-parser-v0.9.0...panache-parser-v0.10.0) (2026-05-17)
 
 ### Features

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 readme = "README.md"
 description = "Lossless CST parser and syntax wrappers for Pandoc markdown, Quarto, and RMarkdown"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.41.0](https://github.com/jolars/panache/compare/panache-code-v2.40.0...panache-code-v2.41.0) (2026-05-20)
+
+### Features
+- **editors:** toggle symbol publication via settings ([`fdf5a94`](https://github.com/jolars/panache/commit/fdf5a941dec8d51e6e1e9eafa4f9d34d3af1bff6)), closes [#297](https://github.com/jolars/panache/issues/297)
+
+### Dependencies
+- updated panache to v2.48.0
 ## [2.40.0](https://github.com/jolars/panache/compare/panache-code-v2.39.0...panache-code-v2.40.0) (2026-05-17)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "2.40.0",
+  "version": "2.41.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "2.47.0",
+  "version": "2.48.0",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "2.47.0",
-    "@panache-cli/linux-arm64-gnu": "2.47.0",
-    "@panache-cli/linux-x64-musl": "2.47.0",
-    "@panache-cli/linux-arm64-musl": "2.47.0",
-    "@panache-cli/darwin-x64": "2.47.0",
-    "@panache-cli/darwin-arm64": "2.47.0",
-    "@panache-cli/win32-x64": "2.47.0",
-    "@panache-cli/win32-arm64": "2.47.0"
+    "@panache-cli/linux-x64-gnu": "2.48.0",
+    "@panache-cli/linux-arm64-gnu": "2.48.0",
+    "@panache-cli/linux-x64-musl": "2.48.0",
+    "@panache-cli/linux-arm64-musl": "2.48.0",
+    "@panache-cli/darwin-x64": "2.48.0",
+    "@panache-cli/darwin-arm64": "2.48.0",
+    "@panache-cli/win32-x64": "2.48.0",
+    "@panache-cli/win32-arm64": "2.48.0"
   }
 }


### PR DESCRIPTION
## [panache: 2.48.0](https://github.com/jolars/panache/compare/v2.47.0...v2.48.0) (2026-05-20)

### Features
- **config:** add `anchor_dir` and `GlobMatcher` ([`4410951`](https://github.com/jolars/panache/commit/44109510e12c1e603d7340cdeb907756e977c2fc))
- **config:** discover `.config/panache.toml` ([`0d9a44f`](https://github.com/jolars/panache/commit/0d9a44ffe8bcbeba8e6bf4985948d255dea483c0)), closes [#294](https://github.com/jolars/panache/issues/294)
- add JSON schema for configuration ([`5ae80bf`](https://github.com/jolars/panache/commit/5ae80bf1ebb75c2e41b2cf8115f301406af10816)), closes [#295](https://github.com/jolars/panache/issues/295)
- **editors:** toggle symbol publication via settings ([`fdf5a94`](https://github.com/jolars/panache/commit/fdf5a941dec8d51e6e1e9eafa4f9d34d3af1bff6)), closes [#297](https://github.com/jolars/panache/issues/297)

### Bug Fixes
- **ci:** pin linux-gnu binaries to a glibc 2.17 floor ([`a1dfa9e`](https://github.com/jolars/panache/commit/a1dfa9e8bb933d9286be32381c6869604fd70921)), fixes [#300](https://github.com/jolars/panache/issues/300)
- **cli:** anchor exclude/include at the config's directory ([`24b948d`](https://github.com/jolars/panache/commit/24b948dda03ddcbe3a951d02a999694deabb78e2))
- **config:** anchor flavor-overrides at the unified project dir ([`38f1a21`](https://github.com/jolars/panache/commit/38f1a21d194ddec0daff5925b98c576d810e14e9))
- **lsp:** floor citation completion window to char boundary ([`8b79812`](https://github.com/jolars/panache/commit/8b798128ec654354f14ed136a74517424db728f5)), fixes [#298](https://github.com/jolars/panache/issues/298)
- **parser:** strip list+bq prefix on line-block lookahead ([`280c6c1`](https://github.com/jolars/panache/commit/280c6c1774ab2b226c0018fcdc96bb03b4449643))
- **parser:** use stripped content in def-list emit ([`a8ba276`](https://github.com/jolars/panache/commit/a8ba276990a2f73951017869c9846f6ed74299be))
- **parser:** strip list+bq prefix on fenced-code lookahead ([`bc0efc3`](https://github.com/jolars/panache/commit/bc0efc35168cd2b70bf54a50841e598fc37b6b1c))
- **linter:** resolve `#ref-<citekey>` anchors for cited keys ([`a0c0afd`](https://github.com/jolars/panache/commit/a0c0afd637fcb64d7c79ed430d7d42044e01af76)), closes [#296](https://github.com/jolars/panache/issues/296)
- **parser:** dispatch bq-in-listitem first-line HTML blocks ([`bc32e49`](https://github.com/jolars/panache/commit/bc32e492b9ea09f6ffe37b3aa23ba330ed632a5c))
- **parser:** dispatch bq-in-listitem first-line content ([`c1c0db5`](https://github.com/jolars/panache/commit/c1c0db50358dc02ae1ec6efe6f000e99eea89e35))
- **parser:** emit `BLOCK_QUOTE_MARKER` for bq continuations in footnotes ([`f24b787`](https://github.com/jolars/panache/commit/f24b787f28e4cff6307f739daf400cadfe8cf0af))
- interpret a-j alphabetical list as one list ([`bed78dd`](https://github.com/jolars/panache/commit/bed78dd0b42bd9dde99c60a2cc08be31b0f99507))

### Dependencies
- updated crates/panache-formatter to v0.6.1
- updated crates/panache-parser to v0.11.0

## [crates/panache-formatter: 0.6.1](https://github.com/jolars/panache/compare/panache-formatter-v0.6.0...panache-formatter-v0.6.1) (2026-05-20)

### Bug Fixes
- **parser:** strip list+bq prefix on line-block lookahead ([`280c6c1`](https://github.com/jolars/panache/commit/280c6c1774ab2b226c0018fcdc96bb03b4449643))

### Dependencies
- updated crates/panache-parser to v0.11.0

## [crates/panache-parser: 0.11.0](https://github.com/jolars/panache/compare/panache-parser-v0.10.0...panache-parser-v0.11.0) (2026-05-20)

### Features
- add JSON schema for configuration ([`5ae80bf`](https://github.com/jolars/panache/commit/5ae80bf1ebb75c2e41b2cf8115f301406af10816)), closes [#295](https://github.com/jolars/panache/issues/295)

### Bug Fixes
- **parser:** strip list+bq prefix on line-block lookahead ([`280c6c1`](https://github.com/jolars/panache/commit/280c6c1774ab2b226c0018fcdc96bb03b4449643))
- **parser:** use stripped content in def-list emit ([`a8ba276`](https://github.com/jolars/panache/commit/a8ba276990a2f73951017869c9846f6ed74299be))
- **parser:** strip list+bq prefix on fenced-code lookahead ([`bc0efc3`](https://github.com/jolars/panache/commit/bc0efc35168cd2b70bf54a50841e598fc37b6b1c))
- **parser:** emit `BLOCK_QUOTE_MARKER` for bq continuations in footnotes ([`f24b787`](https://github.com/jolars/panache/commit/f24b787f28e4cff6307f739daf400cadfe8cf0af))
- **parser:** dispatch bq-in-listitem first-line HTML blocks ([`bc32e49`](https://github.com/jolars/panache/commit/bc32e492b9ea09f6ffe37b3aa23ba330ed632a5c))
- **parser:** dispatch bq-in-listitem first-line content ([`c1c0db5`](https://github.com/jolars/panache/commit/c1c0db50358dc02ae1ec6efe6f000e99eea89e35))
- interpret a-j alphabetical list as one list ([`bed78dd`](https://github.com/jolars/panache/commit/bed78dd0b42bd9dde99c60a2cc08be31b0f99507))

## [editors/code: 2.41.0](https://github.com/jolars/panache/compare/panache-code-v2.40.0...panache-code-v2.41.0) (2026-05-20)

### Features
- **editors:** toggle symbol publication via settings ([`fdf5a94`](https://github.com/jolars/panache/commit/fdf5a941dec8d51e6e1e9eafa4f9d34d3af1bff6)), closes [#297](https://github.com/jolars/panache/issues/297)

### Dependencies
- updated panache to v2.48.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).