### PR TITLE
chore(release): v2.57.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "5062bb52db346572748752210e2c6ec22b97e37d",
+  "baseline-sha": "301d8f98e3499c38a2f3f5a302970ca114a6ad9f",
   "release-targets": [
     {
       "path": ".",
-      "version": "2.56.0",
-      "tag": "v2.56.0"
+      "version": "2.57.0",
+      "tag": "v2.57.0"
     },
     {
       "path": "crates/panache-dprint",
@@ -14,18 +14,18 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.14.0",
-      "tag": "panache-formatter-v0.14.0"
+      "version": "0.15.0",
+      "tag": "panache-formatter-v0.15.0"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.17.2",
-      "tag": "panache-parser-v0.17.2"
+      "version": "0.18.0",
+      "tag": "panache-parser-v0.18.0"
     },
     {
       "path": "editors/code",
-      "version": "2.49.0",
-      "tag": "panache-code-v2.49.0"
+      "version": "2.50.0",
+      "tag": "panache-code-v2.50.0"
     },
     {
       "path": "editors/zed",
@@ -36,28 +36,23 @@
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "2.56.0",
-      "tag": "v2.56.0"
+      "version": "2.57.0",
+      "tag": "v2.57.0"
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.14.0",
-      "tag": "panache-formatter-v0.14.0"
+      "version": "0.15.0",
+      "tag": "panache-formatter-v0.15.0"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.17.2",
-      "tag": "panache-parser-v0.17.2"
+      "version": "0.18.0",
+      "tag": "panache-parser-v0.18.0"
     },
     {
       "path": "editors/code",
-      "version": "2.49.0",
-      "tag": "panache-code-v2.49.0"
-    },
-    {
-      "path": "editors/zed",
-      "version": "2.36.0",
-      "tag": "panache-zed-v2.36.0"
+      "version": "2.50.0",
+      "tag": "panache-code-v2.50.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [2.57.0](https://github.com/jolars/panache/compare/v2.56.0...v2.57.0) (2026-06-21)
+
+### Features
+- **lsp:** on-type continuation indent for lists ([`3c9bc3a`](https://github.com/jolars/panache/commit/3c9bc3a827ee9dd0aad8b3dc63fc3f3e0263d41b))
+- **linter:** make rule metadata the source of truth ([`f0c1c74`](https://github.com/jolars/panache/commit/f0c1c74daaf3e7999919d975c2dfabac9f94bcfc))
+- **lsp:** add did-create/rename/delete file operations ([`e1b1648`](https://github.com/jolars/panache/commit/e1b164885e0676913e52fb621f266acf3146ebb7))
+- **lsp:** extend file rename to more shortcodes and frontmatter ([`255978e`](https://github.com/jolars/panache/commit/255978ecdba458214502f3f6c37803b0db58e82b))
+- **lsp:** add `semanticTokens/full` highlighting ([`0c7d247`](https://github.com/jolars/panache/commit/0c7d2474ab7d3e0984701de5cdd2b4c213450cf8))
+- **lsp:** populate diagnostic `related_documents` ([`33b743d`](https://github.com/jolars/panache/commit/33b743d9eb8db5b8e03955512e2c31461ef812c3))
+- **lsp:** add pull diagnostics with push mode-switch ([`822a2ed`](https://github.com/jolars/panache/commit/822a2ed2c0aabc3e67a4f49b76e731dd2e2f8693))
+- **parser:** retag comment/PI/verbatim as `HTML_BLOCK_RAW` ([`447d537`](https://github.com/jolars/panache/commit/447d537dcbd6bdff6f55d95cb04b17cd9fd17574))
+- **parser:** tokenize table separator rows in the CST ([`3de91a6`](https://github.com/jolars/panache/commit/3de91a623762282b07ede9d249cf3872a5634a5f))
+
+### Bug Fixes
+- **parser:** stop caption theft across simple/multiline tables ([`89610d4`](https://github.com/jolars/panache/commit/89610d4c8230f4894bfe8552322403c54a7ed120))
+- **linter:** dedup citation keys before reporting ([`8ce3a15`](https://github.com/jolars/panache/commit/8ce3a15ba1cb8fb6ee866d6878c9588bf37efaba))
+- **lsp:** stop losing diagnostics to lint cancellation races ([`f72fd78`](https://github.com/jolars/panache/commit/f72fd78a6335e17c2db540435e12ebafb9c7ece1))
+- **parser:** detect setext heading level via underline node ([`ff43f66`](https://github.com/jolars/panache/commit/ff43f664bdb80af8b1452c286650609a250d865e)), closes [#377](https://github.com/jolars/panache/issues/377)
+- **formatter:** keep indent on YAML value below its key ([`52d578a`](https://github.com/jolars/panache/commit/52d578a34e5b53b37e94e34a5effd979e2424c03))
+- **parser:** skip code spans in citation detection ([`859a3db`](https://github.com/jolars/panache/commit/859a3dbbbb6a37b190c87187d85ab790e397f539))
+
+### Performance Improvements
+- **parser:** replay table subtree instead of re-parsing ([`4a050dc`](https://github.com/jolars/panache/commit/4a050dccd45954b9b79ef0245dd82785988e976a))
+- **parser:** use `memchr` for refdef newline scan ([`0e64ba7`](https://github.com/jolars/panache/commit/0e64ba700a3a2afbda06ae8755ab41e81cc0f171))
+- **salsa:** raise lint-query lru to 512 ([`4f1615f`](https://github.com/jolars/panache/commit/4f1615fc6824a46063e874eb73e67ae97642ca7c))
+
+### Dependencies
+- updated crates/panache-formatter to v0.15.0
+- updated crates/panache-parser to v0.18.0
+
 ## [2.56.0](https://github.com/jolars/panache/compare/v2.55.0...v2.56.0) (2026-06-17)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,12 +93,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "assert_cmd"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +356,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,12 +554,6 @@ dependencies = [
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -599,15 +619,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -631,22 +649,13 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -657,7 +666,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -764,12 +773,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,8 +823,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -869,10 +870,11 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
 dependencies = [
+ "defmt",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -882,9 +884,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -936,12 +938,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,9 +975,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lsp-server"
@@ -1151,7 +1147,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "panache"
-version = "2.56.0"
+version = "2.57.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -1194,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "insta",
  "log",
@@ -1212,7 +1208,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.17.2"
+version = "0.18.0"
 dependencies = [
  "entities",
  "insta",
@@ -1361,12 +1357,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
 dependencies = [
  "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -1649,12 +1657,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1813,7 +1815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1962,12 +1964,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,7 +1981,7 @@ version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -2043,16 +2039,7 @@ version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -2098,40 +2085,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.13.0",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -2209,97 +2162,9 @@ checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.13.0",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "2.56.0"
+version = "2.57.0"
 edition.workspace = true
 readme = "README.md"
 description = "An LSP, formatter, and linter for Markdown, Quarto, and R Markdown"
@@ -45,8 +45,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.14.0" }
-panache-parser = { path = "crates/panache-parser", version = "0.17.2", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.15.0" }
+panache-parser = { path = "crates/panache-parser", version = "0.18.0", features = [
     "serde",
     "schema",
 ] }

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.15.0](https://github.com/jolars/panache/compare/panache-formatter-v0.14.0...panache-formatter-v0.15.0) (2026-06-21)
+
+### Features
+- **lsp:** on-type continuation indent for lists ([`3c9bc3a`](https://github.com/jolars/panache/commit/3c9bc3a827ee9dd0aad8b3dc63fc3f3e0263d41b))
+- **parser:** retag comment/PI/verbatim as `HTML_BLOCK_RAW` ([`447d537`](https://github.com/jolars/panache/commit/447d537dcbd6bdff6f55d95cb04b17cd9fd17574))
+- **parser:** tokenize table separator rows in the CST ([`3de91a6`](https://github.com/jolars/panache/commit/3de91a623762282b07ede9d249cf3872a5634a5f))
+
+### Bug Fixes
+- **formatter:** keep indent on YAML value below its key ([`52d578a`](https://github.com/jolars/panache/commit/52d578a34e5b53b37e94e34a5effd979e2424c03))
+
+### Dependencies
+- updated crates/panache-parser to v0.18.0
+
 ## [0.14.0](https://github.com/jolars/panache/compare/panache-formatter-v0.13.0...panache-formatter-v0.14.0) (2026-06-17)
 
 ### Features

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.14.0"
+version = "0.15.0"
 edition.workspace = true
 include = [
     "/src/**/*",
@@ -18,7 +18,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.17.2" }
+panache-parser = { path = "../panache-parser", version = "0.18.0" }
 log = { version = "0.4.31", features = ["release_max_level_debug"] }
 rowan = "0.16.1"
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.18.0](https://github.com/jolars/panache/compare/panache-parser-v0.17.2...panache-parser-v0.18.0) (2026-06-21)
+
+### Features
+- **parser:** retag comment/PI/verbatim as `HTML_BLOCK_RAW` ([`447d537`](https://github.com/jolars/panache/commit/447d537dcbd6bdff6f55d95cb04b17cd9fd17574))
+- **parser:** tokenize table separator rows in the CST ([`3de91a6`](https://github.com/jolars/panache/commit/3de91a623762282b07ede9d249cf3872a5634a5f))
+
+### Bug Fixes
+- **parser:** stop caption theft across simple/multiline tables ([`89610d4`](https://github.com/jolars/panache/commit/89610d4c8230f4894bfe8552322403c54a7ed120))
+- **parser:** skip code spans in citation detection ([`859a3db`](https://github.com/jolars/panache/commit/859a3dbbbb6a37b190c87187d85ab790e397f539))
+- **parser:** detect setext heading level via underline node ([`ff43f66`](https://github.com/jolars/panache/commit/ff43f664bdb80af8b1452c286650609a250d865e)), closes [#377](https://github.com/jolars/panache/issues/377)
+
+### Performance Improvements
+- **parser:** replay table subtree instead of re-parsing ([`4a050dc`](https://github.com/jolars/panache/commit/4a050dccd45954b9b79ef0245dd82785988e976a))
+- **parser:** use `memchr` for refdef newline scan ([`0e64ba7`](https://github.com/jolars/panache/commit/0e64ba700a3a2afbda06ae8755ab41e81cc0f171))
+
 ## [0.17.2](https://github.com/jolars/panache/compare/panache-parser-v0.17.1...panache-parser-v0.17.2) (2026-06-17)
 
 ### Bug Fixes

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.17.2"
+version = "0.18.0"
 edition.workspace = true
 readme = "README.md"
 include = [

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.50.0](https://github.com/jolars/panache/compare/panache-code-v2.49.0...panache-code-v2.50.0) (2026-06-21)
+
+### Dependencies
+- updated panache to v2.57.0
+
 ## [2.49.0](https://github.com/jolars/panache/compare/panache-code-v2.48.0...panache-code-v2.49.0) (2026-06-17)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "2.49.0",
+  "version": "2.50.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -339,9 +339,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "2.56.0",
+  "version": "2.57.0",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "2.56.0",
-    "@panache-cli/linux-arm64-gnu": "2.56.0",
-    "@panache-cli/linux-x64-musl": "2.56.0",
-    "@panache-cli/linux-arm64-musl": "2.56.0",
-    "@panache-cli/darwin-x64": "2.56.0",
-    "@panache-cli/darwin-arm64": "2.56.0",
-    "@panache-cli/win32-x64": "2.56.0",
-    "@panache-cli/win32-arm64": "2.56.0"
+    "@panache-cli/linux-x64-gnu": "2.57.0",
+    "@panache-cli/linux-arm64-gnu": "2.57.0",
+    "@panache-cli/linux-x64-musl": "2.57.0",
+    "@panache-cli/linux-arm64-musl": "2.57.0",
+    "@panache-cli/darwin-x64": "2.57.0",
+    "@panache-cli/darwin-arm64": "2.57.0",
+    "@panache-cli/win32-x64": "2.57.0",
+    "@panache-cli/win32-arm64": "2.57.0"
   }
 }


### PR DESCRIPTION
## [panache: 2.57.0](https://github.com/jolars/panache/compare/v2.56.0...v2.57.0) (2026-06-21)

### Features
- **lsp:** on-type continuation indent for lists ([`3c9bc3a`](https://github.com/jolars/panache/commit/3c9bc3a827ee9dd0aad8b3dc63fc3f3e0263d41b))
- **linter:** make rule metadata the source of truth ([`f0c1c74`](https://github.com/jolars/panache/commit/f0c1c74daaf3e7999919d975c2dfabac9f94bcfc))
- **lsp:** add did-create/rename/delete file operations ([`e1b1648`](https://github.com/jolars/panache/commit/e1b164885e0676913e52fb621f266acf3146ebb7))
- **lsp:** extend file rename to more shortcodes and frontmatter ([`255978e`](https://github.com/jolars/panache/commit/255978ecdba458214502f3f6c37803b0db58e82b))
- **lsp:** add `semanticTokens/full` highlighting ([`0c7d247`](https://github.com/jolars/panache/commit/0c7d2474ab7d3e0984701de5cdd2b4c213450cf8))
- **lsp:** populate diagnostic `related_documents` ([`33b743d`](https://github.com/jolars/panache/commit/33b743d9eb8db5b8e03955512e2c31461ef812c3))
- **lsp:** add pull diagnostics with push mode-switch ([`822a2ed`](https://github.com/jolars/panache/commit/822a2ed2c0aabc3e67a4f49b76e731dd2e2f8693))
- **parser:** retag comment/PI/verbatim as `HTML_BLOCK_RAW` ([`447d537`](https://github.com/jolars/panache/commit/447d537dcbd6bdff6f55d95cb04b17cd9fd17574))
- **parser:** tokenize table separator rows in the CST ([`3de91a6`](https://github.com/jolars/panache/commit/3de91a623762282b07ede9d249cf3872a5634a5f))

### Bug Fixes
- **parser:** stop caption theft across simple/multiline tables ([`89610d4`](https://github.com/jolars/panache/commit/89610d4c8230f4894bfe8552322403c54a7ed120))
- **linter:** dedup citation keys before reporting ([`8ce3a15`](https://github.com/jolars/panache/commit/8ce3a15ba1cb8fb6ee866d6878c9588bf37efaba))
- **lsp:** stop losing diagnostics to lint cancellation races ([`f72fd78`](https://github.com/jolars/panache/commit/f72fd78a6335e17c2db540435e12ebafb9c7ece1))
- **parser:** detect setext heading level via underline node ([`ff43f66`](https://github.com/jolars/panache/commit/ff43f664bdb80af8b1452c286650609a250d865e)), closes [#377](https://github.com/jolars/panache/issues/377)
- **formatter:** keep indent on YAML value below its key ([`52d578a`](https://github.com/jolars/panache/commit/52d578a34e5b53b37e94e34a5effd979e2424c03))
- **parser:** skip code spans in citation detection ([`859a3db`](https://github.com/jolars/panache/commit/859a3dbbbb6a37b190c87187d85ab790e397f539))

### Performance Improvements
- **parser:** replay table subtree instead of re-parsing ([`4a050dc`](https://github.com/jolars/panache/commit/4a050dccd45954b9b79ef0245dd82785988e976a))
- **parser:** use `memchr` for refdef newline scan ([`0e64ba7`](https://github.com/jolars/panache/commit/0e64ba700a3a2afbda06ae8755ab41e81cc0f171))
- **salsa:** raise lint-query lru to 512 ([`4f1615f`](https://github.com/jolars/panache/commit/4f1615fc6824a46063e874eb73e67ae97642ca7c))

### Dependencies
- updated crates/panache-formatter to v0.15.0
- updated crates/panache-parser to v0.18.0

## [crates/panache-formatter: 0.15.0](https://github.com/jolars/panache/compare/panache-formatter-v0.14.0...panache-formatter-v0.15.0) (2026-06-21)

### Features
- **lsp:** on-type continuation indent for lists ([`3c9bc3a`](https://github.com/jolars/panache/commit/3c9bc3a827ee9dd0aad8b3dc63fc3f3e0263d41b))
- **parser:** retag comment/PI/verbatim as `HTML_BLOCK_RAW` ([`447d537`](https://github.com/jolars/panache/commit/447d537dcbd6bdff6f55d95cb04b17cd9fd17574))
- **parser:** tokenize table separator rows in the CST ([`3de91a6`](https://github.com/jolars/panache/commit/3de91a623762282b07ede9d249cf3872a5634a5f))

### Bug Fixes
- **formatter:** keep indent on YAML value below its key ([`52d578a`](https://github.com/jolars/panache/commit/52d578a34e5b53b37e94e34a5effd979e2424c03))

### Dependencies
- updated crates/panache-parser to v0.18.0

## [crates/panache-parser: 0.18.0](https://github.com/jolars/panache/compare/panache-parser-v0.17.2...panache-parser-v0.18.0) (2026-06-21)

### Features
- **parser:** retag comment/PI/verbatim as `HTML_BLOCK_RAW` ([`447d537`](https://github.com/jolars/panache/commit/447d537dcbd6bdff6f55d95cb04b17cd9fd17574))
- **parser:** tokenize table separator rows in the CST ([`3de91a6`](https://github.com/jolars/panache/commit/3de91a623762282b07ede9d249cf3872a5634a5f))

### Bug Fixes
- **parser:** stop caption theft across simple/multiline tables ([`89610d4`](https://github.com/jolars/panache/commit/89610d4c8230f4894bfe8552322403c54a7ed120))
- **parser:** skip code spans in citation detection ([`859a3db`](https://github.com/jolars/panache/commit/859a3dbbbb6a37b190c87187d85ab790e397f539))
- **parser:** detect setext heading level via underline node ([`ff43f66`](https://github.com/jolars/panache/commit/ff43f664bdb80af8b1452c286650609a250d865e)), closes [#377](https://github.com/jolars/panache/issues/377)

### Performance Improvements
- **parser:** replay table subtree instead of re-parsing ([`4a050dc`](https://github.com/jolars/panache/commit/4a050dccd45954b9b79ef0245dd82785988e976a))
- **parser:** use `memchr` for refdef newline scan ([`0e64ba7`](https://github.com/jolars/panache/commit/0e64ba700a3a2afbda06ae8755ab41e81cc0f171))

## [editors/code: 2.50.0](https://github.com/jolars/panache/compare/panache-code-v2.49.0...panache-code-v2.50.0) (2026-06-21)

### Dependencies
- updated panache to v2.57.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).