### PR TITLE
chore(release): v2.52.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "3a172ed40dd9c47a2013b339c1ee85983af4a1e1",
+  "baseline-sha": "f010b4157b30affb4201fcfbccdc5b57ca56992c",
   "release-targets": [
     {
       "path": ".",
-      "version": "2.51.0",
-      "tag": "v2.51.0"
+      "version": "2.52.0",
+      "tag": "v2.52.0"
     },
     {
       "path": "crates/panache-dprint",
@@ -14,18 +14,18 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.9.0",
-      "tag": "panache-formatter-v0.9.0"
+      "version": "0.10.0",
+      "tag": "panache-formatter-v0.10.0"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.14.0",
-      "tag": "panache-parser-v0.14.0"
+      "version": "0.15.0",
+      "tag": "panache-parser-v0.15.0"
     },
     {
       "path": "editors/code",
-      "version": "2.44.0",
-      "tag": "panache-code-v2.44.0"
+      "version": "2.45.0",
+      "tag": "panache-code-v2.45.0"
     },
     {
       "path": "editors/zed",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [2.52.0](https://github.com/jolars/panache/compare/v2.51.0...v2.52.0) (2026-06-07)
 
 This release comes with two major changes:
 
@@ -24,6 +24,44 @@ This release comes with two major changes:
   hashpipe YAML syntax for Quarto/R Markdown documents. The changes won't be
   immediately visible to users, but will pave the way for better linting
   and LSP features in the future.
+
+### Features
+- **parser:** tokenize math operators into `MATH_OPERATOR` ([`303e05b`](https://github.com/jolars/panache/commit/303e05bdd245f08fdb7c2244df6c1df198faaea4))
+- **formatter:** add experimental math content formatter ([`a0e5f51`](https://github.com/jolars/panache/commit/a0e5f51c4ca7cde204eb3fe1f277f74775272571))
+- **linter:** surface math diagnostics via `math-syntax` rule ([`20c0b5b`](https://github.com/jolars/panache/commit/20c0b5b682c1fde65bd70e9f27e77738384f74ae))
+- **parser:** parse math content into a structural CST ([`cfb0c45`](https://github.com/jolars/panache/commit/cfb0c45f5173b49a49853660d1f4030debedd26c))
+- **lsp:** source YAML parse-error diagnostics from the parser channel ([`ad2ec30`](https://github.com/jolars/panache/commit/ad2ec306aa92dd1eeffa0145a21b8c334087e4c7))
+- **parser:** prefix-aware YAML scanner and builder ([`66a8e99`](https://github.com/jolars/panache/commit/66a8e99bdcb6c2b803bfa9ce227b132031006f3d))
+- **parser:** swap YAML parser to our built-in parser ([`4ed243a`](https://github.com/jolars/panache/commit/4ed243ab2c8d9d9d5a0bc404ffaccf44c9b28ea7))
+- **formatter:** swap YAML formatting over to our own formatter ([`9e722e5`](https://github.com/jolars/panache/commit/9e722e5b9a9a412bb20d523ab354cee520326a96))
+- **extensions:** add `space_reference_links` extension ([`309739d`](https://github.com/jolars/panache/commit/309739dbaf54dc84d588fbc45285bcb96795177e))
+- **extensions:** add `wikilinks_title_after/before_pipe` ([`49500f1`](https://github.com/jolars/panache/commit/49500f12b27851789942b18b13db68d4fd691726))
+- **parser:** add syntax-error channel for embedded YAML ([`523fb62`](https://github.com/jolars/panache/commit/523fb62306ab9e0749651b6e4103cf8e3510f9d2))
+- **parser:** embed prefix-aware YAML under HASHPIPE_YAML_CONTENT ([`d515896`](https://github.com/jolars/panache/commit/d515896f6da9ad307015c69c5348ee1d077d7b2a))
+- **parser:** drop host envelope from standalone YAML parse ([`5fecc99`](https://github.com/jolars/panache/commit/5fecc99a61e8429c97764f0a34590ef5d28c223f))
+- inline YAML parser CST into Panache's CST ([`d240130`](https://github.com/jolars/panache/commit/d240130a59cc8018227d7d4fe71fae9b39ea0947))
+
+### Bug Fixes
+- **formatter:** preserve full code fence info string ([`e9638be`](https://github.com/jolars/panache/commit/e9638bef4529d43349a51d92293f4d4182a9181b)), closes [#356](https://github.com/jolars/panache/issues/356)
+- **linter:** raise `math-syntax` diagnostics to error ([`238a3de`](https://github.com/jolars/panache/commit/238a3de0f6e58aa8dfc1af41f1d2135b9630f46c))
+- **linter:** catch stray `:::` inside tight list items ([`d88856d`](https://github.com/jolars/panache/commit/d88856de74824812c73086a4b65c9a21f20ad9a8)), closes [#333](https://github.com/jolars/panache/issues/333)
+- **parser:** don't strip blockquote markers in `<details>` ([`4579dd8`](https://github.com/jolars/panache/commit/4579dd8204db754ca44451d3accd361b702f1675)), closes [#350](https://github.com/jolars/panache/issues/350)
+- **formatter:** align nested pipe tables to container indent (#346) ([`1095aee`](https://github.com/jolars/panache/commit/1095aee302e3b97c9c19958bfc777abb2deb0c96))
+- **parser:** reject bare multi-word fence info in Pandoc ([`395b000`](https://github.com/jolars/panache/commit/395b0008c0a46f7a490d982f793f2dbe0f3a7737))
+- **parser:** peel line prefix after a hashpipe block scalar ([`e246d30`](https://github.com/jolars/panache/commit/e246d30ca7aedf6cc96707dd30a14247f4736760))
+- **parser:** don't start list at continuation for footnote def ([`9494b14`](https://github.com/jolars/panache/commit/9494b143e69cdb8d02ab99ad88b087ff9970a8ee)), closes [#348](https://github.com/jolars/panache/issues/348)
+- **parser:** detect grid borders on dispatch line inside list items ([`e7fa051`](https://github.com/jolars/panache/commit/e7fa05124e3b4c2d14aceb13ce154bda022270e4))
+- **parser:** lift tables and fenced divs from list-item content ([`6f3821c`](https://github.com/jolars/panache/commit/6f3821c4d7bedbcd47d56ad0851eac015f05adcd))
+
+### Performance Improvements
+- **lsp:** run heavy lint reads on cloned salsa handle ([`111f6cc`](https://github.com/jolars/panache/commit/111f6cc6e3f10ea7c9343776e022a80464da7056))
+- **linter:** share one CST walk across built-in rules ([`8569bbf`](https://github.com/jolars/panache/commit/8569bbf01b25329c4377a7baad22ada08ae7e207))
+- **lsp:** debounce diagnostics, lint externally on save ([`99310a5`](https://github.com/jolars/panache/commit/99310a52918869abb1ddbd8bcd538fe26f289f64))
+- **parser:** gate table detection before whole-buffer strip ([`f27fc80`](https://github.com/jolars/panache/commit/f27fc80f0e2b4fa7a351d35d0a7195e048ca666c))
+
+### Dependencies
+- updated crates/panache-formatter to v0.10.0
+- updated crates/panache-parser to v0.15.0
 
 ## [2.51.0](https://github.com/jolars/panache/compare/v2.50.0...v2.51.0) (2026-06-02)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,9 +136,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "borrow-or-share"
@@ -846,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -1028,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "ls-types"
@@ -1188,7 +1188,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "panache"
-version = "2.51.0"
+version = "2.52.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "insta",
  "log",
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "entities",
  "insta",
@@ -2451,9 +2451,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "2.51.0"
+version = "2.52.0"
 edition.workspace = true
 readme = "README.md"
 description = "An LSP, formatter, and linter for Markdown, Quarto, and R Markdown"
@@ -47,8 +47,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.9.0" }
-panache-parser = { path = "crates/panache-parser", version = "0.14.0", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.10.0" }
+panache-parser = { path = "crates/panache-parser", version = "0.15.0", features = [
     "serde",
     "schema",
 ] }

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.10.0](https://github.com/jolars/panache/compare/panache-formatter-v0.9.0...panache-formatter-v0.10.0) (2026-06-07)
+
+### Features
+- **formatter:** add experimental math content formatter ([`a0e5f51`](https://github.com/jolars/panache/commit/a0e5f51c4ca7cde204eb3fe1f277f74775272571))
+- **parser:** parse math content into a structural CST ([`cfb0c45`](https://github.com/jolars/panache/commit/cfb0c45f5173b49a49853660d1f4030debedd26c))
+- **parser:** swap YAML parser to our built-in parser ([`4ed243a`](https://github.com/jolars/panache/commit/4ed243ab2c8d9d9d5a0bc404ffaccf44c9b28ea7))
+- **formatter:** swap YAML formatting over to our own formatter ([`9e722e5`](https://github.com/jolars/panache/commit/9e722e5b9a9a412bb20d523ab354cee520326a96))
+- **extensions:** add `wikilinks_title_after/before_pipe` ([`49500f1`](https://github.com/jolars/panache/commit/49500f12b27851789942b18b13db68d4fd691726))
+
+### Bug Fixes
+- **formatter:** preserve full code fence info string ([`e9638be`](https://github.com/jolars/panache/commit/e9638bef4529d43349a51d92293f4d4182a9181b)), closes [#356](https://github.com/jolars/panache/issues/356)
+- **parser:** don't strip blockquote markers in `<details>` ([`4579dd8`](https://github.com/jolars/panache/commit/4579dd8204db754ca44451d3accd361b702f1675)), closes [#350](https://github.com/jolars/panache/issues/350)
+- **formatter:** align nested pipe tables to container indent (#346) ([`1095aee`](https://github.com/jolars/panache/commit/1095aee302e3b97c9c19958bfc777abb2deb0c96))
+
+### Dependencies
+- updated crates/panache-parser to v0.15.0
+
 ## [0.9.0](https://github.com/jolars/panache/compare/panache-formatter-v0.8.0...panache-formatter-v0.9.0) (2026-06-02)
 
 ### Features

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 description = "Core formatting engine for Pandoc markdown, Quarto, and RMarkdown"
 license.workspace = true
@@ -13,7 +13,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.14.0" }
+panache-parser = { path = "../panache-parser", version = "0.15.0" }
 log = { version = "0.4.31", features = ["release_max_level_debug"] }
 rowan = "0.16.1"
 unicode-width = "0.2"

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.15.0](https://github.com/jolars/panache/compare/panache-parser-v0.14.0...panache-parser-v0.15.0) (2026-06-07)
+
+### Features
+- **parser:** tokenize math operators into `MATH_OPERATOR` ([`303e05b`](https://github.com/jolars/panache/commit/303e05bdd245f08fdb7c2244df6c1df198faaea4))
+- **parser:** parse math content into a structural CST ([`cfb0c45`](https://github.com/jolars/panache/commit/cfb0c45f5173b49a49853660d1f4030debedd26c))
+- **parser:** add syntax-error channel for embedded YAML ([`523fb62`](https://github.com/jolars/panache/commit/523fb62306ab9e0749651b6e4103cf8e3510f9d2))
+- **parser:** embed prefix-aware YAML under HASHPIPE_YAML_CONTENT ([`d515896`](https://github.com/jolars/panache/commit/d515896f6da9ad307015c69c5348ee1d077d7b2a))
+- **parser:** prefix-aware YAML scanner and builder ([`66a8e99`](https://github.com/jolars/panache/commit/66a8e99bdcb6c2b803bfa9ce227b132031006f3d))
+- **parser:** drop host envelope from standalone YAML parse ([`5fecc99`](https://github.com/jolars/panache/commit/5fecc99a61e8429c97764f0a34590ef5d28c223f))
+- inline YAML parser CST into Panache's CST ([`d240130`](https://github.com/jolars/panache/commit/d240130a59cc8018227d7d4fe71fae9b39ea0947))
+- **parser:** swap YAML parser to our built-in parser ([`4ed243a`](https://github.com/jolars/panache/commit/4ed243ab2c8d9d9d5a0bc404ffaccf44c9b28ea7))
+- **extensions:** add `space_reference_links` extension ([`309739d`](https://github.com/jolars/panache/commit/309739dbaf54dc84d588fbc45285bcb96795177e))
+- **extensions:** add `wikilinks_title_after/before_pipe` ([`49500f1`](https://github.com/jolars/panache/commit/49500f12b27851789942b18b13db68d4fd691726))
+
+### Bug Fixes
+- **parser:** reject bare multi-word fence info in Pandoc ([`395b000`](https://github.com/jolars/panache/commit/395b0008c0a46f7a490d982f793f2dbe0f3a7737))
+- **parser:** peel line prefix after a hashpipe block scalar ([`e246d30`](https://github.com/jolars/panache/commit/e246d30ca7aedf6cc96707dd30a14247f4736760))
+- **parser:** don't start list at continuation for footnote def ([`9494b14`](https://github.com/jolars/panache/commit/9494b143e69cdb8d02ab99ad88b087ff9970a8ee)), closes [#348](https://github.com/jolars/panache/issues/348)
+- **parser:** detect grid borders on dispatch line inside list items ([`e7fa051`](https://github.com/jolars/panache/commit/e7fa05124e3b4c2d14aceb13ce154bda022270e4))
+- **parser:** lift tables and fenced divs from list-item content ([`6f3821c`](https://github.com/jolars/panache/commit/6f3821c4d7bedbcd47d56ad0851eac015f05adcd))
+
+### Performance Improvements
+- **parser:** gate table detection before whole-buffer strip ([`f27fc80`](https://github.com/jolars/panache/commit/f27fc80f0e2b4fa7a351d35d0a7195e048ca666c))
+
 ## [0.14.0](https://github.com/jolars/panache/compare/panache-parser-v0.13.0...panache-parser-v0.14.0) (2026-06-02)
 
 ### Features

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.14.0"
+version = "0.15.0"
 edition.workspace = true
 readme = "README.md"
 description = "Lossless CST parser and syntax wrappers for Pandoc markdown, Quarto, and RMarkdown"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.45.0](https://github.com/jolars/panache/compare/panache-code-v2.44.0...panache-code-v2.45.0) (2026-06-07)
+
+### Dependencies
+- updated panache to v2.52.0
+
 ## [2.44.0](https://github.com/jolars/panache/compare/panache-code-v2.43.0...panache-code-v2.44.0) (2026-06-02)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "2.44.0",
+  "version": "2.45.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "cfg-if"
@@ -339,9 +339,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "memchr"
@@ -717,9 +717,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "2.51.0",
+  "version": "2.52.0",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "2.51.0",
-    "@panache-cli/linux-arm64-gnu": "2.51.0",
-    "@panache-cli/linux-x64-musl": "2.51.0",
-    "@panache-cli/linux-arm64-musl": "2.51.0",
-    "@panache-cli/darwin-x64": "2.51.0",
-    "@panache-cli/darwin-arm64": "2.51.0",
-    "@panache-cli/win32-x64": "2.51.0",
-    "@panache-cli/win32-arm64": "2.51.0"
+    "@panache-cli/linux-x64-gnu": "2.52.0",
+    "@panache-cli/linux-arm64-gnu": "2.52.0",
+    "@panache-cli/linux-x64-musl": "2.52.0",
+    "@panache-cli/linux-arm64-musl": "2.52.0",
+    "@panache-cli/darwin-x64": "2.52.0",
+    "@panache-cli/darwin-arm64": "2.52.0",
+    "@panache-cli/win32-x64": "2.52.0",
+    "@panache-cli/win32-arm64": "2.52.0"
   }
 }


### PR DESCRIPTION
## [panache: 2.52.0](https://github.com/jolars/panache/compare/v2.51.0...v2.52.0) (2026-06-07)

This release comes with two major changes:

- There is now an experimental math parser and formatter in Panache! The formatter
  can be enabled via the following setting:

  ```toml
  [experimental]
  format-math = true
  ```

  The formatter is very basic at the moment, only supporting alignment and
  whitespace normalization, but the intent is for it to eventually support
  operator-precedence-aware line breaking and other features.

- Panache now has its own YAML parser and formatter! We have previously relied
  on the external `yaml_parser` and `pretty_yaml` crates. But with this release,
  we have now shifted over to our own hand-crafted YAML parser and formatter,
  fully compatible with the YAML 1.2 spec. YAML syntax is now also a first-class
  citizen in the Panache CST, with all markers and trivia preserved, even in the
  hashpipe YAML syntax for Quarto/R Markdown documents. The changes won't be
  immediately visible to users, but will pave the way for better linting
  and LSP features in the future.

### Features
- **parser:** tokenize math operators into `MATH_OPERATOR` ([`303e05b`](https://github.com/jolars/panache/commit/303e05bdd245f08fdb7c2244df6c1df198faaea4))
- **formatter:** add experimental math content formatter ([`a0e5f51`](https://github.com/jolars/panache/commit/a0e5f51c4ca7cde204eb3fe1f277f74775272571))
- **linter:** surface math diagnostics via `math-syntax` rule ([`20c0b5b`](https://github.com/jolars/panache/commit/20c0b5b682c1fde65bd70e9f27e77738384f74ae))
- **parser:** parse math content into a structural CST ([`cfb0c45`](https://github.com/jolars/panache/commit/cfb0c45f5173b49a49853660d1f4030debedd26c))
- **lsp:** source YAML parse-error diagnostics from the parser channel ([`ad2ec30`](https://github.com/jolars/panache/commit/ad2ec306aa92dd1eeffa0145a21b8c334087e4c7))
- **parser:** prefix-aware YAML scanner and builder ([`66a8e99`](https://github.com/jolars/panache/commit/66a8e99bdcb6c2b803bfa9ce227b132031006f3d))
- **parser:** swap YAML parser to our built-in parser ([`4ed243a`](https://github.com/jolars/panache/commit/4ed243ab2c8d9d9d5a0bc404ffaccf44c9b28ea7))
- **formatter:** swap YAML formatting over to our own formatter ([`9e722e5`](https://github.com/jolars/panache/commit/9e722e5b9a9a412bb20d523ab354cee520326a96))
- **extensions:** add `space_reference_links` extension ([`309739d`](https://github.com/jolars/panache/commit/309739dbaf54dc84d588fbc45285bcb96795177e))
- **extensions:** add `wikilinks_title_after/before_pipe` ([`49500f1`](https://github.com/jolars/panache/commit/49500f12b27851789942b18b13db68d4fd691726))
- **parser:** add syntax-error channel for embedded YAML ([`523fb62`](https://github.com/jolars/panache/commit/523fb62306ab9e0749651b6e4103cf8e3510f9d2))
- **parser:** embed prefix-aware YAML under HASHPIPE_YAML_CONTENT ([`d515896`](https://github.com/jolars/panache/commit/d515896f6da9ad307015c69c5348ee1d077d7b2a))
- **parser:** drop host envelope from standalone YAML parse ([`5fecc99`](https://github.com/jolars/panache/commit/5fecc99a61e8429c97764f0a34590ef5d28c223f))
- inline YAML parser CST into Panache's CST ([`d240130`](https://github.com/jolars/panache/commit/d240130a59cc8018227d7d4fe71fae9b39ea0947))

### Bug Fixes
- **formatter:** preserve full code fence info string ([`e9638be`](https://github.com/jolars/panache/commit/e9638bef4529d43349a51d92293f4d4182a9181b)), closes [#356](https://github.com/jolars/panache/issues/356)
- **linter:** raise `math-syntax` diagnostics to error ([`238a3de`](https://github.com/jolars/panache/commit/238a3de0f6e58aa8dfc1af41f1d2135b9630f46c))
- **linter:** catch stray `:::` inside tight list items ([`d88856d`](https://github.com/jolars/panache/commit/d88856de74824812c73086a4b65c9a21f20ad9a8)), closes [#333](https://github.com/jolars/panache/issues/333)
- **parser:** don't strip blockquote markers in `<details>` ([`4579dd8`](https://github.com/jolars/panache/commit/4579dd8204db754ca44451d3accd361b702f1675)), closes [#350](https://github.com/jolars/panache/issues/350)
- **formatter:** align nested pipe tables to container indent (#346) ([`1095aee`](https://github.com/jolars/panache/commit/1095aee302e3b97c9c19958bfc777abb2deb0c96))
- **parser:** reject bare multi-word fence info in Pandoc ([`395b000`](https://github.com/jolars/panache/commit/395b0008c0a46f7a490d982f793f2dbe0f3a7737))
- **parser:** peel line prefix after a hashpipe block scalar ([`e246d30`](https://github.com/jolars/panache/commit/e246d30ca7aedf6cc96707dd30a14247f4736760))
- **parser:** don't start list at continuation for footnote def ([`9494b14`](https://github.com/jolars/panache/commit/9494b143e69cdb8d02ab99ad88b087ff9970a8ee)), closes [#348](https://github.com/jolars/panache/issues/348)
- **parser:** detect grid borders on dispatch line inside list items ([`e7fa051`](https://github.com/jolars/panache/commit/e7fa05124e3b4c2d14aceb13ce154bda022270e4))
- **parser:** lift tables and fenced divs from list-item content ([`6f3821c`](https://github.com/jolars/panache/commit/6f3821c4d7bedbcd47d56ad0851eac015f05adcd))

### Performance Improvements
- **lsp:** run heavy lint reads on cloned salsa handle ([`111f6cc`](https://github.com/jolars/panache/commit/111f6cc6e3f10ea7c9343776e022a80464da7056))
- **linter:** share one CST walk across built-in rules ([`8569bbf`](https://github.com/jolars/panache/commit/8569bbf01b25329c4377a7baad22ada08ae7e207))
- **lsp:** debounce diagnostics, lint externally on save ([`99310a5`](https://github.com/jolars/panache/commit/99310a52918869abb1ddbd8bcd538fe26f289f64))
- **parser:** gate table detection before whole-buffer strip ([`f27fc80`](https://github.com/jolars/panache/commit/f27fc80f0e2b4fa7a351d35d0a7195e048ca666c))

### Dependencies
- updated crates/panache-formatter to v0.10.0
- updated crates/panache-parser to v0.15.0

## [crates/panache-formatter: 0.10.0](https://github.com/jolars/panache/compare/panache-formatter-v0.9.0...panache-formatter-v0.10.0) (2026-06-07)

### Features
- **formatter:** add experimental math content formatter ([`a0e5f51`](https://github.com/jolars/panache/commit/a0e5f51c4ca7cde204eb3fe1f277f74775272571))
- **parser:** parse math content into a structural CST ([`cfb0c45`](https://github.com/jolars/panache/commit/cfb0c45f5173b49a49853660d1f4030debedd26c))
- **parser:** swap YAML parser to our built-in parser ([`4ed243a`](https://github.com/jolars/panache/commit/4ed243ab2c8d9d9d5a0bc404ffaccf44c9b28ea7))
- **formatter:** swap YAML formatting over to our own formatter ([`9e722e5`](https://github.com/jolars/panache/commit/9e722e5b9a9a412bb20d523ab354cee520326a96))
- **extensions:** add `wikilinks_title_after/before_pipe` ([`49500f1`](https://github.com/jolars/panache/commit/49500f12b27851789942b18b13db68d4fd691726))

### Bug Fixes
- **formatter:** preserve full code fence info string ([`e9638be`](https://github.com/jolars/panache/commit/e9638bef4529d43349a51d92293f4d4182a9181b)), closes [#356](https://github.com/jolars/panache/issues/356)
- **parser:** don't strip blockquote markers in `<details>` ([`4579dd8`](https://github.com/jolars/panache/commit/4579dd8204db754ca44451d3accd361b702f1675)), closes [#350](https://github.com/jolars/panache/issues/350)
- **formatter:** align nested pipe tables to container indent (#346) ([`1095aee`](https://github.com/jolars/panache/commit/1095aee302e3b97c9c19958bfc777abb2deb0c96))

### Dependencies
- updated crates/panache-parser to v0.15.0

## [crates/panache-parser: 0.15.0](https://github.com/jolars/panache/compare/panache-parser-v0.14.0...panache-parser-v0.15.0) (2026-06-07)

### Features
- **parser:** tokenize math operators into `MATH_OPERATOR` ([`303e05b`](https://github.com/jolars/panache/commit/303e05bdd245f08fdb7c2244df6c1df198faaea4))
- **parser:** parse math content into a structural CST ([`cfb0c45`](https://github.com/jolars/panache/commit/cfb0c45f5173b49a49853660d1f4030debedd26c))
- **parser:** add syntax-error channel for embedded YAML ([`523fb62`](https://github.com/jolars/panache/commit/523fb62306ab9e0749651b6e4103cf8e3510f9d2))
- **parser:** embed prefix-aware YAML under HASHPIPE_YAML_CONTENT ([`d515896`](https://github.com/jolars/panache/commit/d515896f6da9ad307015c69c5348ee1d077d7b2a))
- **parser:** prefix-aware YAML scanner and builder ([`66a8e99`](https://github.com/jolars/panache/commit/66a8e99bdcb6c2b803bfa9ce227b132031006f3d))
- **parser:** drop host envelope from standalone YAML parse ([`5fecc99`](https://github.com/jolars/panache/commit/5fecc99a61e8429c97764f0a34590ef5d28c223f))
- inline YAML parser CST into Panache's CST ([`d240130`](https://github.com/jolars/panache/commit/d240130a59cc8018227d7d4fe71fae9b39ea0947))
- **parser:** swap YAML parser to our built-in parser ([`4ed243a`](https://github.com/jolars/panache/commit/4ed243ab2c8d9d9d5a0bc404ffaccf44c9b28ea7))
- **extensions:** add `space_reference_links` extension ([`309739d`](https://github.com/jolars/panache/commit/309739dbaf54dc84d588fbc45285bcb96795177e))
- **extensions:** add `wikilinks_title_after/before_pipe` ([`49500f1`](https://github.com/jolars/panache/commit/49500f12b27851789942b18b13db68d4fd691726))

### Bug Fixes
- **parser:** reject bare multi-word fence info in Pandoc ([`395b000`](https://github.com/jolars/panache/commit/395b0008c0a46f7a490d982f793f2dbe0f3a7737))
- **parser:** peel line prefix after a hashpipe block scalar ([`e246d30`](https://github.com/jolars/panache/commit/e246d30ca7aedf6cc96707dd30a14247f4736760))
- **parser:** don't start list at continuation for footnote def ([`9494b14`](https://github.com/jolars/panache/commit/9494b143e69cdb8d02ab99ad88b087ff9970a8ee)), closes [#348](https://github.com/jolars/panache/issues/348)
- **parser:** detect grid borders on dispatch line inside list items ([`e7fa051`](https://github.com/jolars/panache/commit/e7fa05124e3b4c2d14aceb13ce154bda022270e4))
- **parser:** lift tables and fenced divs from list-item content ([`6f3821c`](https://github.com/jolars/panache/commit/6f3821c4d7bedbcd47d56ad0851eac015f05adcd))

### Performance Improvements
- **parser:** gate table detection before whole-buffer strip ([`f27fc80`](https://github.com/jolars/panache/commit/f27fc80f0e2b4fa7a351d35d0a7195e048ca666c))

## [editors/code: 2.45.0](https://github.com/jolars/panache/compare/panache-code-v2.44.0...panache-code-v2.45.0) (2026-06-07)

### Dependencies
- updated panache to v2.52.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).