### PR TITLE
fix: GFM and CommonMark pipe tables no longer get 2-space top-level indent

### DIFF
--- a/crates/panache-formatter/src/formatter/tables.rs
+++ b/crates/panache-formatter/src/formatter/tables.rs
@@ -1,4 +1,4 @@
-use crate::config::{Config, WrapMode};
+use crate::config::{Config, Flavor, WrapMode};
 use crate::formatter::inline::format_inline_node;
 use crate::formatter::inline_layout::wrap_text_first_fit;
 use crate::formatter::sentence_wrap::{ResolvedProfile, resolve_profile, split_sentence_text};
@@ -714,7 +714,11 @@ pub fn format_pipe_table(node: &SyntaxNode, config: &Config, indent: usize) -> S
         output.push_str(&formatted_caption);
         output.push('\n');
     }
-    let block_indent = if indent == 0 {
+    // GFM and CommonMark keep top-level tables flush at column zero; those
+    // flavors do not self-indent pipe tables.  Pandoc/Quarto/RMarkdown use a
+    // two-space indent so the table is rendered as a block element.
+    let self_indents = !matches!(config.flavor, Flavor::Gfm | Flavor::CommonMark);
+    let block_indent = if indent == 0 && self_indents {
         TABLE_BLOCK_INDENT
     } else {
         indent


### PR DESCRIPTION
## Problem

Closes #344.

With `flavor = "gfm"` (or `"commonmark"`), top-level pipe tables were rewritten with a two-space leading indent on every row:

```markdown
  | Status | Description |
  | --- | --- |
  | `active` | usable |
```

Expected (flush at column zero, matching Prettier and other GFM tools):

```markdown
| Status | Description |
| --- | --- |
| `active` | usable |
```

The indent was idempotent (no drift on repeated passes), but it still produced unwanted diff churn and made panache unusable as a drop-in formatter for table-heavy GFM documents.

## Root cause

`format_pipe_table` applied `TABLE_BLOCK_INDENT = 2` unconditionally when the caller passed `indent = 0` (top-level context) with no check on the active flavor. Only Pandoc/Quarto/RMarkdown need the self-indent as a block-element convention; GFM and CommonMark do not.

## Fix

Check `config.flavor` before applying `TABLE_BLOCK_INDENT`:

```rust
let self_indents = !matches!(config.flavor, Flavor::Gfm | Flavor::CommonMark);
let block_indent = if indent == 0 && self_indents {
    TABLE_BLOCK_INDENT
} else {
    indent
};
```

GFM and CommonMark top-level tables now stay at column zero.
Pandoc/Quarto/RMarkdown behaviour is unchanged.