### PR TITLE
chore(release): v2.53.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "f010b4157b30affb4201fcfbccdc5b57ca56992c",
+  "baseline-sha": "b9927fa1c73e8e3696dcc7bc6e5d0d73f88afb31",
   "release-targets": [
     {
       "path": ".",
-      "version": "2.52.0",
-      "tag": "v2.52.0"
+      "version": "2.53.0",
+      "tag": "v2.53.0"
     },
     {
       "path": "crates/panache-dprint",
@@ -14,18 +14,18 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.10.0",
-      "tag": "panache-formatter-v0.10.0"
+      "version": "0.11.0",
+      "tag": "panache-formatter-v0.11.0"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.15.0",
-      "tag": "panache-parser-v0.15.0"
+      "version": "0.16.0",
+      "tag": "panache-parser-v0.16.0"
     },
     {
       "path": "editors/code",
-      "version": "2.45.0",
-      "tag": "panache-code-v2.45.0"
+      "version": "2.46.0",
+      "tag": "panache-code-v2.46.0"
     },
     {
       "path": "editors/zed",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [2.53.0](https://github.com/jolars/panache/compare/v2.52.0...v2.53.0) (2026-06-10)
+
+### Features
+- **formatter:** enable wrap modes for folded yaml scalars ([`327f12c`](https://github.com/jolars/panache/commit/327f12cc8cc8f3d9ce8c48a8237c035811eda8a6))
+- **formatter:** wrap folded YAML scalars ([`b8dc1c0`](https://github.com/jolars/panache/commit/b8dc1c07497c0b6f010df58d1a302b775d7171c9))
+- **parser:** condition YAML validation on consumer profiles ([`f77f153`](https://github.com/jolars/panache/commit/f77f153a7ad8d3339e31395f2b9b76535c01dff5))
+
+### Bug Fixes
+- **formatter:** add span-aware grid table formatting ([`75e5b2e`](https://github.com/jolars/panache/commit/75e5b2e0a49f93e617f5bbf8474de6ce22cca014)), closes [#359](https://github.com/jolars/panache/issues/359)
+- **parser:** report YAML required-simple-key errors ([`f8f804c`](https://github.com/jolars/panache/commit/f8f804c89aceabced19e6063932f4621882b3f61))
+- **lsp:** answer panicking request handlers with InternalError ([`c4dc85d`](https://github.com/jolars/panache/commit/c4dc85d7244b33c9af18354669e672cda8e6f2f2))
+- **formatter:** don't indent multi-line YAML scalar ([`b9927fa`](https://github.com/jolars/panache/commit/b9927fa1c73e8e3696dcc7bc6e5d0d73f88afb31))
+- **lsp:** adopt LogOutputChannel for vscode-languageclient 10 ([`ffd61cc`](https://github.com/jolars/panache/commit/ffd61cccaad08d418a06b4b06e30f0803b122c4c))
+
+### Performance Improvements
+- **lsp:** avoid reparse on formatting ([`95330af`](https://github.com/jolars/panache/commit/95330afd4599608d58901e604a2dc634456b04d0))
+- **lsp:** address cross-file leak and `project_graph` invalidation ([`bdf45f9`](https://github.com/jolars/panache/commit/bdf45f95c1994a30965d5ea0b1aeba711e59693d))
+- cache external formatter blocks ([`d6b81f9`](https://github.com/jolars/panache/commit/d6b81f98bcda6c95ee0d50a46d2dae5fd66abb64))
+- **cli:** use shared thread budget for format/lint of multiple files ([`83aa8ec`](https://github.com/jolars/panache/commit/83aa8ec79ebf27aa5daf3546d3f664944379f339))
+- **cli:** share one external-tool thread budget ([`91a61e0`](https://github.com/jolars/panache/commit/91a61e0b21ec76ae8c1dc1652a45a0e649101c98))
+- **linter:** run external linters across languages concurrently ([`02c1e38`](https://github.com/jolars/panache/commit/02c1e38ceb8f17f1334f4fb1b188bb775a01627f))
+
+### Dependencies
+- updated crates/panache-formatter to v0.11.0
+- updated crates/panache-parser to v0.16.0
+
 ## [2.52.0](https://github.com/jolars/panache/compare/v2.51.0...v2.52.0) (2026-06-07)
 
 This release comes with two major changes:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,13 +893,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1152,7 +1151,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "panache"
-version = "2.52.0"
+version = "2.53.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -1195,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "insta",
  "log",
@@ -1210,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "entities",
  "insta",
@@ -1485,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1508,9 +1507,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "roff"
@@ -1978,9 +1977,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -2054,9 +2053,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2067,9 +2066,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2077,9 +2076,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2090,9 +2089,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
 dependencies = [
  "unicode-ident",
 ]
@@ -2133,9 +2132,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.2"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+checksum = "c789537cf2f7f55be8e6192f92e464174ee55f91af622777f7f1ceb0dbccd03e"
 dependencies = [
  "libc",
 ]
@@ -2339,18 +2338,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "2.52.0"
+version = "2.53.0"
 edition.workspace = true
 readme = "README.md"
 description = "An LSP, formatter, and linter for Markdown, Quarto, and R Markdown"
@@ -47,8 +47,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.10.0" }
-panache-parser = { path = "crates/panache-parser", version = "0.15.0", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.11.0" }
+panache-parser = { path = "crates/panache-parser", version = "0.16.0", features = [
     "serde",
     "schema",
 ] }

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.11.0](https://github.com/jolars/panache/compare/panache-formatter-v0.10.0...panache-formatter-v0.11.0) (2026-06-10)
+
+### Features
+- **formatter:** enable wrap modes for folded yaml scalars ([`327f12c`](https://github.com/jolars/panache/commit/327f12cc8cc8f3d9ce8c48a8237c035811eda8a6))
+- **formatter:** wrap folded YAML scalars ([`b8dc1c0`](https://github.com/jolars/panache/commit/b8dc1c07497c0b6f010df58d1a302b775d7171c9))
+
+### Bug Fixes
+- **formatter:** don't indent multi-line YAML scalar ([`b9927fa`](https://github.com/jolars/panache/commit/b9927fa1c73e8e3696dcc7bc6e5d0d73f88afb31))
+- **formatter:** add span-aware grid table formatting ([`75e5b2e`](https://github.com/jolars/panache/commit/75e5b2e0a49f93e617f5bbf8474de6ce22cca014)), closes [#359](https://github.com/jolars/panache/issues/359)
+
+### Dependencies
+- updated crates/panache-parser to v0.16.0
+
 ## [0.10.0](https://github.com/jolars/panache/compare/panache-formatter-v0.9.0...panache-formatter-v0.10.0) (2026-06-07)
 
 ### Features

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 description = "Core formatting engine for Pandoc markdown, Quarto, and RMarkdown"
 license.workspace = true
@@ -13,7 +13,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.15.0" }
+panache-parser = { path = "../panache-parser", version = "0.16.0" }
 log = { version = "0.4.31", features = ["release_max_level_debug"] }
 rowan = "0.16.1"
 unicode-width = "0.2"

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.16.0](https://github.com/jolars/panache/compare/panache-parser-v0.15.0...panache-parser-v0.16.0) (2026-06-10)
+
+### Features
+- **parser:** condition YAML validation on consumer profiles ([`f77f153`](https://github.com/jolars/panache/commit/f77f153a7ad8d3339e31395f2b9b76535c01dff5))
+
+### Bug Fixes
+- **parser:** report YAML required-simple-key errors ([`f8f804c`](https://github.com/jolars/panache/commit/f8f804c89aceabced19e6063932f4621882b3f61))
+
 ## [0.15.0](https://github.com/jolars/panache/compare/panache-parser-v0.14.0...panache-parser-v0.15.0) (2026-06-07)
 
 ### Features

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 readme = "README.md"
 description = "Lossless CST parser and syntax wrappers for Pandoc markdown, Quarto, and RMarkdown"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.46.0](https://github.com/jolars/panache/compare/panache-code-v2.45.0...panache-code-v2.46.0) (2026-06-10)
+
+### Bug Fixes
+- **lsp:** adopt LogOutputChannel for vscode-languageclient 10 ([`ffd61cc`](https://github.com/jolars/panache/commit/ffd61cccaad08d418a06b4b06e30f0803b122c4c))
+
+### Dependencies
+- updated panache to v2.53.0
+
 ## [2.45.0](https://github.com/jolars/panache/compare/panache-code-v2.44.0...panache-code-v2.45.0) (2026-06-07)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "2.45.0",
+  "version": "2.46.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "2.52.0",
+  "version": "2.53.0",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "2.52.0",
-    "@panache-cli/linux-arm64-gnu": "2.52.0",
-    "@panache-cli/linux-x64-musl": "2.52.0",
-    "@panache-cli/linux-arm64-musl": "2.52.0",
-    "@panache-cli/darwin-x64": "2.52.0",
-    "@panache-cli/darwin-arm64": "2.52.0",
-    "@panache-cli/win32-x64": "2.52.0",
-    "@panache-cli/win32-arm64": "2.52.0"
+    "@panache-cli/linux-x64-gnu": "2.53.0",
+    "@panache-cli/linux-arm64-gnu": "2.53.0",
+    "@panache-cli/linux-x64-musl": "2.53.0",
+    "@panache-cli/linux-arm64-musl": "2.53.0",
+    "@panache-cli/darwin-x64": "2.53.0",
+    "@panache-cli/darwin-arm64": "2.53.0",
+    "@panache-cli/win32-x64": "2.53.0",
+    "@panache-cli/win32-arm64": "2.53.0"
   }
 }


### PR DESCRIPTION
## [panache: 2.53.0](https://github.com/jolars/panache/compare/v2.52.0...v2.53.0) (2026-06-10)

### Features
- **formatter:** enable wrap modes for folded yaml scalars ([`327f12c`](https://github.com/jolars/panache/commit/327f12cc8cc8f3d9ce8c48a8237c035811eda8a6))
- **formatter:** wrap folded YAML scalars ([`b8dc1c0`](https://github.com/jolars/panache/commit/b8dc1c07497c0b6f010df58d1a302b775d7171c9))
- **parser:** condition YAML validation on consumer profiles ([`f77f153`](https://github.com/jolars/panache/commit/f77f153a7ad8d3339e31395f2b9b76535c01dff5))

### Bug Fixes
- **formatter:** add span-aware grid table formatting ([`75e5b2e`](https://github.com/jolars/panache/commit/75e5b2e0a49f93e617f5bbf8474de6ce22cca014)), closes [#359](https://github.com/jolars/panache/issues/359)
- **parser:** report YAML required-simple-key errors ([`f8f804c`](https://github.com/jolars/panache/commit/f8f804c89aceabced19e6063932f4621882b3f61))
- **lsp:** answer panicking request handlers with InternalError ([`c4dc85d`](https://github.com/jolars/panache/commit/c4dc85d7244b33c9af18354669e672cda8e6f2f2))
- **formatter:** don't indent multi-line YAML scalar ([`b9927fa`](https://github.com/jolars/panache/commit/b9927fa1c73e8e3696dcc7bc6e5d0d73f88afb31))
- **lsp:** adopt LogOutputChannel for vscode-languageclient 10 ([`ffd61cc`](https://github.com/jolars/panache/commit/ffd61cccaad08d418a06b4b06e30f0803b122c4c))

### Performance Improvements
- **lsp:** avoid reparse on formatting ([`95330af`](https://github.com/jolars/panache/commit/95330afd4599608d58901e604a2dc634456b04d0))
- **lsp:** address cross-file leak and `project_graph` invalidation ([`bdf45f9`](https://github.com/jolars/panache/commit/bdf45f95c1994a30965d5ea0b1aeba711e59693d))
- cache external formatter blocks ([`d6b81f9`](https://github.com/jolars/panache/commit/d6b81f98bcda6c95ee0d50a46d2dae5fd66abb64))
- **cli:** use shared thread budget for format/lint of multiple files ([`83aa8ec`](https://github.com/jolars/panache/commit/83aa8ec79ebf27aa5daf3546d3f664944379f339))
- **cli:** share one external-tool thread budget ([`91a61e0`](https://github.com/jolars/panache/commit/91a61e0b21ec76ae8c1dc1652a45a0e649101c98))
- **linter:** run external linters across languages concurrently ([`02c1e38`](https://github.com/jolars/panache/commit/02c1e38ceb8f17f1334f4fb1b188bb775a01627f))

### Dependencies
- updated crates/panache-formatter to v0.11.0
- updated crates/panache-parser to v0.16.0

## [crates/panache-formatter: 0.11.0](https://github.com/jolars/panache/compare/panache-formatter-v0.10.0...panache-formatter-v0.11.0) (2026-06-10)

### Features
- **formatter:** enable wrap modes for folded yaml scalars ([`327f12c`](https://github.com/jolars/panache/commit/327f12cc8cc8f3d9ce8c48a8237c035811eda8a6))
- **formatter:** wrap folded YAML scalars ([`b8dc1c0`](https://github.com/jolars/panache/commit/b8dc1c07497c0b6f010df58d1a302b775d7171c9))

### Bug Fixes
- **formatter:** don't indent multi-line YAML scalar ([`b9927fa`](https://github.com/jolars/panache/commit/b9927fa1c73e8e3696dcc7bc6e5d0d73f88afb31))
- **formatter:** add span-aware grid table formatting ([`75e5b2e`](https://github.com/jolars/panache/commit/75e5b2e0a49f93e617f5bbf8474de6ce22cca014)), closes [#359](https://github.com/jolars/panache/issues/359)

### Dependencies
- updated crates/panache-parser to v0.16.0

## [crates/panache-parser: 0.16.0](https://github.com/jolars/panache/compare/panache-parser-v0.15.0...panache-parser-v0.16.0) (2026-06-10)

### Features
- **parser:** condition YAML validation on consumer profiles ([`f77f153`](https://github.com/jolars/panache/commit/f77f153a7ad8d3339e31395f2b9b76535c01dff5))

### Bug Fixes
- **parser:** report YAML required-simple-key errors ([`f8f804c`](https://github.com/jolars/panache/commit/f8f804c89aceabced19e6063932f4621882b3f61))

## [editors/code: 2.46.0](https://github.com/jolars/panache/compare/panache-code-v2.45.0...panache-code-v2.46.0) (2026-06-10)

### Bug Fixes
- **lsp:** adopt LogOutputChannel for vscode-languageclient 10 ([`ffd61cc`](https://github.com/jolars/panache/commit/ffd61cccaad08d418a06b4b06e30f0803b122c4c))

### Dependencies
- updated panache to v2.53.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).