### PR TITLE
fix(formatter): align nested pipe tables to container indent

### DIFF
--- a/crates/panache-formatter/src/formatter/core.rs
+++ b/crates/panache-formatter/src/formatter/core.rs
@@ -2124,7 +2124,7 @@ impl Formatter {
 
             SyntaxKind::PIPE_TABLE => {
                 // Format pipe table with proper alignment
-                let formatted = tables::format_pipe_table(node, &self.config);
+                let formatted = tables::format_pipe_table(node, &self.config, indent);
                 self.output.push_str(&formatted);
             }
 

--- a/crates/panache-formatter/src/formatter/tables.rs
+++ b/crates/panache-formatter/src/formatter/tables.rs
@@ -714,10 +714,6 @@ pub fn format_pipe_table(node: &SyntaxNode, config: &Config, indent: usize) -> S
         output.push_str(&formatted_caption);
         output.push('\n');
     }
-    // Honor the threaded container indent so a nested pipe table aligns to its
-    // container's content column (e.g. an ordered list whose content starts at
-    // column 3). At the top level the dispatcher passes indent 0; keep the
-    // house-style two-space indent there.
     let block_indent = if indent == 0 {
         TABLE_BLOCK_INDENT
     } else {

--- a/crates/panache-formatter/src/formatter/tables.rs
+++ b/crates/panache-formatter/src/formatter/tables.rs
@@ -7,10 +7,10 @@ use rowan::NodeOrToken;
 use std::collections::HashMap;
 use unicode_width::UnicodeWidthStr;
 
-/// Default indent (in spaces) for table types that still self-indent at the top
-/// level (pipe, simple, multiline). Grid tables instead honor the container
-/// indent threaded from the dispatcher so a top-level grid sits at column 0 --
-/// pandoc rejects an indented `+---+` border. See `format_grid_table`.
+/// Default indent (in spaces) for table types that self-indent at the top level
+/// (pipe, simple, multiline). Grid tables instead honor the container indent
+/// threaded from the dispatcher so a top-level grid sits at column 0 -- pandoc
+/// rejects an indented `+---+` border. See `format_grid_table`.
 const TABLE_BLOCK_INDENT: usize = 2;
 
 fn indent_table_block(block: &str, indent: usize) -> String {
@@ -618,7 +618,7 @@ fn calculate_grid_column_widths(rows: &[Vec<String>]) -> Vec<usize> {
 }
 
 /// Format a pipe table with consistent alignment and padding
-pub fn format_pipe_table(node: &SyntaxNode, config: &Config) -> String {
+pub fn format_pipe_table(node: &SyntaxNode, config: &Config, indent: usize) -> String {
     let table_data = extract_pipe_table_data(node, config);
     let mut output = String::new();
 
@@ -714,7 +714,16 @@ pub fn format_pipe_table(node: &SyntaxNode, config: &Config) -> String {
         output.push_str(&formatted_caption);
         output.push('\n');
     }
-    indent_table_block(&output, TABLE_BLOCK_INDENT)
+    // Honor the threaded container indent so a nested pipe table aligns to its
+    // container's content column (e.g. an ordered list whose content starts at
+    // column 3). At the top level the dispatcher passes indent 0; keep the
+    // house-style two-space indent there.
+    let block_indent = if indent == 0 {
+        TABLE_BLOCK_INDENT
+    } else {
+        indent
+    };
+    indent_table_block(&output, block_indent)
 }
 
 // Grid Table Formatting

--- a/tests/fixtures/cases/nested_pipe_table_indent/expected.md
+++ b/tests/fixtures/cases/nested_pipe_table_indent/expected.md
@@ -1,0 +1,5 @@
+1. First item with a table:
+
+   | Key | Value |
+   | --- | ----- |
+   | a   | 1     |

--- a/tests/fixtures/cases/nested_pipe_table_indent/input.md
+++ b/tests/fixtures/cases/nested_pipe_table_indent/input.md
@@ -1,0 +1,5 @@
+1. First item with a table:
+
+   | Key | Value |
+   | --- | --- |
+   | a | 1 |

--- a/tests/golden_cases.rs
+++ b/tests/golden_cases.rs
@@ -328,6 +328,7 @@ golden_test_cases!(
     paragraph_plain_mixed,
     paragraph_wrapping,
     paragraphs,
+    nested_pipe_table_indent,
     pipe_table,
     pipe_table_unicode,
     plain_continuation_edge_cases,


### PR DESCRIPTION
Related to #344 #345

Pipe tables ignored the container indent that the dispatcher threads in and always self-indented by a hard-coded two spaces, so a pipe table nested in a container whose content column isn't two (e.g., an ordered list, where content starts at column 3) was emitted under-indented and detached from its item. This threads the container indent through `format_pipe_table` (as grid tables already do) and uses it for nested tables, while preserving the existing two-space indent at the top level.