### PR TITLE
chore(release): v2.56.0 (+4 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "dabe00dcad39c8493c4990be9a8dec7fdf2369b1",
+  "baseline-sha": "5062bb52db346572748752210e2c6ec22b97e37d",
   "release-targets": [
     {
       "path": ".",
-      "version": "2.55.0",
-      "tag": "v2.55.0"
+      "version": "2.56.0",
+      "tag": "v2.56.0"
     },
     {
       "path": "crates/panache-dprint",
@@ -14,50 +14,50 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.13.0",
-      "tag": "panache-formatter-v0.13.0"
+      "version": "0.14.0",
+      "tag": "panache-formatter-v0.14.0"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.17.1",
-      "tag": "panache-parser-v0.17.1"
+      "version": "0.17.2",
+      "tag": "panache-parser-v0.17.2"
     },
     {
       "path": "editors/code",
-      "version": "2.48.0",
-      "tag": "panache-code-v2.48.0"
+      "version": "2.49.0",
+      "tag": "panache-code-v2.49.0"
     },
     {
       "path": "editors/zed",
-      "version": "2.35.1",
-      "tag": "panache-zed-v2.35.1"
+      "version": "2.36.0",
+      "tag": "panache-zed-v2.36.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "2.55.0",
-      "tag": "v2.55.0"
+      "version": "2.56.0",
+      "tag": "v2.56.0"
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.13.0",
-      "tag": "panache-formatter-v0.13.0"
+      "version": "0.14.0",
+      "tag": "panache-formatter-v0.14.0"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.17.1",
-      "tag": "panache-parser-v0.17.1"
+      "version": "0.17.2",
+      "tag": "panache-parser-v0.17.2"
     },
     {
       "path": "editors/code",
-      "version": "2.48.0",
-      "tag": "panache-code-v2.48.0"
+      "version": "2.49.0",
+      "tag": "panache-code-v2.49.0"
     },
     {
       "path": "editors/zed",
-      "version": "2.35.1",
-      "tag": "panache-zed-v2.35.1"
+      "version": "2.36.0",
+      "tag": "panache-zed-v2.36.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [2.56.0](https://github.com/jolars/panache/compare/v2.55.0...v2.56.0) (2026-06-17)
+
+### Features
+- **formatter:** expose config-enum JsonSchema behind schema feature ([`5062bb5`](https://github.com/jolars/panache/commit/5062bb52db346572748752210e2c6ec22b97e37d))
+- **formatter:** add `table-indent` config option ([`1365b80`](https://github.com/jolars/panache/commit/1365b801c48fbb8670ff8343884b20e5b427f1c7)), resolves [#344](https://github.com/jolars/panache/issues/344) and [#352](https://github.com/jolars/panache/issues/352)
+- **formatter:** hang math binary continuations flush under the RHS ([`0fae430`](https://github.com/jolars/panache/commit/0fae4303b8a758a7ac3a218170dfc9fb7a0c4409))
+- **formatter:** align assignment-led math chains under the RHS ([`e20d0d6`](https://github.com/jolars/panache/commit/e20d0d6c36b4fa7bae295ea41ddc27d770fa4755))
+- break out dprint plugin into its own repo ([`014ab7c`](https://github.com/jolars/panache/commit/014ab7cc7135bb5ed0555b7c5bb6fe37326d7dd1))
+- **config:** add `cache = <bool>` option to toggle caching ([`aa20278`](https://github.com/jolars/panache/commit/aa2027844cb3a54fd8e95249e3d4cc9284d814a3))
+
+### Bug Fixes
+- **parser:** conform ordered marker on pipe-table line to pandoc ([`bf02d16`](https://github.com/jolars/panache/commit/bf02d1626c3f7f10de07e9ca735dfdb2de3d2759))
+- **formatter:** collapse line breaks inside split citations ([`148f69f`](https://github.com/jolars/panache/commit/148f69fb2d97ba5c42eb0b92645163cdc7ee4602))
+
+### Dependencies
+- updated crates/panache-formatter to v0.14.0
+- updated crates/panache-parser to v0.17.2
+
 ## [2.55.0](https://github.com/jolars/panache/compare/v2.54.0...v2.55.0) (2026-06-15)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,7 +1151,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "panache"
-version = "2.55.0"
+version = "2.56.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "insta",
  "log",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "entities",
  "insta",
@@ -1785,9 +1785,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2135,9 +2135,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.3"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c789537cf2f7f55be8e6192f92e464174ee55f91af622777f7f1ceb0dbccd03e"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "2.55.0"
+version = "2.56.0"
 edition.workspace = true
 readme = "README.md"
 description = "An LSP, formatter, and linter for Markdown, Quarto, and R Markdown"
@@ -45,8 +45,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.13.0" }
-panache-parser = { path = "crates/panache-parser", version = "0.17.1", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.14.0" }
+panache-parser = { path = "crates/panache-parser", version = "0.17.2", features = [
     "serde",
     "schema",
 ] }

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.14.0](https://github.com/jolars/panache/compare/panache-formatter-v0.13.0...panache-formatter-v0.14.0) (2026-06-17)
+
+### Features
+- **formatter:** expose config-enum JsonSchema behind schema feature ([`5062bb5`](https://github.com/jolars/panache/commit/5062bb52db346572748752210e2c6ec22b97e37d))
+- **formatter:** add `table-indent` config option ([`1365b80`](https://github.com/jolars/panache/commit/1365b801c48fbb8670ff8343884b20e5b427f1c7)), resolves [#344](https://github.com/jolars/panache/issues/344) and [#352](https://github.com/jolars/panache/issues/352)
+- **formatter:** hang math binary continuations flush under the RHS ([`0fae430`](https://github.com/jolars/panache/commit/0fae4303b8a758a7ac3a218170dfc9fb7a0c4409))
+- **formatter:** align assignment-led math chains under the RHS ([`e20d0d6`](https://github.com/jolars/panache/commit/e20d0d6c36b4fa7bae295ea41ddc27d770fa4755))
+
+### Bug Fixes
+- **formatter:** collapse line breaks inside split citations ([`148f69f`](https://github.com/jolars/panache/commit/148f69fb2d97ba5c42eb0b92645163cdc7ee4602))
+
+### Dependencies
+- updated crates/panache-parser to v0.17.2
+
 ## [0.13.0](https://github.com/jolars/panache/compare/panache-formatter-v0.12.0...panache-formatter-v0.13.0) (2026-06-15)
 
 ### Features

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.13.0"
+version = "0.14.0"
 edition.workspace = true
 include = [
     "/src/**/*",
@@ -18,7 +18,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.17.1" }
+panache-parser = { path = "../panache-parser", version = "0.17.2" }
 log = { version = "0.4.31", features = ["release_max_level_debug"] }
 rowan = "0.16.1"
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.17.2](https://github.com/jolars/panache/compare/panache-parser-v0.17.1...panache-parser-v0.17.2) (2026-06-17)
+
+### Bug Fixes
+- **parser:** conform ordered marker on pipe-table line to pandoc ([`bf02d16`](https://github.com/jolars/panache/commit/bf02d1626c3f7f10de07e9ca735dfdb2de3d2759))
+
 ## [0.17.1](https://github.com/jolars/panache/compare/panache-parser-v0.17.0...panache-parser-v0.17.1) (2026-06-15)
 
 ### Bug Fixes

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.17.1"
+version = "0.17.2"
 edition.workspace = true
 readme = "README.md"
 include = [

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.49.0](https://github.com/jolars/panache/compare/panache-code-v2.48.0...panache-code-v2.49.0) (2026-06-17)
+
+### Dependencies
+- updated panache to v2.56.0
+
 ## [2.48.0](https://github.com/jolars/panache/compare/panache-code-v2.47.0...panache-code-v2.48.0) (2026-06-15)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "2.48.0",
+  "version": "2.49.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/zed/CHANGELOG.md
+++ b/editors/zed/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.36.0](https://github.com/jolars/panache/compare/panache-zed-v2.35.1...panache-zed-v2.36.0) (2026-06-17)
+
+### Features
+- break out dprint plugin into its own repo ([`014ab7c`](https://github.com/jolars/panache/commit/014ab7cc7135bb5ed0555b7c5bb6fe37326d7dd1))
+
 ## [2.35.1](https://github.com/jolars/panache/compare/panache-zed-v2.35.0...panache-zed-v2.35.1) (2026-06-15)
 
 ### Bug Fixes

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -502,9 +502,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "zed_panache"
-version = "2.35.1"
+version = "2.36.0"
 dependencies = [
  "zed_extension_api",
 ]

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_panache"
-version = "2.35.1"
+version = "2.36.0"
 edition = "2021"
 license = "MIT"
 publish = false

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,7 +1,7 @@
 id = "panache-language-server"
 name = "Panache"
 description = "Language server for Markdown, Quarto, and R Markdown"
-version = "2.35.1"
+version = "2.36.0"
 schema_version = 1
 authors = ["Johan Larsson <johan@jolars.co>"]
 repository = "https://github.com/jolars/panache"

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "2.55.0",
+  "version": "2.56.0",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "2.55.0",
-    "@panache-cli/linux-arm64-gnu": "2.55.0",
-    "@panache-cli/linux-x64-musl": "2.55.0",
-    "@panache-cli/linux-arm64-musl": "2.55.0",
-    "@panache-cli/darwin-x64": "2.55.0",
-    "@panache-cli/darwin-arm64": "2.55.0",
-    "@panache-cli/win32-x64": "2.55.0",
-    "@panache-cli/win32-arm64": "2.55.0"
+    "@panache-cli/linux-x64-gnu": "2.56.0",
+    "@panache-cli/linux-arm64-gnu": "2.56.0",
+    "@panache-cli/linux-x64-musl": "2.56.0",
+    "@panache-cli/linux-arm64-musl": "2.56.0",
+    "@panache-cli/darwin-x64": "2.56.0",
+    "@panache-cli/darwin-arm64": "2.56.0",
+    "@panache-cli/win32-x64": "2.56.0",
+    "@panache-cli/win32-arm64": "2.56.0"
   }
 }


### PR DESCRIPTION
## [panache: 2.56.0](https://github.com/jolars/panache/compare/v2.55.0...v2.56.0) (2026-06-17)

### Features
- **formatter:** expose config-enum JsonSchema behind schema feature ([`5062bb5`](https://github.com/jolars/panache/commit/5062bb52db346572748752210e2c6ec22b97e37d))
- **formatter:** add `table-indent` config option ([`1365b80`](https://github.com/jolars/panache/commit/1365b801c48fbb8670ff8343884b20e5b427f1c7)), resolves [#344](https://github.com/jolars/panache/issues/344) and [#352](https://github.com/jolars/panache/issues/352)
- **formatter:** hang math binary continuations flush under the RHS ([`0fae430`](https://github.com/jolars/panache/commit/0fae4303b8a758a7ac3a218170dfc9fb7a0c4409))
- **formatter:** align assignment-led math chains under the RHS ([`e20d0d6`](https://github.com/jolars/panache/commit/e20d0d6c36b4fa7bae295ea41ddc27d770fa4755))
- break out dprint plugin into its own repo ([`014ab7c`](https://github.com/jolars/panache/commit/014ab7cc7135bb5ed0555b7c5bb6fe37326d7dd1))
- **config:** add `cache = <bool>` option to toggle caching ([`aa20278`](https://github.com/jolars/panache/commit/aa2027844cb3a54fd8e95249e3d4cc9284d814a3))

### Bug Fixes
- **parser:** conform ordered marker on pipe-table line to pandoc ([`bf02d16`](https://github.com/jolars/panache/commit/bf02d1626c3f7f10de07e9ca735dfdb2de3d2759))
- **formatter:** collapse line breaks inside split citations ([`148f69f`](https://github.com/jolars/panache/commit/148f69fb2d97ba5c42eb0b92645163cdc7ee4602))

### Dependencies
- updated crates/panache-formatter to v0.14.0
- updated crates/panache-parser to v0.17.2

## [crates/panache-formatter: 0.14.0](https://github.com/jolars/panache/compare/panache-formatter-v0.13.0...panache-formatter-v0.14.0) (2026-06-17)

### Features
- **formatter:** expose config-enum JsonSchema behind schema feature ([`5062bb5`](https://github.com/jolars/panache/commit/5062bb52db346572748752210e2c6ec22b97e37d))
- **formatter:** add `table-indent` config option ([`1365b80`](https://github.com/jolars/panache/commit/1365b801c48fbb8670ff8343884b20e5b427f1c7)), resolves [#344](https://github.com/jolars/panache/issues/344) and [#352](https://github.com/jolars/panache/issues/352)
- **formatter:** hang math binary continuations flush under the RHS ([`0fae430`](https://github.com/jolars/panache/commit/0fae4303b8a758a7ac3a218170dfc9fb7a0c4409))
- **formatter:** align assignment-led math chains under the RHS ([`e20d0d6`](https://github.com/jolars/panache/commit/e20d0d6c36b4fa7bae295ea41ddc27d770fa4755))

### Bug Fixes
- **formatter:** collapse line breaks inside split citations ([`148f69f`](https://github.com/jolars/panache/commit/148f69fb2d97ba5c42eb0b92645163cdc7ee4602))

### Dependencies
- updated crates/panache-parser to v0.17.2

## [crates/panache-parser: 0.17.2](https://github.com/jolars/panache/compare/panache-parser-v0.17.1...panache-parser-v0.17.2) (2026-06-17)

### Bug Fixes
- **parser:** conform ordered marker on pipe-table line to pandoc ([`bf02d16`](https://github.com/jolars/panache/commit/bf02d1626c3f7f10de07e9ca735dfdb2de3d2759))

## [editors/code: 2.49.0](https://github.com/jolars/panache/compare/panache-code-v2.48.0...panache-code-v2.49.0) (2026-06-17)

### Dependencies
- updated panache to v2.56.0

## [editors/zed: 2.36.0](https://github.com/jolars/panache/compare/panache-zed-v2.35.1...panache-zed-v2.36.0) (2026-06-17)

### Features
- break out dprint plugin into its own repo ([`014ab7c`](https://github.com/jolars/panache/commit/014ab7cc7135bb5ed0555b7c5bb6fe37326d7dd1))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).