### PR TITLE
chore(release): v2.50.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "37293aad7a541d023190bdd3d57e66e76de3eab7",
+  "baseline-sha": "8ade63092ef9dc58bab04d37a2f9fa44a7256d0f",
   "release-targets": [
     {
       "path": ".",
-      "version": "2.49.0",
-      "tag": "v2.49.0"
+      "version": "2.50.0",
+      "tag": "v2.50.0"
     },
     {
       "path": "crates/panache-dprint",
@@ -14,18 +14,18 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.7.0",
-      "tag": "panache-formatter-v0.7.0"
+      "version": "0.8.0",
+      "tag": "panache-formatter-v0.8.0"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.12.0",
-      "tag": "panache-parser-v0.12.0"
+      "version": "0.13.0",
+      "tag": "panache-parser-v0.13.0"
     },
     {
       "path": "editors/code",
-      "version": "2.42.0",
-      "tag": "panache-code-v2.42.0"
+      "version": "2.43.0",
+      "tag": "panache-code-v2.43.0"
     },
     {
       "path": "editors/zed",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## [2.50.0](https://github.com/jolars/panache/compare/v2.49.0...v2.50.0) (2026-05-29)
+
+### Features
+- **lsp:** honor config excludes in full doc format ([`bbc1407`](https://github.com/jolars/panache/commit/bbc140729109d47d1c718037083abd07894851fb))
+- **linter:** increase the reach of `stray-fenced-div-markers` ([`a334951`](https://github.com/jolars/panache/commit/a334951c2a115d508e47b67c88cd564ac4fd082f)), closes [#333](https://github.com/jolars/panache/issues/333)
+- **lsp:** code actions to convert links inline to reference ([`e958a37`](https://github.com/jolars/panache/commit/e958a375dabf216e4c2f050490db7f74a35efbb9)), closes [#331](https://github.com/jolars/panache/issues/331)
+- **linter:** add `link-text-is-url` rule with autolink autofix ([`1249e16`](https://github.com/jolars/panache/commit/1249e16b5142faa71d66fc970b324a4a0b884b6e)), closes [#331](https://github.com/jolars/panache/issues/331)
+- **formatter:** reflow grid table cells ([`721b110`](https://github.com/jolars/panache/commit/721b1104b609ac9401e0bc8c9faa6dbfb925eaf7)), closes [#323](https://github.com/jolars/panache/issues/323)
+- **formatter:** reflow multiline table cells ([`5682db7`](https://github.com/jolars/panache/commit/5682db7e2389f862c90655c55bd2ab1c0cc08248)), ref [#323](https://github.com/jolars/panache/issues/323)
+- **parser:** reject yaml node property under parent key indent ([`db371fd`](https://github.com/jolars/panache/commit/db371fd97830263f0410cfb59a0e9a9f4898319e))
+- **parser:** reject yaml %YAML directive with malformed version ([`557b116`](https://github.com/jolars/panache/commit/557b1162f41d450280af35aa89cd488aedbd6b00))
+- **parser:** reject invalid yaml block-scalar indent + tab-in-quoted ([`e577390`](https://github.com/jolars/panache/commit/e577390270b8c784e64ad67d0a3f8a4456034ebe))
+- **parser:** detect tab-in-indent-slot in yaml `check_tab_as_indent` ([`8b2ece9`](https://github.com/jolars/panache/commit/8b2ece90325a4a860b5c9bd7c20b784c5bc6d690))
+- **parser:** reject yaml anchor in invalid positions ([`c8b8d6d`](https://github.com/jolars/panache/commit/c8b8d6d311c3c7a5f5d9fa3f1d04089aaa1226ed))
+- **parser:** reject yaml tag with c-flow-indicator char ([`d83dca9`](https://github.com/jolars/panache/commit/d83dca99f7379a08462a5cfe2cacf54551687183))
+- **parser:** reject yaml anchor decorating alias node ([`53289ca`](https://github.com/jolars/panache/commit/53289cac2dcb7efb8bbe2260463e5a39dd8c9cdb))
+- **parser:** dispatch yaml `!tag` tokens in scanner ([`378a380`](https://github.com/jolars/panache/commit/378a3803889ccf11920416b68a40e17ddc62707f))
+- **parser:** wrap indentless yaml seq when anchor decorates value ([`a7ca3c1`](https://github.com/jolars/panache/commit/a7ca3c1902eb58db57fc7fb7905d8586f51cc515))
+- **parser:** propagate yaml anchors and aliases through flow projection ([`5874f78`](https://github.com/jolars/panache/commit/5874f785cc7c40534c25c3add630ec45dbc9d03e))
+- **parser:** dispatch yaml `&anchor` / `*alias` in scanner ([`3959305`](https://github.com/jolars/panache/commit/39593053eecff1fa9bc293f0e2e3aaa27cb1aa53))
+- **parser:** support flow collections as complex yaml keys ([`f1799d2`](https://github.com/jolars/panache/commit/f1799d23a15f850931b756b265ba7a574cf83e92))
+- **parser:** reject yaml doc markers in flow and seq-item quoted dedent ([`8eddfdc`](https://github.com/jolars/panache/commit/8eddfdc40446c1902ab59e2b0ef3d8f8e5f20471))
+- **parser:** reject doc-level comment-split plain scalar (BS4K) ([`641313a`](https://github.com/jolars/panache/commit/641313a60ec92844163567b87b2a7c4f3f7b8857))
+
+### Bug Fixes
+- **lsp:** expose table reference to find-references ([`a194b21`](https://github.com/jolars/panache/commit/a194b21dc16b57c01daa5fec3c6eced9d80c46f3))
+- **linter:** fix false positive on bookdown table reference ([`773fcc1`](https://github.com/jolars/panache/commit/773fcc1f0b4c2db7b13d91003316b77fe9c4f51f))
+- **parser:** don't swallow space after inline code in emph ([`adf92fa`](https://github.com/jolars/panache/commit/adf92fae91d50c4a9cc82cc10128c8f1232e858b)), closes [#332](https://github.com/jolars/panache/issues/332)
+- **linter:** count reference images as definition uses ([`56964e6`](https://github.com/jolars/panache/commit/56964e61dc9f55b6dec4bfe11311e9c7ff718212)), closes [#325](https://github.com/jolars/panache/issues/325)
+- **formatter:** preserve grid table column widths ([`c4d011b`](https://github.com/jolars/panache/commit/c4d011b4a2b1ca1ab7c2ddc9728f8d3f04724f77))
+- keep grid tables at column 0 to match pandoc ([`73016e3`](https://github.com/jolars/panache/commit/73016e3acabdfff0b0c800e8c557ea51a63456b4))
+- add `inline-images` to gfm flavor ([`8ade630`](https://github.com/jolars/panache/commit/8ade63092ef9dc58bab04d37a2f9fa44a7256d0f))
+- **parser:** preserve `\<ws>` escape arg and tab-as-content in yaml fold ([`c99c6a5`](https://github.com/jolars/panache/commit/c99c6a509ded4420b1bdb01030aaf7f87ca3f25c))
+- **parser:** emit yaml anchor before tag in event projection ([`26c0b5f`](https://github.com/jolars/panache/commit/26c0b5fc98feccef606f28ee49aade9f3a90375a))
+- **parser:** allow column-0 block scalar body at doc root ([`a0f358c`](https://github.com/jolars/panache/commit/a0f358c47a3635d050adbdc96810e8fccab1c37d))
+- **parser:** reject YAML comment not preceded by space ([`a6125c3`](https://github.com/jolars/panache/commit/a6125c361b0b86ebac4a4bc76237f59aee9cc1ca))
+- **parser:** reject unterminated and over-indented YAML scalars ([`23f855e`](https://github.com/jolars/panache/commit/23f855ebfa2b14c1a908d031aef464cdc0bb155a))
+
+### Dependencies
+- updated crates/panache-formatter to v0.8.0
+- updated crates/panache-parser to v0.13.0
 ## [2.49.0](https://github.com/jolars/panache/compare/v2.48.0...v2.49.0) (2026-05-26)
 
 The largest change in this release is likely a new wrap mode, `semantic`, which

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,9 +136,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "2c61cd05405eb1d0f3a4660f802bad76ece84b6e722426342ba5dd511f724e97"
 
 [[package]]
 name = "borrow-or-share"
@@ -395,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -917,9 +917,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.26"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30457d51cb0e68ee18184b30cd9eb8e1602a20837c321f6ea9706b94f1c681c3"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
 dependencies = [
  "jiff-static",
  "log",
@@ -930,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.26"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f86e4f0326c61ae6c00b04d9009aaeda644d0b5bdfbf6c67247f492f42b3f3"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -998,9 +998,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
@@ -1047,9 +1047,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memoffset"
@@ -1068,9 +1068,9 @@ checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -1188,7 +1188,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "panache"
-version = "2.49.0"
+version = "2.50.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "insta",
  "log",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "entities",
  "insta",
@@ -2107,9 +2107,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -2468,18 +2468,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "2.49.0"
+version = "2.50.0"
 edition.workspace = true
 readme = "README.md"
 description = "An LSP, formatter, and linter for Markdown, Quarto, and R Markdown"
@@ -47,8 +47,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.7.0" }
-panache-parser = { path = "crates/panache-parser", version = "0.12.0", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.8.0" }
+panache-parser = { path = "crates/panache-parser", version = "0.13.0", features = [
     "serde",
     "schema",
 ] }

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.8.0](https://github.com/jolars/panache/compare/panache-formatter-v0.7.0...panache-formatter-v0.8.0) (2026-05-29)
+
+### Features
+- **formatter:** reflow grid table cells ([`721b110`](https://github.com/jolars/panache/commit/721b1104b609ac9401e0bc8c9faa6dbfb925eaf7)), closes [#323](https://github.com/jolars/panache/issues/323)
+- **formatter:** reflow multiline table cells ([`5682db7`](https://github.com/jolars/panache/commit/5682db7e2389f862c90655c55bd2ab1c0cc08248)), ref [#323](https://github.com/jolars/panache/issues/323)
+
+### Bug Fixes
+- **parser:** don't swallow space after inline code in emph ([`adf92fa`](https://github.com/jolars/panache/commit/adf92fae91d50c4a9cc82cc10128c8f1232e858b)), closes [#332](https://github.com/jolars/panache/issues/332)
+- **formatter:** preserve grid table column widths ([`c4d011b`](https://github.com/jolars/panache/commit/c4d011b4a2b1ca1ab7c2ddc9728f8d3f04724f77))
+- keep grid tables at column 0 to match pandoc ([`73016e3`](https://github.com/jolars/panache/commit/73016e3acabdfff0b0c800e8c557ea51a63456b4))
+
+### Dependencies
+- updated crates/panache-parser to v0.13.0
 ## [0.7.0](https://github.com/jolars/panache/compare/panache-formatter-v0.6.1...panache-formatter-v0.7.0) (2026-05-26)
 
 ### Features

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 description = "Core formatting engine for Pandoc markdown, Quarto, and RMarkdown"
 license.workspace = true
@@ -13,7 +13,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.12.0" }
+panache-parser = { path = "../panache-parser", version = "0.13.0" }
 log = { version = "0.4.28", features = ["release_max_level_debug"] }
 rowan = "0.16.1"
 yaml_parser = "0.3.0"

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [0.13.0](https://github.com/jolars/panache/compare/panache-parser-v0.12.0...panache-parser-v0.13.0) (2026-05-29)
+
+### Features
+- **parser:** reject yaml node property under parent key indent ([`db371fd`](https://github.com/jolars/panache/commit/db371fd97830263f0410cfb59a0e9a9f4898319e))
+- **parser:** reject yaml %YAML directive with malformed version ([`557b116`](https://github.com/jolars/panache/commit/557b1162f41d450280af35aa89cd488aedbd6b00))
+- **parser:** reject invalid yaml block-scalar indent + tab-in-quoted ([`e577390`](https://github.com/jolars/panache/commit/e577390270b8c784e64ad67d0a3f8a4456034ebe))
+- **parser:** detect tab-in-indent-slot in yaml `check_tab_as_indent` ([`8b2ece9`](https://github.com/jolars/panache/commit/8b2ece90325a4a860b5c9bd7c20b784c5bc6d690))
+- **parser:** reject yaml anchor in invalid positions ([`c8b8d6d`](https://github.com/jolars/panache/commit/c8b8d6d311c3c7a5f5d9fa3f1d04089aaa1226ed))
+- **parser:** reject yaml tag with c-flow-indicator char ([`d83dca9`](https://github.com/jolars/panache/commit/d83dca99f7379a08462a5cfe2cacf54551687183))
+- **parser:** reject yaml anchor decorating alias node ([`53289ca`](https://github.com/jolars/panache/commit/53289cac2dcb7efb8bbe2260463e5a39dd8c9cdb))
+- **parser:** dispatch yaml `!tag` tokens in scanner ([`378a380`](https://github.com/jolars/panache/commit/378a3803889ccf11920416b68a40e17ddc62707f))
+- **parser:** wrap indentless yaml seq when anchor decorates value ([`a7ca3c1`](https://github.com/jolars/panache/commit/a7ca3c1902eb58db57fc7fb7905d8586f51cc515))
+- **parser:** propagate yaml anchors and aliases through flow projection ([`5874f78`](https://github.com/jolars/panache/commit/5874f785cc7c40534c25c3add630ec45dbc9d03e))
+- **parser:** dispatch yaml `&anchor` / `*alias` in scanner ([`3959305`](https://github.com/jolars/panache/commit/39593053eecff1fa9bc293f0e2e3aaa27cb1aa53))
+- **parser:** support flow collections as complex yaml keys ([`f1799d2`](https://github.com/jolars/panache/commit/f1799d23a15f850931b756b265ba7a574cf83e92))
+- **parser:** reject yaml doc markers in flow and seq-item quoted dedent ([`8eddfdc`](https://github.com/jolars/panache/commit/8eddfdc40446c1902ab59e2b0ef3d8f8e5f20471))
+- **parser:** reject doc-level comment-split plain scalar (BS4K) ([`641313a`](https://github.com/jolars/panache/commit/641313a60ec92844163567b87b2a7c4f3f7b8857))
+
+### Bug Fixes
+- add `inline-images` to gfm flavor ([`8ade630`](https://github.com/jolars/panache/commit/8ade63092ef9dc58bab04d37a2f9fa44a7256d0f))
+- **parser:** preserve `\<ws>` escape arg and tab-as-content in yaml fold ([`c99c6a5`](https://github.com/jolars/panache/commit/c99c6a509ded4420b1bdb01030aaf7f87ca3f25c))
+- **parser:** emit yaml anchor before tag in event projection ([`26c0b5f`](https://github.com/jolars/panache/commit/26c0b5fc98feccef606f28ee49aade9f3a90375a))
+- **parser:** allow column-0 block scalar body at doc root ([`a0f358c`](https://github.com/jolars/panache/commit/a0f358c47a3635d050adbdc96810e8fccab1c37d))
+- **parser:** reject YAML comment not preceded by space ([`a6125c3`](https://github.com/jolars/panache/commit/a6125c361b0b86ebac4a4bc76237f59aee9cc1ca))
+- keep grid tables at column 0 to match pandoc ([`73016e3`](https://github.com/jolars/panache/commit/73016e3acabdfff0b0c800e8c557ea51a63456b4))
+- **parser:** reject unterminated and over-indented YAML scalars ([`23f855e`](https://github.com/jolars/panache/commit/23f855ebfa2b14c1a908d031aef464cdc0bb155a))
 ## [0.12.0](https://github.com/jolars/panache/compare/panache-parser-v0.11.0...panache-parser-v0.12.0) (2026-05-26)
 
 ### Features

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.12.0"
+version = "0.13.0"
 edition.workspace = true
 readme = "README.md"
 description = "Lossless CST parser and syntax wrappers for Pandoc markdown, Quarto, and RMarkdown"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.43.0](https://github.com/jolars/panache/compare/panache-code-v2.42.0...panache-code-v2.43.0) (2026-05-29)
+
+### Dependencies
+- updated panache to v2.50.0
 ## [2.42.0](https://github.com/jolars/panache/compare/panache-code-v2.41.0...panache-code-v2.42.0) (2026-05-26)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "2.42.0",
+  "version": "2.43.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "2c61cd05405eb1d0f3a4660f802bad76ece84b6e722426342ba5dd511f724e97"
 
 [[package]]
 name = "cfg-if"
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -345,9 +345,9 @@ checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "miniz_oxide"

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "2.49.0",
+  "version": "2.50.0",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "2.49.0",
-    "@panache-cli/linux-arm64-gnu": "2.49.0",
-    "@panache-cli/linux-x64-musl": "2.49.0",
-    "@panache-cli/linux-arm64-musl": "2.49.0",
-    "@panache-cli/darwin-x64": "2.49.0",
-    "@panache-cli/darwin-arm64": "2.49.0",
-    "@panache-cli/win32-x64": "2.49.0",
-    "@panache-cli/win32-arm64": "2.49.0"
+    "@panache-cli/linux-x64-gnu": "2.50.0",
+    "@panache-cli/linux-arm64-gnu": "2.50.0",
+    "@panache-cli/linux-x64-musl": "2.50.0",
+    "@panache-cli/linux-arm64-musl": "2.50.0",
+    "@panache-cli/darwin-x64": "2.50.0",
+    "@panache-cli/darwin-arm64": "2.50.0",
+    "@panache-cli/win32-x64": "2.50.0",
+    "@panache-cli/win32-arm64": "2.50.0"
   }
 }


### PR DESCRIPTION
## [panache: 2.50.0](https://github.com/jolars/panache/compare/v2.49.0...v2.50.0) (2026-05-29)

### Features
- **lsp:** honor config excludes in full doc format ([`bbc1407`](https://github.com/jolars/panache/commit/bbc140729109d47d1c718037083abd07894851fb))
- **linter:** increase the reach of `stray-fenced-div-markers` ([`a334951`](https://github.com/jolars/panache/commit/a334951c2a115d508e47b67c88cd564ac4fd082f)), closes [#333](https://github.com/jolars/panache/issues/333)
- **lsp:** code actions to convert links inline to reference ([`e958a37`](https://github.com/jolars/panache/commit/e958a375dabf216e4c2f050490db7f74a35efbb9)), closes [#331](https://github.com/jolars/panache/issues/331)
- **linter:** add `link-text-is-url` rule with autolink autofix ([`1249e16`](https://github.com/jolars/panache/commit/1249e16b5142faa71d66fc970b324a4a0b884b6e)), closes [#331](https://github.com/jolars/panache/issues/331)
- **formatter:** reflow grid table cells ([`721b110`](https://github.com/jolars/panache/commit/721b1104b609ac9401e0bc8c9faa6dbfb925eaf7)), closes [#323](https://github.com/jolars/panache/issues/323)
- **formatter:** reflow multiline table cells ([`5682db7`](https://github.com/jolars/panache/commit/5682db7e2389f862c90655c55bd2ab1c0cc08248)), ref [#323](https://github.com/jolars/panache/issues/323)
- **parser:** reject yaml node property under parent key indent ([`db371fd`](https://github.com/jolars/panache/commit/db371fd97830263f0410cfb59a0e9a9f4898319e))
- **parser:** reject yaml %YAML directive with malformed version ([`557b116`](https://github.com/jolars/panache/commit/557b1162f41d450280af35aa89cd488aedbd6b00))
- **parser:** reject invalid yaml block-scalar indent + tab-in-quoted ([`e577390`](https://github.com/jolars/panache/commit/e577390270b8c784e64ad67d0a3f8a4456034ebe))
- **parser:** detect tab-in-indent-slot in yaml `check_tab_as_indent` ([`8b2ece9`](https://github.com/jolars/panache/commit/8b2ece90325a4a860b5c9bd7c20b784c5bc6d690))
- **parser:** reject yaml anchor in invalid positions ([`c8b8d6d`](https://github.com/jolars/panache/commit/c8b8d6d311c3c7a5f5d9fa3f1d04089aaa1226ed))
- **parser:** reject yaml tag with c-flow-indicator char ([`d83dca9`](https://github.com/jolars/panache/commit/d83dca99f7379a08462a5cfe2cacf54551687183))
- **parser:** reject yaml anchor decorating alias node ([`53289ca`](https://github.com/jolars/panache/commit/53289cac2dcb7efb8bbe2260463e5a39dd8c9cdb))
- **parser:** dispatch yaml `!tag` tokens in scanner ([`378a380`](https://github.com/jolars/panache/commit/378a3803889ccf11920416b68a40e17ddc62707f))
- **parser:** wrap indentless yaml seq when anchor decorates value ([`a7ca3c1`](https://github.com/jolars/panache/commit/a7ca3c1902eb58db57fc7fb7905d8586f51cc515))
- **parser:** propagate yaml anchors and aliases through flow projection ([`5874f78`](https://github.com/jolars/panache/commit/5874f785cc7c40534c25c3add630ec45dbc9d03e))
- **parser:** dispatch yaml `&anchor` / `*alias` in scanner ([`3959305`](https://github.com/jolars/panache/commit/39593053eecff1fa9bc293f0e2e3aaa27cb1aa53))
- **parser:** support flow collections as complex yaml keys ([`f1799d2`](https://github.com/jolars/panache/commit/f1799d23a15f850931b756b265ba7a574cf83e92))
- **parser:** reject yaml doc markers in flow and seq-item quoted dedent ([`8eddfdc`](https://github.com/jolars/panache/commit/8eddfdc40446c1902ab59e2b0ef3d8f8e5f20471))
- **parser:** reject doc-level comment-split plain scalar (BS4K) ([`641313a`](https://github.com/jolars/panache/commit/641313a60ec92844163567b87b2a7c4f3f7b8857))

### Bug Fixes
- **lsp:** expose table reference to find-references ([`a194b21`](https://github.com/jolars/panache/commit/a194b21dc16b57c01daa5fec3c6eced9d80c46f3))
- **linter:** fix false positive on bookdown table reference ([`773fcc1`](https://github.com/jolars/panache/commit/773fcc1f0b4c2db7b13d91003316b77fe9c4f51f))
- **parser:** don't swallow space after inline code in emph ([`adf92fa`](https://github.com/jolars/panache/commit/adf92fae91d50c4a9cc82cc10128c8f1232e858b)), closes [#332](https://github.com/jolars/panache/issues/332)
- **linter:** count reference images as definition uses ([`56964e6`](https://github.com/jolars/panache/commit/56964e61dc9f55b6dec4bfe11311e9c7ff718212)), closes [#325](https://github.com/jolars/panache/issues/325)
- **formatter:** preserve grid table column widths ([`c4d011b`](https://github.com/jolars/panache/commit/c4d011b4a2b1ca1ab7c2ddc9728f8d3f04724f77))
- keep grid tables at column 0 to match pandoc ([`73016e3`](https://github.com/jolars/panache/commit/73016e3acabdfff0b0c800e8c557ea51a63456b4))
- add `inline-images` to gfm flavor ([`8ade630`](https://github.com/jolars/panache/commit/8ade63092ef9dc58bab04d37a2f9fa44a7256d0f))
- **parser:** preserve `\<ws>` escape arg and tab-as-content in yaml fold ([`c99c6a5`](https://github.com/jolars/panache/commit/c99c6a509ded4420b1bdb01030aaf7f87ca3f25c))
- **parser:** emit yaml anchor before tag in event projection ([`26c0b5f`](https://github.com/jolars/panache/commit/26c0b5fc98feccef606f28ee49aade9f3a90375a))
- **parser:** allow column-0 block scalar body at doc root ([`a0f358c`](https://github.com/jolars/panache/commit/a0f358c47a3635d050adbdc96810e8fccab1c37d))
- **parser:** reject YAML comment not preceded by space ([`a6125c3`](https://github.com/jolars/panache/commit/a6125c361b0b86ebac4a4bc76237f59aee9cc1ca))
- **parser:** reject unterminated and over-indented YAML scalars ([`23f855e`](https://github.com/jolars/panache/commit/23f855ebfa2b14c1a908d031aef464cdc0bb155a))

### Dependencies
- updated crates/panache-formatter to v0.8.0
- updated crates/panache-parser to v0.13.0

## [crates/panache-formatter: 0.8.0](https://github.com/jolars/panache/compare/panache-formatter-v0.7.0...panache-formatter-v0.8.0) (2026-05-29)

### Features
- **formatter:** reflow grid table cells ([`721b110`](https://github.com/jolars/panache/commit/721b1104b609ac9401e0bc8c9faa6dbfb925eaf7)), closes [#323](https://github.com/jolars/panache/issues/323)
- **formatter:** reflow multiline table cells ([`5682db7`](https://github.com/jolars/panache/commit/5682db7e2389f862c90655c55bd2ab1c0cc08248)), ref [#323](https://github.com/jolars/panache/issues/323)

### Bug Fixes
- **parser:** don't swallow space after inline code in emph ([`adf92fa`](https://github.com/jolars/panache/commit/adf92fae91d50c4a9cc82cc10128c8f1232e858b)), closes [#332](https://github.com/jolars/panache/issues/332)
- **formatter:** preserve grid table column widths ([`c4d011b`](https://github.com/jolars/panache/commit/c4d011b4a2b1ca1ab7c2ddc9728f8d3f04724f77))
- keep grid tables at column 0 to match pandoc ([`73016e3`](https://github.com/jolars/panache/commit/73016e3acabdfff0b0c800e8c557ea51a63456b4))

### Dependencies
- updated crates/panache-parser to v0.13.0

## [crates/panache-parser: 0.13.0](https://github.com/jolars/panache/compare/panache-parser-v0.12.0...panache-parser-v0.13.0) (2026-05-29)

### Features
- **parser:** reject yaml node property under parent key indent ([`db371fd`](https://github.com/jolars/panache/commit/db371fd97830263f0410cfb59a0e9a9f4898319e))
- **parser:** reject yaml %YAML directive with malformed version ([`557b116`](https://github.com/jolars/panache/commit/557b1162f41d450280af35aa89cd488aedbd6b00))
- **parser:** reject invalid yaml block-scalar indent + tab-in-quoted ([`e577390`](https://github.com/jolars/panache/commit/e577390270b8c784e64ad67d0a3f8a4456034ebe))
- **parser:** detect tab-in-indent-slot in yaml `check_tab_as_indent` ([`8b2ece9`](https://github.com/jolars/panache/commit/8b2ece90325a4a860b5c9bd7c20b784c5bc6d690))
- **parser:** reject yaml anchor in invalid positions ([`c8b8d6d`](https://github.com/jolars/panache/commit/c8b8d6d311c3c7a5f5d9fa3f1d04089aaa1226ed))
- **parser:** reject yaml tag with c-flow-indicator char ([`d83dca9`](https://github.com/jolars/panache/commit/d83dca99f7379a08462a5cfe2cacf54551687183))
- **parser:** reject yaml anchor decorating alias node ([`53289ca`](https://github.com/jolars/panache/commit/53289cac2dcb7efb8bbe2260463e5a39dd8c9cdb))
- **parser:** dispatch yaml `!tag` tokens in scanner ([`378a380`](https://github.com/jolars/panache/commit/378a3803889ccf11920416b68a40e17ddc62707f))
- **parser:** wrap indentless yaml seq when anchor decorates value ([`a7ca3c1`](https://github.com/jolars/panache/commit/a7ca3c1902eb58db57fc7fb7905d8586f51cc515))
- **parser:** propagate yaml anchors and aliases through flow projection ([`5874f78`](https://github.com/jolars/panache/commit/5874f785cc7c40534c25c3add630ec45dbc9d03e))
- **parser:** dispatch yaml `&anchor` / `*alias` in scanner ([`3959305`](https://github.com/jolars/panache/commit/39593053eecff1fa9bc293f0e2e3aaa27cb1aa53))
- **parser:** support flow collections as complex yaml keys ([`f1799d2`](https://github.com/jolars/panache/commit/f1799d23a15f850931b756b265ba7a574cf83e92))
- **parser:** reject yaml doc markers in flow and seq-item quoted dedent ([`8eddfdc`](https://github.com/jolars/panache/commit/8eddfdc40446c1902ab59e2b0ef3d8f8e5f20471))
- **parser:** reject doc-level comment-split plain scalar (BS4K) ([`641313a`](https://github.com/jolars/panache/commit/641313a60ec92844163567b87b2a7c4f3f7b8857))

### Bug Fixes
- add `inline-images` to gfm flavor ([`8ade630`](https://github.com/jolars/panache/commit/8ade63092ef9dc58bab04d37a2f9fa44a7256d0f))
- **parser:** preserve `\<ws>` escape arg and tab-as-content in yaml fold ([`c99c6a5`](https://github.com/jolars/panache/commit/c99c6a509ded4420b1bdb01030aaf7f87ca3f25c))
- **parser:** emit yaml anchor before tag in event projection ([`26c0b5f`](https://github.com/jolars/panache/commit/26c0b5fc98feccef606f28ee49aade9f3a90375a))
- **parser:** allow column-0 block scalar body at doc root ([`a0f358c`](https://github.com/jolars/panache/commit/a0f358c47a3635d050adbdc96810e8fccab1c37d))
- **parser:** reject YAML comment not preceded by space ([`a6125c3`](https://github.com/jolars/panache/commit/a6125c361b0b86ebac4a4bc76237f59aee9cc1ca))
- keep grid tables at column 0 to match pandoc ([`73016e3`](https://github.com/jolars/panache/commit/73016e3acabdfff0b0c800e8c557ea51a63456b4))
- **parser:** reject unterminated and over-indented YAML scalars ([`23f855e`](https://github.com/jolars/panache/commit/23f855ebfa2b14c1a908d031aef464cdc0bb155a))

## [editors/code: 2.43.0](https://github.com/jolars/panache/compare/panache-code-v2.42.0...panache-code-v2.43.0) (2026-05-29)

### Dependencies
- updated panache to v2.50.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).