### PR TITLE
chore(release): v2.51.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "8ade63092ef9dc58bab04d37a2f9fa44a7256d0f",
+  "baseline-sha": "3a172ed40dd9c47a2013b339c1ee85983af4a1e1",
   "release-targets": [
     {
       "path": ".",
-      "version": "2.50.0",
-      "tag": "v2.50.0"
+      "version": "2.51.0",
+      "tag": "v2.51.0"
     },
     {
       "path": "crates/panache-dprint",
@@ -14,18 +14,18 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.8.0",
-      "tag": "panache-formatter-v0.8.0"
+      "version": "0.9.0",
+      "tag": "panache-formatter-v0.9.0"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.13.0",
-      "tag": "panache-parser-v0.13.0"
+      "version": "0.14.0",
+      "tag": "panache-parser-v0.14.0"
     },
     {
       "path": "editors/code",
-      "version": "2.43.0",
-      "tag": "panache-code-v2.43.0"
+      "version": "2.44.0",
+      "tag": "panache-code-v2.44.0"
     },
     {
       "path": "editors/zed",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [2.51.0](https://github.com/jolars/panache/compare/v2.50.0...v2.51.0) (2026-06-02)
+
+### Features
+- **config:** abort on unknown extensions, add exts to schema ([`397e1e5`](https://github.com/jolars/panache/commit/397e1e58a83e42a1decfb7692114099702fe681d))
+- **config:** abort on unknown config fields ([`d8ec90c`](https://github.com/jolars/panache/commit/d8ec90c796a0abd21c2d9cf876f8b046e9f43a95))
+- **lsp:** allow folding of HTML blocks ([`eb97109`](https://github.com/jolars/panache/commit/eb97109ef55626e9579e8814dc81fa395e66970a)), closes [#342](https://github.com/jolars/panache/issues/342)
+- **linter:** add `empty_list_item` rule ([`d033968`](https://github.com/jolars/panache/commit/d03396811f25ae8c9688425e501747dd3ceb44d7)), closes [#341](https://github.com/jolars/panache/issues/341)
+- **cli:** allow `-o extensions.<name>=<bool>` overrides ([`2df73ab`](https://github.com/jolars/panache/commit/2df73ab3153b1f4e009a930536f3f590d1a0ef37))
+- **formatter:** add `east_asian_line_breaks` extension ([`4f28716`](https://github.com/jolars/panache/commit/4f2871673d2ba4d00142032d066386db151179e9)), in [#339](https://github.com/jolars/panache/issues/339), closes [#339](https://github.com/jolars/panache/issues/339)
+
+### Bug Fixes
+- **formatter:** preserve layout when paragraph swallows a fence shape ([`6458e96`](https://github.com/jolars/panache/commit/6458e96a5e276232866d12225300a61e6e46a8af)), closes [#340](https://github.com/jolars/panache/issues/340)
+- **parser:** restrict bare-URI autolinks to known schemes (#337) ([`930db45`](https://github.com/jolars/panache/commit/930db45b8f7bf71f08e3bdb4f036e5a6928936d9)), closes [#336](https://github.com/jolars/panache/issues/336)
+- **formatter:** fix panic when formatting `<!--->` ([`b580bb9`](https://github.com/jolars/panache/commit/b580bb9cfa9345787c106a6d3522be2a515fb451))
+- **parser:** keep `.class`/`#id` on executable fence info ([`4c8f396`](https://github.com/jolars/panache/commit/4c8f39682b6de5c887f0727a39b0f18b264ec762)), fixes [#334](https://github.com/jolars/panache/issues/334)
+- **formatter:** keep list marker off reflowed line start ([`68bc1fc`](https://github.com/jolars/panache/commit/68bc1fc8cb43e2e3eea72d7363d8b35c5dad055d))
+- **formatter:** keep escaped pipe in table-cell code span ([`0b94ca2`](https://github.com/jolars/panache/commit/0b94ca2537f8b51ddd285468c144c09620b0ecfd))
+- **parser:** reject deeply-indented empty bullets as nested lists ([`15691ff`](https://github.com/jolars/panache/commit/15691ffdc2c2ad6c1180dbee12f540607f01f602)), ref [#341](https://github.com/jolars/panache/issues/341)
+
+### Dependencies
+- updated crates/panache-formatter to v0.9.0
+- updated crates/panache-parser to v0.14.0
 ## [2.50.0](https://github.com/jolars/panache/compare/v2.49.0...v2.50.0) (2026-05-29)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,9 +136,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.12.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c61cd05405eb1d0f3a4660f802bad76ece84b6e722426342ba5dd511f724e97"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "borrow-or-share"
@@ -1188,7 +1188,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "panache"
-version = "2.50.0"
+version = "2.51.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "insta",
  "log",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "entities",
  "insta",
@@ -2077,9 +2077,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -2468,18 +2468,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "2.50.0"
+version = "2.51.0"
 edition.workspace = true
 readme = "README.md"
 description = "An LSP, formatter, and linter for Markdown, Quarto, and R Markdown"
@@ -47,8 +47,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.8.0" }
-panache-parser = { path = "crates/panache-parser", version = "0.13.0", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.9.0" }
+panache-parser = { path = "crates/panache-parser", version = "0.14.0", features = [
     "serde",
     "schema",
 ] }

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.9.0](https://github.com/jolars/panache/compare/panache-formatter-v0.8.0...panache-formatter-v0.9.0) (2026-06-02)
+
+### Features
+- **config:** abort on unknown extensions, add exts to schema ([`397e1e5`](https://github.com/jolars/panache/commit/397e1e58a83e42a1decfb7692114099702fe681d))
+- **cli:** allow `-o extensions.<name>=<bool>` overrides ([`2df73ab`](https://github.com/jolars/panache/commit/2df73ab3153b1f4e009a930536f3f590d1a0ef37))
+- **formatter:** add `east_asian_line_breaks` extension ([`4f28716`](https://github.com/jolars/panache/commit/4f2871673d2ba4d00142032d066386db151179e9)), in [#339](https://github.com/jolars/panache/issues/339), closes [#339](https://github.com/jolars/panache/issues/339)
+
+### Bug Fixes
+- **formatter:** preserve layout when paragraph swallows a fence shape ([`6458e96`](https://github.com/jolars/panache/commit/6458e96a5e276232866d12225300a61e6e46a8af)), closes [#340](https://github.com/jolars/panache/issues/340)
+- **formatter:** keep list marker off reflowed line start ([`68bc1fc`](https://github.com/jolars/panache/commit/68bc1fc8cb43e2e3eea72d7363d8b35c5dad055d))
+- **formatter:** keep escaped pipe in table-cell code span ([`0b94ca2`](https://github.com/jolars/panache/commit/0b94ca2537f8b51ddd285468c144c09620b0ecfd))
+- **parser:** restrict bare-URI autolinks to known schemes (#337) ([`930db45`](https://github.com/jolars/panache/commit/930db45b8f7bf71f08e3bdb4f036e5a6928936d9)), closes [#336](https://github.com/jolars/panache/issues/336)
+- **formatter:** fix panic when formatting `<!--->` ([`b580bb9`](https://github.com/jolars/panache/commit/b580bb9cfa9345787c106a6d3522be2a515fb451))
+- **parser:** keep `.class`/`#id` on executable fence info ([`4c8f396`](https://github.com/jolars/panache/commit/4c8f39682b6de5c887f0727a39b0f18b264ec762)), fixes [#334](https://github.com/jolars/panache/issues/334)
+
+### Dependencies
+- updated crates/panache-parser to v0.14.0
 ## [0.8.0](https://github.com/jolars/panache/compare/panache-formatter-v0.7.0...panache-formatter-v0.8.0) (2026-05-29)
 
 ### Features

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 description = "Core formatting engine for Pandoc markdown, Quarto, and RMarkdown"
 license.workspace = true
@@ -13,7 +13,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.13.0" }
+panache-parser = { path = "../panache-parser", version = "0.14.0" }
 log = { version = "0.4.28", features = ["release_max_level_debug"] }
 rowan = "0.16.1"
 yaml_parser = "0.3.0"

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.14.0](https://github.com/jolars/panache/compare/panache-parser-v0.13.0...panache-parser-v0.14.0) (2026-06-02)
+
+### Features
+- **config:** abort on unknown extensions, add exts to schema ([`397e1e5`](https://github.com/jolars/panache/commit/397e1e58a83e42a1decfb7692114099702fe681d))
+- **cli:** allow `-o extensions.<name>=<bool>` overrides ([`2df73ab`](https://github.com/jolars/panache/commit/2df73ab3153b1f4e009a930536f3f590d1a0ef37))
+- **formatter:** add `east_asian_line_breaks` extension ([`4f28716`](https://github.com/jolars/panache/commit/4f2871673d2ba4d00142032d066386db151179e9)), in [#339](https://github.com/jolars/panache/issues/339), closes [#339](https://github.com/jolars/panache/issues/339)
+
+### Bug Fixes
+- **parser:** reject deeply-indented empty bullets as nested lists ([`15691ff`](https://github.com/jolars/panache/commit/15691ffdc2c2ad6c1180dbee12f540607f01f602)), ref [#341](https://github.com/jolars/panache/issues/341)
+- **parser:** restrict bare-URI autolinks to known schemes (#337) ([`930db45`](https://github.com/jolars/panache/commit/930db45b8f7bf71f08e3bdb4f036e5a6928936d9)), closes [#336](https://github.com/jolars/panache/issues/336)
+- **parser:** keep `.class`/`#id` on executable fence info ([`4c8f396`](https://github.com/jolars/panache/commit/4c8f39682b6de5c887f0727a39b0f18b264ec762)), fixes [#334](https://github.com/jolars/panache/issues/334)
 ## [0.13.0](https://github.com/jolars/panache/compare/panache-parser-v0.12.0...panache-parser-v0.13.0) (2026-05-29)
 
 ### Features

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.13.0"
+version = "0.14.0"
 edition.workspace = true
 readme = "README.md"
 description = "Lossless CST parser and syntax wrappers for Pandoc markdown, Quarto, and RMarkdown"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.44.0](https://github.com/jolars/panache/compare/panache-code-v2.43.0...panache-code-v2.44.0) (2026-06-02)
+
+### Dependencies
+- updated panache to v2.51.0
 ## [2.43.0](https://github.com/jolars/panache/compare/panache-code-v2.42.0...panache-code-v2.43.0) (2026-05-29)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "2.43.0",
+  "version": "2.44.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.12.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c61cd05405eb1d0f3a4660f802bad76ece84b6e722426342ba5dd511f724e97"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "cfg-if"

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "2.50.0",
+  "version": "2.51.0",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "2.50.0",
-    "@panache-cli/linux-arm64-gnu": "2.50.0",
-    "@panache-cli/linux-x64-musl": "2.50.0",
-    "@panache-cli/linux-arm64-musl": "2.50.0",
-    "@panache-cli/darwin-x64": "2.50.0",
-    "@panache-cli/darwin-arm64": "2.50.0",
-    "@panache-cli/win32-x64": "2.50.0",
-    "@panache-cli/win32-arm64": "2.50.0"
+    "@panache-cli/linux-x64-gnu": "2.51.0",
+    "@panache-cli/linux-arm64-gnu": "2.51.0",
+    "@panache-cli/linux-x64-musl": "2.51.0",
+    "@panache-cli/linux-arm64-musl": "2.51.0",
+    "@panache-cli/darwin-x64": "2.51.0",
+    "@panache-cli/darwin-arm64": "2.51.0",
+    "@panache-cli/win32-x64": "2.51.0",
+    "@panache-cli/win32-arm64": "2.51.0"
   }
 }


### PR DESCRIPTION
## [panache: 2.51.0](https://github.com/jolars/panache/compare/v2.50.0...v2.51.0) (2026-06-02)

### Features
- **config:** abort on unknown extensions, add exts to schema ([`397e1e5`](https://github.com/jolars/panache/commit/397e1e58a83e42a1decfb7692114099702fe681d))
- **config:** abort on unknown config fields ([`d8ec90c`](https://github.com/jolars/panache/commit/d8ec90c796a0abd21c2d9cf876f8b046e9f43a95))
- **lsp:** allow folding of HTML blocks ([`eb97109`](https://github.com/jolars/panache/commit/eb97109ef55626e9579e8814dc81fa395e66970a)), closes [#342](https://github.com/jolars/panache/issues/342)
- **linter:** add `empty_list_item` rule ([`d033968`](https://github.com/jolars/panache/commit/d03396811f25ae8c9688425e501747dd3ceb44d7)), closes [#341](https://github.com/jolars/panache/issues/341)
- **cli:** allow `-o extensions.<name>=<bool>` overrides ([`2df73ab`](https://github.com/jolars/panache/commit/2df73ab3153b1f4e009a930536f3f590d1a0ef37))
- **formatter:** add `east_asian_line_breaks` extension ([`4f28716`](https://github.com/jolars/panache/commit/4f2871673d2ba4d00142032d066386db151179e9)), in [#339](https://github.com/jolars/panache/issues/339), closes [#339](https://github.com/jolars/panache/issues/339)

### Bug Fixes
- **formatter:** preserve layout when paragraph swallows a fence shape ([`6458e96`](https://github.com/jolars/panache/commit/6458e96a5e276232866d12225300a61e6e46a8af)), closes [#340](https://github.com/jolars/panache/issues/340)
- **parser:** restrict bare-URI autolinks to known schemes (#337) ([`930db45`](https://github.com/jolars/panache/commit/930db45b8f7bf71f08e3bdb4f036e5a6928936d9)), closes [#336](https://github.com/jolars/panache/issues/336)
- **formatter:** fix panic when formatting `<!--->` ([`b580bb9`](https://github.com/jolars/panache/commit/b580bb9cfa9345787c106a6d3522be2a515fb451))
- **parser:** keep `.class`/`#id` on executable fence info ([`4c8f396`](https://github.com/jolars/panache/commit/4c8f39682b6de5c887f0727a39b0f18b264ec762)), fixes [#334](https://github.com/jolars/panache/issues/334)
- **formatter:** keep list marker off reflowed line start ([`68bc1fc`](https://github.com/jolars/panache/commit/68bc1fc8cb43e2e3eea72d7363d8b35c5dad055d))
- **formatter:** keep escaped pipe in table-cell code span ([`0b94ca2`](https://github.com/jolars/panache/commit/0b94ca2537f8b51ddd285468c144c09620b0ecfd))
- **parser:** reject deeply-indented empty bullets as nested lists ([`15691ff`](https://github.com/jolars/panache/commit/15691ffdc2c2ad6c1180dbee12f540607f01f602)), ref [#341](https://github.com/jolars/panache/issues/341)

### Dependencies
- updated crates/panache-formatter to v0.9.0
- updated crates/panache-parser to v0.14.0

## [crates/panache-formatter: 0.9.0](https://github.com/jolars/panache/compare/panache-formatter-v0.8.0...panache-formatter-v0.9.0) (2026-06-02)

### Features
- **config:** abort on unknown extensions, add exts to schema ([`397e1e5`](https://github.com/jolars/panache/commit/397e1e58a83e42a1decfb7692114099702fe681d))
- **cli:** allow `-o extensions.<name>=<bool>` overrides ([`2df73ab`](https://github.com/jolars/panache/commit/2df73ab3153b1f4e009a930536f3f590d1a0ef37))
- **formatter:** add `east_asian_line_breaks` extension ([`4f28716`](https://github.com/jolars/panache/commit/4f2871673d2ba4d00142032d066386db151179e9)), in [#339](https://github.com/jolars/panache/issues/339), closes [#339](https://github.com/jolars/panache/issues/339)

### Bug Fixes
- **formatter:** preserve layout when paragraph swallows a fence shape ([`6458e96`](https://github.com/jolars/panache/commit/6458e96a5e276232866d12225300a61e6e46a8af)), closes [#340](https://github.com/jolars/panache/issues/340)
- **formatter:** keep list marker off reflowed line start ([`68bc1fc`](https://github.com/jolars/panache/commit/68bc1fc8cb43e2e3eea72d7363d8b35c5dad055d))
- **formatter:** keep escaped pipe in table-cell code span ([`0b94ca2`](https://github.com/jolars/panache/commit/0b94ca2537f8b51ddd285468c144c09620b0ecfd))
- **parser:** restrict bare-URI autolinks to known schemes (#337) ([`930db45`](https://github.com/jolars/panache/commit/930db45b8f7bf71f08e3bdb4f036e5a6928936d9)), closes [#336](https://github.com/jolars/panache/issues/336)
- **formatter:** fix panic when formatting `<!--->` ([`b580bb9`](https://github.com/jolars/panache/commit/b580bb9cfa9345787c106a6d3522be2a515fb451))
- **parser:** keep `.class`/`#id` on executable fence info ([`4c8f396`](https://github.com/jolars/panache/commit/4c8f39682b6de5c887f0727a39b0f18b264ec762)), fixes [#334](https://github.com/jolars/panache/issues/334)

### Dependencies
- updated crates/panache-parser to v0.14.0

## [crates/panache-parser: 0.14.0](https://github.com/jolars/panache/compare/panache-parser-v0.13.0...panache-parser-v0.14.0) (2026-06-02)

### Features
- **config:** abort on unknown extensions, add exts to schema ([`397e1e5`](https://github.com/jolars/panache/commit/397e1e58a83e42a1decfb7692114099702fe681d))
- **cli:** allow `-o extensions.<name>=<bool>` overrides ([`2df73ab`](https://github.com/jolars/panache/commit/2df73ab3153b1f4e009a930536f3f590d1a0ef37))
- **formatter:** add `east_asian_line_breaks` extension ([`4f28716`](https://github.com/jolars/panache/commit/4f2871673d2ba4d00142032d066386db151179e9)), in [#339](https://github.com/jolars/panache/issues/339), closes [#339](https://github.com/jolars/panache/issues/339)

### Bug Fixes
- **parser:** reject deeply-indented empty bullets as nested lists ([`15691ff`](https://github.com/jolars/panache/commit/15691ffdc2c2ad6c1180dbee12f540607f01f602)), ref [#341](https://github.com/jolars/panache/issues/341)
- **parser:** restrict bare-URI autolinks to known schemes (#337) ([`930db45`](https://github.com/jolars/panache/commit/930db45b8f7bf71f08e3bdb4f036e5a6928936d9)), closes [#336](https://github.com/jolars/panache/issues/336)
- **parser:** keep `.class`/`#id` on executable fence info ([`4c8f396`](https://github.com/jolars/panache/commit/4c8f39682b6de5c887f0727a39b0f18b264ec762)), fixes [#334](https://github.com/jolars/panache/issues/334)

## [editors/code: 2.44.0](https://github.com/jolars/panache/compare/panache-code-v2.43.0...panache-code-v2.44.0) (2026-06-02)

### Dependencies
- updated panache to v2.51.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).