### PR TITLE
feat(formatter): add `table-indent` style option

### DIFF
--- a/crates/panache-formatter/src/config.rs
+++ b/crates/panache-formatter/src/config.rs
@@ -26,6 +26,17 @@ pub enum MathDelimiterStyle {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TableIndentStyle {
+    /// Indent pipe, simple, and multiline tables by two columns at the top
+    /// level (default).
+    #[default]
+    Unified,
+    /// Keep pipe tables flush at column 0, as Pandoc's pipe-table writers do;
+    /// simple and multiline tables stay indented two columns.
+    Pandoc,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum TabStopMode {
     /// Normalize tabs to spaces (4-column tab stop).
     #[default]
@@ -166,6 +177,7 @@ pub struct Config {
     pub line_width: usize,
     pub math_indent: usize,
     pub math_delimiter_style: MathDelimiterStyle,
+    pub table_indent: TableIndentStyle,
     pub tab_stops: TabStopMode,
     pub tab_width: usize,
     pub wrap: Option<WrapMode>,
@@ -197,6 +209,7 @@ impl Default for Config {
             line_width: 80,
             math_indent: 0,
             math_delimiter_style: MathDelimiterStyle::default(),
+            table_indent: TableIndentStyle::default(),
             tab_stops: TabStopMode::Normalize,
             tab_width: 4,
             wrap: Some(WrapMode::Reflow),
@@ -240,6 +253,11 @@ impl ConfigBuilder {
 
     pub fn tab_stops(mut self, mode: TabStopMode) -> Self {
         self.config.tab_stops = mode;
+        self
+    }
+
+    pub fn table_indent(mut self, style: TableIndentStyle) -> Self {
+        self.config.table_indent = style;
         self
     }
 

--- a/crates/panache-formatter/src/formatter/tables.rs
+++ b/crates/panache-formatter/src/formatter/tables.rs
@@ -1,4 +1,4 @@
-use crate::config::{Config, WrapMode};
+use crate::config::{Config, TableIndentStyle, WrapMode};
 use crate::formatter::inline::format_inline_node;
 use crate::formatter::inline_layout::wrap_text_first_fit;
 use crate::formatter::sentence_wrap::{ResolvedProfile, resolve_profile, split_sentence_text};
@@ -10,7 +10,9 @@ use unicode_width::UnicodeWidthStr;
 /// Default indent (in spaces) for table types that self-indent at the top level
 /// (pipe, simple, multiline). Grid tables instead honor the container indent
 /// threaded from the dispatcher so a top-level grid sits at column 0 -- pandoc
-/// rejects an indented `+---+` border. See `format_grid_table`.
+/// rejects an indented `+---+` border. See `format_grid_table`. Pipe tables
+/// also drop the self-indent when `table-indent = "pandoc"`; see
+/// `format_pipe_table`.
 const TABLE_BLOCK_INDENT: usize = 2;
 
 fn indent_table_block(block: &str, indent: usize) -> String {
@@ -714,10 +716,12 @@ pub fn format_pipe_table(node: &SyntaxNode, config: &Config, indent: usize) -> S
         output.push_str(&formatted_caption);
         output.push('\n');
     }
-    let block_indent = if indent == 0 {
-        TABLE_BLOCK_INDENT
-    } else {
-        indent
+    // A top-level pipe table self-indents two columns under the unified style;
+    // under the pandoc style it stays flush (`indent == 0`) like pandoc's pipe
+    // writers. Nested tables always honor the container indent threaded in.
+    let block_indent = match config.table_indent {
+        TableIndentStyle::Unified if indent == 0 => TABLE_BLOCK_INDENT,
+        _ => indent,
     };
     indent_table_block(&output, block_indent)
 }

--- a/crates/panache-formatter/src/lib.rs
+++ b/crates/panache-formatter/src/lib.rs
@@ -13,6 +13,7 @@ pub use config::LineEnding;
 pub use config::MathDelimiterStyle;
 pub use config::ParserOptions;
 pub use config::TabStopMode;
+pub use config::TableIndentStyle;
 pub use config::WrapMode;
 pub use formatter::ExternalCodeBlock;
 pub use formatter::FormattedCodeMap;

--- a/crates/panache-formatter/tests/format/tables.rs
+++ b/crates/panache-formatter/tests/format/tables.rs
@@ -1,5 +1,5 @@
-use panache_formatter::config::WrapMode;
-use panache_formatter::{Config, format};
+use panache_formatter::config::{TableIndentStyle, WrapMode};
+use panache_formatter::{Config, ConfigBuilder, format};
 
 #[test]
 fn test_basic_pipe_table() {
@@ -431,5 +431,44 @@ fn test_simple_table_compresses_oversized_separator_columns() {
     let expected = "    Right     Left\n  -------     ----\n       12     12\n      123     123\n        1     1\n";
 
     let result = format(input, None, None);
+    assert_eq!(result, expected);
+}
+
+// `table-indent = "pandoc"` keeps a top-level pipe table flush at column 0.
+#[test]
+fn test_pipe_table_pandoc_indent_flush() {
+    let input = "| A | B |\n|---|---|\n| C | D |";
+    let expected = "| A   | B   |\n| --- | --- |\n| C   | D   |\n";
+
+    let config = ConfigBuilder::default()
+        .table_indent(TableIndentStyle::Pandoc)
+        .build();
+    let result = format(input, Some(config.clone()), None);
+    assert_eq!(result, expected);
+    assert_eq!(format(&result, Some(config), None), result);
+}
+
+#[test]
+fn test_pipe_table_unified_indent_is_default() {
+    let input = "| A | B |\n|---|---|\n| C | D |";
+    let expected = "  | A   | B   |\n  | --- | --- |\n  | C   | D   |\n";
+
+    let config = ConfigBuilder::default()
+        .table_indent(TableIndentStyle::Unified)
+        .build();
+    let result = format(input, Some(config), None);
+    assert_eq!(result, expected);
+}
+
+// The pandoc style flushes only pipe tables; simple tables stay indented.
+#[test]
+fn test_pandoc_indent_leaves_simple_table_indented() {
+    let input = "   Right     Left\n -------     --------------\n     12         12\n   123          123\n       1        1\n";
+    let expected = "    Right     Left\n  -------     ----\n       12     12\n      123     123\n        1     1\n";
+
+    let config = ConfigBuilder::default()
+        .table_indent(TableIndentStyle::Pandoc)
+        .build();
+    let result = format(input, Some(config), None);
     assert_eq!(result, expected);
 }

--- a/docs/guide/configuration.qmd
+++ b/docs/guide/configuration.qmd
@@ -294,6 +294,7 @@ Formatting style preferences are organized under the `[format]` section:
 wrap = "reflow"
 math-delimiter-style = "preserve"
 math-indent = 0
+table-indent = "unified"
 tab-stops = "normalize"
 tab-width = 4
 ```
@@ -384,6 +385,28 @@ Math delimiter styles:
 
 The `math-indent` field specifies indentation (in spaces) for display math
 blocks. Default is 0.
+
+### Table Indentation
+
+Control how tables are indented at the top level of a document:
+
+```toml
+[format]
+table-indent = "unified"
+```
+
+`unified`
+:   Indent pipe, simple, and multiline tables by two columns (default)
+
+`pandoc`
+:   Keep pipe tables flush at column 0, as Pandoc's pipe-table writers do; simple
+    and multiline tables stay indented two columns
+
+This setting affects only top-level tables. A table nested inside a list item or
+other container still honors the container's content indentation.
+
+The `-o table-indent=<STYLE>` flag on `panache format` can override this setting
+for a single invocation, e.g. `panache format -o table-indent=pandoc`.
 
 ### Tab Stops
 

--- a/docs/guide/formatting.qmd
+++ b/docs/guide/formatting.qmd
@@ -543,6 +543,13 @@ blocks are indented by two spaces. Grid tables are left at the margin (column
 0): Pandoc only recognizes a grid table when its `+---+` border starts at column
 0, so an indented border would be parsed as a paragraph instead.
 
+The two-space indent for pipe tables is configurable. Setting `table-indent =
+"pandoc"` under `[format]` keeps pipe tables flush at column 0 to match Pandoc's
+pipe-table writers (and grid tables, which are always flush); simple and
+multiline tables stay indented. See
+[Table Indentation](configuration.qmd#table-indentation) for details. The
+examples below show the default `unified` style.
+
 ### Pipe Tables
 
 Pipe tables are normalized to have consistent spacing and alignment. The header

--- a/panache.schema.json
+++ b/panache.schema.json
@@ -250,6 +250,10 @@
           "minimum": 0,
           "type": "integer"
         },
+        "table-indent": {
+          "$ref": "#/$defs/TableIndentStyle",
+          "description": "Indentation style for top-level tables"
+        },
         "wrap": {
           "anyOf": [
             {
@@ -275,6 +279,21 @@
         {
           "const": "preserve",
           "description": "Preserve tabs in literal code spans/blocks.",
+          "type": "string"
+        }
+      ]
+    },
+    "TableIndentStyle": {
+      "description": "Indentation style for tables at the top level of a document.",
+      "oneOf": [
+        {
+          "const": "unified",
+          "description": "Indent pipe, simple, and multiline tables by two columns (default).",
+          "type": "string"
+        },
+        {
+          "const": "pandoc",
+          "description": "Keep pipe tables flush at column 0, as Pandoc's pipe-table writers do;\nsimple and multiline tables stay indented two columns.",
           "type": "string"
         }
       ]

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,7 @@ pub use types::LintConfig;
 pub use types::MathDelimiterStyle;
 pub use types::NoBreakAbbreviations;
 pub use types::TabStopMode;
+pub use types::TableIndentStyle;
 pub use types::WrapMode;
 
 // Globset forms (the engine `GlobMatcher` is built on): `**/<dir>/**` excludes
@@ -1179,6 +1180,31 @@ mod tests {
             .expect_err("typo'd [format] key must error");
         assert!(
             err.to_string().contains("wrapp"),
+            "error must name the offending key: {err}"
+        );
+    }
+
+    #[test]
+    fn table_indent_defaults_to_unified() {
+        let cfg = parse_config_str("", Path::new("panache.toml")).expect("empty config parses");
+        assert_eq!(cfg.table_indent, TableIndentStyle::Unified);
+    }
+
+    #[test]
+    fn table_indent_pandoc_parses_from_format_section() {
+        let toml = "[format]\ntable-indent = \"pandoc\"\n";
+        let cfg = parse_config_str(toml, Path::new("panache.toml"))
+            .expect("table-indent = pandoc must parse");
+        assert_eq!(cfg.table_indent, TableIndentStyle::Pandoc);
+    }
+
+    #[test]
+    fn unknown_table_indent_value_is_rejected() {
+        let toml = "[format]\ntable-indent = \"flush\"\n";
+        let err = parse_config_str(toml, Path::new("panache.toml"))
+            .expect_err("unknown table-indent value must error");
+        assert!(
+            err.to_string().contains("table-indent"),
             "error must name the offending key: {err}"
         );
     }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -238,6 +238,18 @@ pub enum TabStopMode {
     Preserve,
 }
 
+/// Indentation style for tables at the top level of a document.
+#[derive(Debug, Clone, Copy, Deserialize, JsonSchema, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum TableIndentStyle {
+    /// Indent pipe, simple, and multiline tables by two columns (default).
+    #[default]
+    Unified,
+    /// Keep pipe tables flush at column 0, as Pandoc's pipe-table writers do;
+    /// simple and multiline tables stay indented two columns.
+    Pandoc,
+}
+
 /// User-supplied no-break abbreviations for sentence wrapping.
 ///
 /// Accepts either a flat list applied to every document, or a table keyed by
@@ -300,6 +312,8 @@ pub struct StyleConfig {
     pub math_delimiter_style: MathDelimiterStyle,
     /// Math indentation (spaces)
     pub math_indent: usize,
+    /// Indentation style for top-level tables
+    pub table_indent: TableIndentStyle,
     /// Tab stop handling (normalize or preserve)
     pub tab_stops: TabStopMode,
     /// Tab width for expanding tabs when normalizing
@@ -328,6 +342,7 @@ impl Default for StyleConfig {
             blank_lines: BlankLines::Collapse,
             math_delimiter_style: MathDelimiterStyle::default(),
             math_indent: 0,
+            table_indent: TableIndentStyle::default(),
             tab_stops: TabStopMode::Normalize,
             tab_width: 4,
             built_in_greedy_wrap: true,
@@ -751,6 +766,7 @@ impl RawConfig {
                 blank_lines: self.blank_lines,
                 math_delimiter_style: self.math_delimiter_style,
                 math_indent: self.math_indent,
+                table_indent: TableIndentStyle::default(),
                 tab_stops: self.tab_stops,
                 tab_width: self.tab_width,
                 built_in_greedy_wrap: true,
@@ -773,6 +789,7 @@ impl RawConfig {
             blank_lines: style.blank_lines,
             math_delimiter_style: style.math_delimiter_style,
             math_indent: style.math_indent,
+            table_indent: style.table_indent,
             tab_stops: style.tab_stops,
             tab_width: style.tab_width,
             formatters: resolve_formatters(self.formatters),
@@ -987,6 +1004,7 @@ pub struct Config {
     pub line_width: usize,
     pub math_indent: usize,
     pub math_delimiter_style: MathDelimiterStyle,
+    pub table_indent: TableIndentStyle,
     pub tab_stops: TabStopMode,
     pub tab_width: usize,
     pub wrap: Option<WrapMode>,
@@ -1048,6 +1066,7 @@ impl Default for Config {
             line_width: 80,
             math_indent: 0,
             math_delimiter_style: MathDelimiterStyle::default(),
+            table_indent: TableIndentStyle::default(),
             tab_stops: TabStopMode::Normalize,
             tab_width: 4,
             wrap: Some(WrapMode::Reflow),

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -29,6 +29,10 @@ fn to_formatter_config(config: &Config) -> panache_formatter::Config {
         crate::config::TabStopMode::Normalize => panache_formatter::TabStopMode::Normalize,
         crate::config::TabStopMode::Preserve => panache_formatter::TabStopMode::Preserve,
     };
+    let table_indent = match config.table_indent {
+        crate::config::TableIndentStyle::Unified => panache_formatter::TableIndentStyle::Unified,
+        crate::config::TableIndentStyle::Pandoc => panache_formatter::TableIndentStyle::Pandoc,
+    };
     let wrap = config.wrap.as_ref().map(|wrap| match wrap {
         crate::config::WrapMode::Preserve => panache_formatter::WrapMode::Preserve,
         crate::config::WrapMode::Reflow => panache_formatter::WrapMode::Reflow,
@@ -90,6 +94,7 @@ fn to_formatter_config(config: &Config) -> panache_formatter::Config {
         line_width: config.line_width,
         math_indent: config.math_indent,
         math_delimiter_style,
+        table_indent,
         tab_stops,
         tab_width: config.tab_width,
         wrap,

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use cache::{
 };
 use cli::{Cli, CliFlavor, ColorMode, Commands, DebugChecks, DebugCommands, ParseOutput};
 use diagnostic_renderer::print_diagnostics;
-use panache::config::{Flavor, WrapMode};
+use panache::config::{Flavor, TableIndentStyle, WrapMode};
 
 impl From<CliFlavor> for Flavor {
     fn from(value: CliFlavor) -> Self {
@@ -69,6 +69,18 @@ fn apply_format_overrides(cfg: &mut panache::Config, overrides: &[String]) -> Re
                 };
                 cfg.wrap = Some(mode);
             }
+            "table-indent" => {
+                let style = match value {
+                    "unified" => TableIndentStyle::Unified,
+                    "pandoc" => TableIndentStyle::Pandoc,
+                    other => {
+                        return Err(format!(
+                            "invalid value for `table-indent`: `{other}` (expected one of: unified, pandoc)"
+                        ));
+                    }
+                };
+                cfg.table_indent = style;
+            }
             ext_key if ext_key.starts_with("extensions.") => {
                 let name = ext_key["extensions.".len()..].trim();
                 if name.is_empty() {
@@ -89,7 +101,7 @@ fn apply_format_overrides(cfg: &mut panache::Config, overrides: &[String]) -> Re
             }
             other => {
                 return Err(format!(
-                    "unknown config key in --option: `{other}` (supported: line-width, wrap, extensions.<name>)"
+                    "unknown config key in --option: `{other}` (supported: line-width, wrap, table-indent, extensions.<name>)"
                 ));
             }
         }
@@ -2412,6 +2424,23 @@ mod tests {
             let mut c = cfg();
             let err = apply_format_overrides(&mut c, &["nope=1".to_string()]).unwrap_err();
             assert!(err.contains("unknown config key"), "{err}");
+        }
+
+        #[test]
+        fn table_indent_override_sets_pandoc_style() {
+            use panache::config::TableIndentStyle;
+            let mut c = cfg();
+            assert_eq!(c.table_indent, TableIndentStyle::Unified);
+            apply_format_overrides(&mut c, &["table-indent=pandoc".to_string()]).unwrap();
+            assert_eq!(c.table_indent, TableIndentStyle::Pandoc);
+        }
+
+        #[test]
+        fn table_indent_override_rejects_unknown_value() {
+            let mut c = cfg();
+            let err =
+                apply_format_overrides(&mut c, &["table-indent=flush".to_string()]).unwrap_err();
+            assert!(err.contains("invalid value for `table-indent`"), "{err}");
         }
     }
 }

--- a/tests/fixtures/cases/issue_344_pipe_table_indent_pandoc/expected.md
+++ b/tests/fixtures/cases/issue_344_pipe_table_indent_pandoc/expected.md
@@ -1,0 +1,3 @@
+| Status   | Description |
+| -------- | ----------- |
+| `active` | usable      |

--- a/tests/fixtures/cases/issue_344_pipe_table_indent_pandoc/input.md
+++ b/tests/fixtures/cases/issue_344_pipe_table_indent_pandoc/input.md
@@ -1,0 +1,3 @@
+| Status | Description |
+| --- | --- |
+| `active` | usable |

--- a/tests/fixtures/cases/issue_344_pipe_table_indent_pandoc/panache.toml
+++ b/tests/fixtures/cases/issue_344_pipe_table_indent_pandoc/panache.toml
@@ -1,0 +1,5 @@
+flavor = "gfm"
+
+[format]
+wrap = "preserve"
+table-indent = "pandoc"

--- a/tests/golden_cases.rs
+++ b/tests/golden_cases.rs
@@ -416,6 +416,7 @@ golden_test_cases!(
     issue_280_hashpipe_yaml_tag_and_dotted_key_idempotency,
     issue_286_fenced_div_collapse_blanks,
     issue_332_space_after_inline_code_in_strong,
+    issue_344_pipe_table_indent_pandoc,
     writer_autolinks,
     writer_blockquote_not,
     writer_definition_lists_multiblock,


### PR DESCRIPTION
Resolves #344 (alternative to #345)

This PR takes the configurable route instead of changing the default, per https://github.com/jolars/panache/issues/344#issuecomment-4604755137.

Adds a `[format] table-indent` setting:

- `unified` (default): pipe, simple, and multiline tables indented two columns. Identical to today's behavior, so existing users see no diff churn.
- `pandoc`: pipe tables kept flush at column 0, matching pandoc's pipe-table writers (`pandoc -f gfm -t gfm`). Simple and multiline tables stay indented (pandoc indents those), and grid tables remain flush as before. 

The only behavioral change is in `format_pipe_table`, gated on the setting. Everything else is config plumbing. Also exposed as `-o table-indent=<style>` for single invocations, alongside `wrap`.

Includes formatter unit tests, host config-parse tests, CLI-override tests, an end-to-end golden case (`issue_344_pipe_table_indent_pandoc`), a regenerated `panache.schema.json`, and docs (a new "Table Indentation" section in the configuration guide plus a note in the formatting guide).