### PR TITLE
chore(release): v2.55.0 (+4 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "ac1f18b2b0a9e89d453f2a2f02fa91170c54fcb8",
+  "baseline-sha": "dabe00dcad39c8493c4990be9a8dec7fdf2369b1",
   "release-targets": [
     {
       "path": ".",
-      "version": "2.54.0",
-      "tag": "v2.54.0"
+      "version": "2.55.0",
+      "tag": "v2.55.0"
     },
     {
       "path": "crates/panache-dprint",
@@ -14,45 +14,50 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.12.0",
-      "tag": "panache-formatter-v0.12.0"
+      "version": "0.13.0",
+      "tag": "panache-formatter-v0.13.0"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.17.0",
-      "tag": "panache-parser-v0.17.0"
+      "version": "0.17.1",
+      "tag": "panache-parser-v0.17.1"
     },
     {
       "path": "editors/code",
-      "version": "2.47.0",
-      "tag": "panache-code-v2.47.0"
+      "version": "2.48.0",
+      "tag": "panache-code-v2.48.0"
     },
     {
       "path": "editors/zed",
-      "version": "2.35.0",
-      "tag": "panache-zed-v2.35.0"
+      "version": "2.35.1",
+      "tag": "panache-zed-v2.35.1"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "2.54.0",
-      "tag": "v2.54.0"
+      "version": "2.55.0",
+      "tag": "v2.55.0"
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.12.0",
-      "tag": "panache-formatter-v0.12.0"
+      "version": "0.13.0",
+      "tag": "panache-formatter-v0.13.0"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.17.0",
-      "tag": "panache-parser-v0.17.0"
+      "version": "0.17.1",
+      "tag": "panache-parser-v0.17.1"
     },
     {
       "path": "editors/code",
-      "version": "2.47.0",
-      "tag": "panache-code-v2.47.0"
+      "version": "2.48.0",
+      "tag": "panache-code-v2.48.0"
+    },
+    {
+      "path": "editors/zed",
+      "version": "2.35.1",
+      "tag": "panache-zed-v2.35.1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [2.55.0](https://github.com/jolars/panache/compare/v2.54.0...v2.55.0) (2026-06-15)
+
+### Features
+- **formatter:** nest broken binary math continuations by `math-indent` ([`5948ca1`](https://github.com/jolars/panache/commit/5948ca15bb1fa1350e91dbf8fdfc5e11f0e40c32))
+- **formatter:** default `math-indent` to 2 ([`3d0422b`](https://github.com/jolars/panache/commit/3d0422b8355e57b2d9e04b0ac86128da414b75b2))
+
+### Bug Fixes
+- **editors:** revert to use `latest_github_release` ([`dabe00d`](https://github.com/jolars/panache/commit/dabe00dcad39c8493c4990be9a8dec7fdf2369b1))
+- **formatter:** fix(formatter): charge math-indent against display line-break budget ([`754faaa`](https://github.com/jolars/panache/commit/754faaa451ae418a681237f86bc5ad3d6096c92f))
+- **parser:** claim trailing caption for table-first list item ([`a09f066`](https://github.com/jolars/panache/commit/a09f066a9493f3f626b44691023c59c151caafb8))
+- **formatter:** re-emit list marker for table-first item ([`9633b86`](https://github.com/jolars/panache/commit/9633b8632a2f075df3d59852cf414933c9aaba44))
+
+### Dependencies
+- updated crates/panache-formatter to v0.13.0
+- updated crates/panache-parser to v0.17.1
+
 ## [2.54.0](https://github.com/jolars/panache/compare/v2.53.0...v2.54.0) (2026-06-13)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,7 +1151,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "panache"
-version = "2.54.0"
+version = "2.55.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "insta",
  "log",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "entities",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "2.54.0"
+version = "2.55.0"
 edition.workspace = true
 readme = "README.md"
 description = "An LSP, formatter, and linter for Markdown, Quarto, and R Markdown"
@@ -53,8 +53,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.12.0" }
-panache-parser = { path = "crates/panache-parser", version = "0.17.0", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.13.0" }
+panache-parser = { path = "crates/panache-parser", version = "0.17.1", features = [
     "serde",
     "schema",
 ] }

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.13.0](https://github.com/jolars/panache/compare/panache-formatter-v0.12.0...panache-formatter-v0.13.0) (2026-06-15)
+
+### Features
+- **formatter:** nest broken binary math continuations by `math-indent` ([`5948ca1`](https://github.com/jolars/panache/commit/5948ca15bb1fa1350e91dbf8fdfc5e11f0e40c32))
+- **formatter:** default `math-indent` to 2 ([`3d0422b`](https://github.com/jolars/panache/commit/3d0422b8355e57b2d9e04b0ac86128da414b75b2))
+
+### Bug Fixes
+- **formatter:** fix(formatter): charge math-indent against display line-break budget ([`754faaa`](https://github.com/jolars/panache/commit/754faaa451ae418a681237f86bc5ad3d6096c92f))
+- **parser:** claim trailing caption for table-first list item ([`a09f066`](https://github.com/jolars/panache/commit/a09f066a9493f3f626b44691023c59c151caafb8))
+- **formatter:** re-emit list marker for table-first item ([`9633b86`](https://github.com/jolars/panache/commit/9633b8632a2f075df3d59852cf414933c9aaba44))
+
+### Dependencies
+- updated crates/panache-parser to v0.17.1
+
 ## [0.12.0](https://github.com/jolars/panache/compare/panache-formatter-v0.11.0...panache-formatter-v0.12.0) (2026-06-13)
 
 ### Features

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.12.0"
+version = "0.13.0"
 edition.workspace = true
 include = [
     "/src/**/*",
@@ -18,7 +18,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.17.0" }
+panache-parser = { path = "../panache-parser", version = "0.17.1" }
 log = { version = "0.4.31", features = ["release_max_level_debug"] }
 rowan = "0.16.1"
 unicode-width = "0.2"

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.17.1](https://github.com/jolars/panache/compare/panache-parser-v0.17.0...panache-parser-v0.17.1) (2026-06-15)
+
+### Bug Fixes
+- **parser:** claim trailing caption for table-first list item ([`a09f066`](https://github.com/jolars/panache/commit/a09f066a9493f3f626b44691023c59c151caafb8))
+
 ## [0.17.0](https://github.com/jolars/panache/compare/panache-parser-v0.16.0...panache-parser-v0.17.0) (2026-06-13)
 
 ### Features

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.17.0"
+version = "0.17.1"
 edition.workspace = true
 readme = "README.md"
 include = [

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.48.0](https://github.com/jolars/panache/compare/panache-code-v2.47.0...panache-code-v2.48.0) (2026-06-15)
+
+### Dependencies
+- updated panache to v2.55.0
+
 ## [2.47.0](https://github.com/jolars/panache/compare/panache-code-v2.46.0...panache-code-v2.47.0) (2026-06-13)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "2.47.0",
+  "version": "2.48.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/zed/CHANGELOG.md
+++ b/editors/zed/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.35.1](https://github.com/jolars/panache/compare/panache-zed-v2.35.0...panache-zed-v2.35.1) (2026-06-15)
+
+### Bug Fixes
+- **editors:** revert to use `latest_github_release` ([`dabe00d`](https://github.com/jolars/panache/commit/dabe00dcad39c8493c4990be9a8dec7fdf2369b1))
+
 ## [2.35.0](https://github.com/jolars/panache/compare/panache-zed-v2.34.1...panache-zed-v2.35.0) (2026-04-19)
 
 ### Features

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "zed_panache"
-version = "2.35.0"
+version = "2.35.1"
 dependencies = [
  "zed_extension_api",
 ]

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_panache"
-version = "2.35.0"
+version = "2.35.1"
 edition = "2021"
 license = "MIT"
 publish = false

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,7 +1,7 @@
 id = "panache-language-server"
 name = "Panache"
 description = "Language server for Markdown, Quarto, and R Markdown"
-version = "2.35.0"
+version = "2.35.1"
 schema_version = 1
 authors = ["Johan Larsson <johan@jolars.co>"]
 repository = "https://github.com/jolars/panache"

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "2.54.0",
+  "version": "2.55.0",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "2.54.0",
-    "@panache-cli/linux-arm64-gnu": "2.54.0",
-    "@panache-cli/linux-x64-musl": "2.54.0",
-    "@panache-cli/linux-arm64-musl": "2.54.0",
-    "@panache-cli/darwin-x64": "2.54.0",
-    "@panache-cli/darwin-arm64": "2.54.0",
-    "@panache-cli/win32-x64": "2.54.0",
-    "@panache-cli/win32-arm64": "2.54.0"
+    "@panache-cli/linux-x64-gnu": "2.55.0",
+    "@panache-cli/linux-arm64-gnu": "2.55.0",
+    "@panache-cli/linux-x64-musl": "2.55.0",
+    "@panache-cli/linux-arm64-musl": "2.55.0",
+    "@panache-cli/darwin-x64": "2.55.0",
+    "@panache-cli/darwin-arm64": "2.55.0",
+    "@panache-cli/win32-x64": "2.55.0",
+    "@panache-cli/win32-arm64": "2.55.0"
   }
 }


### PR DESCRIPTION
## [panache: 2.55.0](https://github.com/jolars/panache/compare/v2.54.0...v2.55.0) (2026-06-15)

### Features
- **formatter:** nest broken binary math continuations by `math-indent` ([`5948ca1`](https://github.com/jolars/panache/commit/5948ca15bb1fa1350e91dbf8fdfc5e11f0e40c32))
- **formatter:** default `math-indent` to 2 ([`3d0422b`](https://github.com/jolars/panache/commit/3d0422b8355e57b2d9e04b0ac86128da414b75b2))

### Bug Fixes
- **editors:** revert to use `latest_github_release` ([`dabe00d`](https://github.com/jolars/panache/commit/dabe00dcad39c8493c4990be9a8dec7fdf2369b1))
- **formatter:** fix(formatter): charge math-indent against display line-break budget ([`754faaa`](https://github.com/jolars/panache/commit/754faaa451ae418a681237f86bc5ad3d6096c92f))
- **parser:** claim trailing caption for table-first list item ([`a09f066`](https://github.com/jolars/panache/commit/a09f066a9493f3f626b44691023c59c151caafb8))
- **formatter:** re-emit list marker for table-first item ([`9633b86`](https://github.com/jolars/panache/commit/9633b8632a2f075df3d59852cf414933c9aaba44))

### Dependencies
- updated crates/panache-formatter to v0.13.0
- updated crates/panache-parser to v0.17.1

## [crates/panache-formatter: 0.13.0](https://github.com/jolars/panache/compare/panache-formatter-v0.12.0...panache-formatter-v0.13.0) (2026-06-15)

### Features
- **formatter:** nest broken binary math continuations by `math-indent` ([`5948ca1`](https://github.com/jolars/panache/commit/5948ca15bb1fa1350e91dbf8fdfc5e11f0e40c32))
- **formatter:** default `math-indent` to 2 ([`3d0422b`](https://github.com/jolars/panache/commit/3d0422b8355e57b2d9e04b0ac86128da414b75b2))

### Bug Fixes
- **formatter:** fix(formatter): charge math-indent against display line-break budget ([`754faaa`](https://github.com/jolars/panache/commit/754faaa451ae418a681237f86bc5ad3d6096c92f))
- **parser:** claim trailing caption for table-first list item ([`a09f066`](https://github.com/jolars/panache/commit/a09f066a9493f3f626b44691023c59c151caafb8))
- **formatter:** re-emit list marker for table-first item ([`9633b86`](https://github.com/jolars/panache/commit/9633b8632a2f075df3d59852cf414933c9aaba44))

### Dependencies
- updated crates/panache-parser to v0.17.1

## [crates/panache-parser: 0.17.1](https://github.com/jolars/panache/compare/panache-parser-v0.17.0...panache-parser-v0.17.1) (2026-06-15)

### Bug Fixes
- **parser:** claim trailing caption for table-first list item ([`a09f066`](https://github.com/jolars/panache/commit/a09f066a9493f3f626b44691023c59c151caafb8))

## [editors/code: 2.48.0](https://github.com/jolars/panache/compare/panache-code-v2.47.0...panache-code-v2.48.0) (2026-06-15)

### Dependencies
- updated panache to v2.55.0

## [editors/zed: 2.35.1](https://github.com/jolars/panache/compare/panache-zed-v2.35.0...panache-zed-v2.35.1) (2026-06-15)

### Bug Fixes
- **editors:** revert to use `latest_github_release` ([`dabe00d`](https://github.com/jolars/panache/commit/dabe00dcad39c8493c4990be9a8dec7fdf2369b1))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).