### PR TITLE
chore(release): v2.54.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "b9927fa1c73e8e3696dcc7bc6e5d0d73f88afb31",
+  "baseline-sha": "ac1f18b2b0a9e89d453f2a2f02fa91170c54fcb8",
   "release-targets": [
     {
       "path": ".",
-      "version": "2.53.0",
-      "tag": "v2.53.0"
+      "version": "2.54.0",
+      "tag": "v2.54.0"
     },
     {
       "path": "crates/panache-dprint",
@@ -14,23 +14,45 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.11.0",
-      "tag": "panache-formatter-v0.11.0"
+      "version": "0.12.0",
+      "tag": "panache-formatter-v0.12.0"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.16.0",
-      "tag": "panache-parser-v0.16.0"
+      "version": "0.17.0",
+      "tag": "panache-parser-v0.17.0"
     },
     {
       "path": "editors/code",
-      "version": "2.46.0",
-      "tag": "panache-code-v2.46.0"
+      "version": "2.47.0",
+      "tag": "panache-code-v2.47.0"
     },
     {
       "path": "editors/zed",
       "version": "2.35.0",
       "tag": "panache-zed-v2.35.0"
+    }
+  ],
+  "pending-release-targets": [
+    {
+      "path": ".",
+      "version": "2.54.0",
+      "tag": "v2.54.0"
+    },
+    {
+      "path": "crates/panache-formatter",
+      "version": "0.12.0",
+      "tag": "panache-formatter-v0.12.0"
+    },
+    {
+      "path": "crates/panache-parser",
+      "version": "0.17.0",
+      "tag": "panache-parser-v0.17.0"
+    },
+    {
+      "path": "editors/code",
+      "version": "2.47.0",
+      "tag": "panache-code-v2.47.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [2.54.0](https://github.com/jolars/panache/compare/v2.53.0...v2.54.0) (2026-06-13)
+
+### Features
+- **formatter:** treat `vignette` yaml field as verbatim ([`f9d7c5a`](https://github.com/jolars/panache/commit/f9d7c5adb92df1cc8d364aba14e7a24f2651237a)), closes [#366](https://github.com/jolars/panache/issues/366)
+- **lsp:** flag broken project manifests on their own URI ([`af5c288`](https://github.com/jolars/panache/commit/af5c288cf62f9631096e71ad25c4bcf618fb43d2))
+- **formatter:** break math binary chains outside relations ([`dde4511`](https://github.com/jolars/panache/commit/dde4511dc9c58df82fd9fdf762c2e7b2fc35f8d4))
+- **formatter:** nest binary breaks under math relation chains ([`0128da4`](https://github.com/jolars/panache/commit/0128da426a5878518efe60533916d669272e34ef))
+- **formatter:** break over-width display math at relations ([`9d7c2e5`](https://github.com/jolars/panache/commit/9d7c2e5ba9f0c41ffc50add0c72ed47159e37138))
+- **parser:** tokenize math delimiters and punctuation ([`7249710`](https://github.com/jolars/panache/commit/7249710c2c983f651358488b991c15d095b256ba))
+- **formatter:** space math command operators ([`1e43f25`](https://github.com/jolars/panache/commit/1e43f251b3f691d1e38bb29f2a2aaa261fac07e9))
+- **formatter:** precedence-aware math operator spacing ([`adbebe0`](https://github.com/jolars/panache/commit/adbebe06f1f82fa89b9275dc9a13ff45e0eb8f0b))
+- **formatter:** don't escape `|` in commonmark ([`0092e6c`](https://github.com/jolars/panache/commit/0092e6c342c4900dda952fdce8f31b37d2de5d60)), ref [#367](https://github.com/jolars/panache/issues/367)
+
+### Bug Fixes
+- **parser:** claim caption-led table as list item's first line ([`ac1f18b`](https://github.com/jolars/panache/commit/ac1f18b2b0a9e89d453f2a2f02fa91170c54fcb8))
+- **formatter:** keep blockquote prefix on quoted tables ([`b9f7d2a`](https://github.com/jolars/panache/commit/b9f7d2affe4d8a5bb453144d248163e2c7a0d8f3))
+- **formatter:** dedent indented code in list items ([`bf14ecc`](https://github.com/jolars/panache/commit/bf14eccf416453ace37947fefec2716791ad45b7))
+- **formatter:** wrap task-item text at content column ([`42ecf70`](https://github.com/jolars/panache/commit/42ecf705b185cbcdb1c02d191c08246f70c3740a))
+- **formatter:** nest task-list children at content column ([`d6fb32b`](https://github.com/jolars/panache/commit/d6fb32bd58f87b4bd5de5e5657776f20796cdece))
+- **formatter:** drop stray blank line after hashpipe block scalar ([`c56f60f`](https://github.com/jolars/panache/commit/c56f60f17821fa8db24045d33e06b98ed76d1ed5))
+- **parser:** keep table captions lossless inside containers ([`b04f65a`](https://github.com/jolars/panache/commit/b04f65aa33a365faf01bed3eff130e0f4760ba92))
+- **parser:** treat deep list marker as lazy continuation ([`3fe17e0`](https://github.com/jolars/panache/commit/3fe17e09cb9515f7734f57b1013dc16181985816))
+
+### Performance Improvements
+- **parser:** make giant-blockquote parsing O(n) not O(n²) ([`4ec2cc0`](https://github.com/jolars/panache/commit/4ec2cc0011116fdba2bab588416cd636bac8445f))
+- **lsp:** fold symbol-usage index into a single CST walk ([`e5f4498`](https://github.com/jolars/panache/commit/e5f4498c31ac49f44ee874cb861c5d86fcc98f4c))
+
+### Dependencies
+- updated crates/panache-formatter to v0.12.0
+- updated crates/panache-parser to v0.17.0
+
 ## [2.53.0](https://github.com/jolars/panache/compare/v2.52.0...v2.53.0) (2026-06-10)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.2"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
  "console",
  "once_cell",
@@ -839,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "intrusive-collections"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e165935eba36cb526af8389effd2005a741adcbb6ed32106cc68e3f7b92960"
+checksum = "4b719c59241cfaac1042a6d26787e28ed7ee4a4e21a5a907786f54222d1b0062"
 dependencies = [
  "memoffset",
 ]
@@ -893,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.100"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1011,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memoffset"
@@ -1151,7 +1151,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "panache"
-version = "2.53.0"
+version = "2.54.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "insta",
  "log",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "entities",
  "insta",
@@ -1764,9 +1764,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "stable_deref_trait"
@@ -2035,9 +2035,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]
@@ -2053,9 +2053,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2066,9 +2066,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2076,9 +2076,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2089,9 +2089,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "2.53.0"
+version = "2.54.0"
 edition.workspace = true
 readme = "README.md"
 description = "An LSP, formatter, and linter for Markdown, Quarto, and R Markdown"
@@ -53,8 +53,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.11.0" }
-panache-parser = { path = "crates/panache-parser", version = "0.16.0", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.12.0" }
+panache-parser = { path = "crates/panache-parser", version = "0.17.0", features = [
     "serde",
     "schema",
 ] }

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.12.0](https://github.com/jolars/panache/compare/panache-formatter-v0.11.0...panache-formatter-v0.12.0) (2026-06-13)
+
+### Features
+- **formatter:** don't escape `|` in commonmark ([`0092e6c`](https://github.com/jolars/panache/commit/0092e6c342c4900dda952fdce8f31b37d2de5d60)), ref [#367](https://github.com/jolars/panache/issues/367)
+- **formatter:** treat `vignette` yaml field as verbatim ([`f9d7c5a`](https://github.com/jolars/panache/commit/f9d7c5adb92df1cc8d364aba14e7a24f2651237a)), closes [#366](https://github.com/jolars/panache/issues/366)
+- **formatter:** break math binary chains outside relations ([`dde4511`](https://github.com/jolars/panache/commit/dde4511dc9c58df82fd9fdf762c2e7b2fc35f8d4))
+- **formatter:** nest binary breaks under math relation chains ([`0128da4`](https://github.com/jolars/panache/commit/0128da426a5878518efe60533916d669272e34ef))
+- **formatter:** break over-width display math at relations ([`9d7c2e5`](https://github.com/jolars/panache/commit/9d7c2e5ba9f0c41ffc50add0c72ed47159e37138))
+- **parser:** tokenize math delimiters and punctuation ([`7249710`](https://github.com/jolars/panache/commit/7249710c2c983f651358488b991c15d095b256ba))
+- **formatter:** space math command operators ([`1e43f25`](https://github.com/jolars/panache/commit/1e43f251b3f691d1e38bb29f2a2aaa261fac07e9))
+- **formatter:** precedence-aware math operator spacing ([`adbebe0`](https://github.com/jolars/panache/commit/adbebe06f1f82fa89b9275dc9a13ff45e0eb8f0b))
+
+### Bug Fixes
+- **formatter:** keep blockquote prefix on quoted tables ([`b9f7d2a`](https://github.com/jolars/panache/commit/b9f7d2affe4d8a5bb453144d248163e2c7a0d8f3))
+- **formatter:** dedent indented code in list items ([`bf14ecc`](https://github.com/jolars/panache/commit/bf14eccf416453ace37947fefec2716791ad45b7))
+- **formatter:** wrap task-item text at content column ([`42ecf70`](https://github.com/jolars/panache/commit/42ecf705b185cbcdb1c02d191c08246f70c3740a))
+- **formatter:** nest task-list children at content column ([`d6fb32b`](https://github.com/jolars/panache/commit/d6fb32bd58f87b4bd5de5e5657776f20796cdece))
+- **formatter:** drop stray blank line after hashpipe block scalar ([`c56f60f`](https://github.com/jolars/panache/commit/c56f60f17821fa8db24045d33e06b98ed76d1ed5))
+
+### Dependencies
+- updated crates/panache-parser to v0.17.0
+
 ## [0.11.0](https://github.com/jolars/panache/compare/panache-formatter-v0.10.0...panache-formatter-v0.11.0) (2026-06-10)
 
 ### Features

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 include = [
     "/src/**/*",
@@ -18,7 +18,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.16.0" }
+panache-parser = { path = "../panache-parser", version = "0.17.0" }
 log = { version = "0.4.31", features = ["release_max_level_debug"] }
 rowan = "0.16.1"
 unicode-width = "0.2"

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.17.0](https://github.com/jolars/panache/compare/panache-parser-v0.16.0...panache-parser-v0.17.0) (2026-06-13)
+
+### Features
+- **parser:** tokenize math delimiters and punctuation ([`7249710`](https://github.com/jolars/panache/commit/7249710c2c983f651358488b991c15d095b256ba))
+
+### Bug Fixes
+- **parser:** claim caption-led table as list item's first line ([`ac1f18b`](https://github.com/jolars/panache/commit/ac1f18b2b0a9e89d453f2a2f02fa91170c54fcb8))
+- **parser:** keep table captions lossless inside containers ([`b04f65a`](https://github.com/jolars/panache/commit/b04f65aa33a365faf01bed3eff130e0f4760ba92))
+- **parser:** treat deep list marker as lazy continuation ([`3fe17e0`](https://github.com/jolars/panache/commit/3fe17e09cb9515f7734f57b1013dc16181985816))
+
+### Performance Improvements
+- **parser:** make giant-blockquote parsing O(n) not O(n²) ([`4ec2cc0`](https://github.com/jolars/panache/commit/4ec2cc0011116fdba2bab588416cd636bac8445f))
+
 ## [0.16.0](https://github.com/jolars/panache/compare/panache-parser-v0.15.0...panache-parser-v0.16.0) (2026-06-10)
 
 ### Features

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.16.0"
+version = "0.17.0"
 edition.workspace = true
 readme = "README.md"
 include = [

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.47.0](https://github.com/jolars/panache/compare/panache-code-v2.46.0...panache-code-v2.47.0) (2026-06-13)
+
+### Dependencies
+- updated panache to v2.54.0
+
 ## [2.46.0](https://github.com/jolars/panache/compare/panache-code-v2.45.0...panache-code-v2.46.0) (2026-06-10)
 
 ### Bug Fixes

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "2.46.0",
+  "version": "2.47.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -345,9 +345,9 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "miniz_oxide"
@@ -481,9 +481,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "spdx"

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "2.53.0",
+  "version": "2.54.0",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "2.53.0",
-    "@panache-cli/linux-arm64-gnu": "2.53.0",
-    "@panache-cli/linux-x64-musl": "2.53.0",
-    "@panache-cli/linux-arm64-musl": "2.53.0",
-    "@panache-cli/darwin-x64": "2.53.0",
-    "@panache-cli/darwin-arm64": "2.53.0",
-    "@panache-cli/win32-x64": "2.53.0",
-    "@panache-cli/win32-arm64": "2.53.0"
+    "@panache-cli/linux-x64-gnu": "2.54.0",
+    "@panache-cli/linux-arm64-gnu": "2.54.0",
+    "@panache-cli/linux-x64-musl": "2.54.0",
+    "@panache-cli/linux-arm64-musl": "2.54.0",
+    "@panache-cli/darwin-x64": "2.54.0",
+    "@panache-cli/darwin-arm64": "2.54.0",
+    "@panache-cli/win32-x64": "2.54.0",
+    "@panache-cli/win32-arm64": "2.54.0"
   }
 }


### PR DESCRIPTION
## [panache: 2.54.0](https://github.com/jolars/panache/compare/v2.53.0...v2.54.0) (2026-06-13)

### Features
- **formatter:** treat `vignette` yaml field as verbatim ([`f9d7c5a`](https://github.com/jolars/panache/commit/f9d7c5adb92df1cc8d364aba14e7a24f2651237a)), closes [#366](https://github.com/jolars/panache/issues/366)
- **lsp:** flag broken project manifests on their own URI ([`af5c288`](https://github.com/jolars/panache/commit/af5c288cf62f9631096e71ad25c4bcf618fb43d2))
- **formatter:** break math binary chains outside relations ([`dde4511`](https://github.com/jolars/panache/commit/dde4511dc9c58df82fd9fdf762c2e7b2fc35f8d4))
- **formatter:** nest binary breaks under math relation chains ([`0128da4`](https://github.com/jolars/panache/commit/0128da426a5878518efe60533916d669272e34ef))
- **formatter:** break over-width display math at relations ([`9d7c2e5`](https://github.com/jolars/panache/commit/9d7c2e5ba9f0c41ffc50add0c72ed47159e37138))
- **parser:** tokenize math delimiters and punctuation ([`7249710`](https://github.com/jolars/panache/commit/7249710c2c983f651358488b991c15d095b256ba))
- **formatter:** space math command operators ([`1e43f25`](https://github.com/jolars/panache/commit/1e43f251b3f691d1e38bb29f2a2aaa261fac07e9))
- **formatter:** precedence-aware math operator spacing ([`adbebe0`](https://github.com/jolars/panache/commit/adbebe06f1f82fa89b9275dc9a13ff45e0eb8f0b))
- **formatter:** don't escape `|` in commonmark ([`0092e6c`](https://github.com/jolars/panache/commit/0092e6c342c4900dda952fdce8f31b37d2de5d60)), ref [#367](https://github.com/jolars/panache/issues/367)

### Bug Fixes
- **parser:** claim caption-led table as list item's first line ([`ac1f18b`](https://github.com/jolars/panache/commit/ac1f18b2b0a9e89d453f2a2f02fa91170c54fcb8))
- **formatter:** keep blockquote prefix on quoted tables ([`b9f7d2a`](https://github.com/jolars/panache/commit/b9f7d2affe4d8a5bb453144d248163e2c7a0d8f3))
- **formatter:** dedent indented code in list items ([`bf14ecc`](https://github.com/jolars/panache/commit/bf14eccf416453ace37947fefec2716791ad45b7))
- **formatter:** wrap task-item text at content column ([`42ecf70`](https://github.com/jolars/panache/commit/42ecf705b185cbcdb1c02d191c08246f70c3740a))
- **formatter:** nest task-list children at content column ([`d6fb32b`](https://github.com/jolars/panache/commit/d6fb32bd58f87b4bd5de5e5657776f20796cdece))
- **formatter:** drop stray blank line after hashpipe block scalar ([`c56f60f`](https://github.com/jolars/panache/commit/c56f60f17821fa8db24045d33e06b98ed76d1ed5))
- **parser:** keep table captions lossless inside containers ([`b04f65a`](https://github.com/jolars/panache/commit/b04f65aa33a365faf01bed3eff130e0f4760ba92))
- **parser:** treat deep list marker as lazy continuation ([`3fe17e0`](https://github.com/jolars/panache/commit/3fe17e09cb9515f7734f57b1013dc16181985816))

### Performance Improvements
- **parser:** make giant-blockquote parsing O(n) not O(n²) ([`4ec2cc0`](https://github.com/jolars/panache/commit/4ec2cc0011116fdba2bab588416cd636bac8445f))
- **lsp:** fold symbol-usage index into a single CST walk ([`e5f4498`](https://github.com/jolars/panache/commit/e5f4498c31ac49f44ee874cb861c5d86fcc98f4c))

### Dependencies
- updated crates/panache-formatter to v0.12.0
- updated crates/panache-parser to v0.17.0

## [crates/panache-formatter: 0.12.0](https://github.com/jolars/panache/compare/panache-formatter-v0.11.0...panache-formatter-v0.12.0) (2026-06-13)

### Features
- **formatter:** don't escape `|` in commonmark ([`0092e6c`](https://github.com/jolars/panache/commit/0092e6c342c4900dda952fdce8f31b37d2de5d60)), ref [#367](https://github.com/jolars/panache/issues/367)
- **formatter:** treat `vignette` yaml field as verbatim ([`f9d7c5a`](https://github.com/jolars/panache/commit/f9d7c5adb92df1cc8d364aba14e7a24f2651237a)), closes [#366](https://github.com/jolars/panache/issues/366)
- **formatter:** break math binary chains outside relations ([`dde4511`](https://github.com/jolars/panache/commit/dde4511dc9c58df82fd9fdf762c2e7b2fc35f8d4))
- **formatter:** nest binary breaks under math relation chains ([`0128da4`](https://github.com/jolars/panache/commit/0128da426a5878518efe60533916d669272e34ef))
- **formatter:** break over-width display math at relations ([`9d7c2e5`](https://github.com/jolars/panache/commit/9d7c2e5ba9f0c41ffc50add0c72ed47159e37138))
- **parser:** tokenize math delimiters and punctuation ([`7249710`](https://github.com/jolars/panache/commit/7249710c2c983f651358488b991c15d095b256ba))
- **formatter:** space math command operators ([`1e43f25`](https://github.com/jolars/panache/commit/1e43f251b3f691d1e38bb29f2a2aaa261fac07e9))
- **formatter:** precedence-aware math operator spacing ([`adbebe0`](https://github.com/jolars/panache/commit/adbebe06f1f82fa89b9275dc9a13ff45e0eb8f0b))

### Bug Fixes
- **formatter:** keep blockquote prefix on quoted tables ([`b9f7d2a`](https://github.com/jolars/panache/commit/b9f7d2affe4d8a5bb453144d248163e2c7a0d8f3))
- **formatter:** dedent indented code in list items ([`bf14ecc`](https://github.com/jolars/panache/commit/bf14eccf416453ace37947fefec2716791ad45b7))
- **formatter:** wrap task-item text at content column ([`42ecf70`](https://github.com/jolars/panache/commit/42ecf705b185cbcdb1c02d191c08246f70c3740a))
- **formatter:** nest task-list children at content column ([`d6fb32b`](https://github.com/jolars/panache/commit/d6fb32bd58f87b4bd5de5e5657776f20796cdece))
- **formatter:** drop stray blank line after hashpipe block scalar ([`c56f60f`](https://github.com/jolars/panache/commit/c56f60f17821fa8db24045d33e06b98ed76d1ed5))

### Dependencies
- updated crates/panache-parser to v0.17.0

## [crates/panache-parser: 0.17.0](https://github.com/jolars/panache/compare/panache-parser-v0.16.0...panache-parser-v0.17.0) (2026-06-13)

### Features
- **parser:** tokenize math delimiters and punctuation ([`7249710`](https://github.com/jolars/panache/commit/7249710c2c983f651358488b991c15d095b256ba))

### Bug Fixes
- **parser:** claim caption-led table as list item's first line ([`ac1f18b`](https://github.com/jolars/panache/commit/ac1f18b2b0a9e89d453f2a2f02fa91170c54fcb8))
- **parser:** keep table captions lossless inside containers ([`b04f65a`](https://github.com/jolars/panache/commit/b04f65aa33a365faf01bed3eff130e0f4760ba92))
- **parser:** treat deep list marker as lazy continuation ([`3fe17e0`](https://github.com/jolars/panache/commit/3fe17e09cb9515f7734f57b1013dc16181985816))

### Performance Improvements
- **parser:** make giant-blockquote parsing O(n) not O(n²) ([`4ec2cc0`](https://github.com/jolars/panache/commit/4ec2cc0011116fdba2bab588416cd636bac8445f))

## [editors/code: 2.47.0](https://github.com/jolars/panache/compare/panache-code-v2.46.0...panache-code-v2.47.0) (2026-06-13)

### Dependencies
- updated panache to v2.54.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).