### PR TITLE
docs: add Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ linters on code blocks.
 
 ## Installation
 
+### Homebrew
+
+Panache is available from Homebrew on macOS and Linux:
+
+```bash
+brew install panache
+```
+
 ### From crates.io
 
 If you have Rust installed, the easiest way is likely to install from

--- a/docs/getting-started.qmd
+++ b/docs/getting-started.qmd
@@ -8,6 +8,14 @@ description: >
 
 ## Installation
 
+### Homebrew
+
+Install `panache` from Homebrew on macOS or Linux:
+
+```bash
+brew install panache
+```
+
 ### From crates.io
 
 Install `panache` with Cargo:

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -54,7 +54,13 @@ and in CI, with consistent behavior across all environments.
 
 ## Quick Start
 
-Install with Cargo:
+Install with Homebrew on macOS or Linux:
+
+```bash
+brew install panache
+```
+
+Or install with Cargo:
 
 ```bash
 cargo install panache


### PR DESCRIPTION
## Summary
- add `brew install panache` to the main installation docs
- surface Homebrew in the getting started guide and docs homepage quick start
- keep the existing Cargo and release-install options documented

## Testing
- not run (documentation-only change)
