### PR TITLE
chore(release): v2.58.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "301d8f98e3499c38a2f3f5a302970ca114a6ad9f",
+  "baseline-sha": "39c799fdeac2adb4087a7a50de3c447269958986",
   "release-targets": [
     {
       "path": ".",
-      "version": "2.57.0",
-      "tag": "v2.57.0"
+      "version": "2.58.0",
+      "tag": "v2.58.0"
     },
     {
       "path": "crates/panache-dprint",
@@ -14,18 +14,18 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.15.0",
-      "tag": "panache-formatter-v0.15.0"
+      "version": "0.16.0",
+      "tag": "panache-formatter-v0.16.0"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.18.0",
-      "tag": "panache-parser-v0.18.0"
+      "version": "0.19.0",
+      "tag": "panache-parser-v0.19.0"
     },
     {
       "path": "editors/code",
-      "version": "2.50.0",
-      "tag": "panache-code-v2.50.0"
+      "version": "2.51.0",
+      "tag": "panache-code-v2.51.0"
     },
     {
       "path": "editors/zed",
@@ -36,23 +36,23 @@
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "2.57.0",
-      "tag": "v2.57.0"
+      "version": "2.58.0",
+      "tag": "v2.58.0"
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.15.0",
-      "tag": "panache-formatter-v0.15.0"
+      "version": "0.16.0",
+      "tag": "panache-formatter-v0.16.0"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.18.0",
-      "tag": "panache-parser-v0.18.0"
+      "version": "0.19.0",
+      "tag": "panache-parser-v0.19.0"
     },
     {
       "path": "editors/code",
-      "version": "2.50.0",
-      "tag": "panache-code-v2.50.0"
+      "version": "2.51.0",
+      "tag": "panache-code-v2.51.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [2.58.0](https://github.com/jolars/panache/compare/v2.57.0...v2.58.0) (2026-06-23)
+
+### Features
+- **linter:** add `consumer-divergence` rule ([`39c799f`](https://github.com/jolars/panache/commit/39c799fdeac2adb4087a7a50de3c447269958986))
+- **linter:** add opt-in unsafe auto-fixes ([`0267d9d`](https://github.com/jolars/panache/commit/0267d9d47fd88d41ed4a092ccb34036f21bf524f))
+- **linter:** add `empty-values` rule ([`aac9a11`](https://github.com/jolars/panache/commit/aac9a112d09ebd0176f1f1ae30d1dea144833921))
+- **config:** add `[compat]` section for quarto, pandoc ([`3d16467`](https://github.com/jolars/panache/commit/3d164679b7f3cfd8326a6de8e7cb10ffc6ce8279))
+- **linter:** validate Quarto YAML schema options ([`7b3d363`](https://github.com/jolars/panache/commit/7b3d36353fcc1db8a9318f867c024c3dcd81fa44)), closes [#385](https://github.com/jolars/panache/issues/385)
+- add `crossref-prefixes` for extension crossrefs ([`0b190cc`](https://github.com/jolars/panache/commit/0b190cc1ad00e1ca146c758226a325b0c7a16017))
+- **formatter:** tighten spacing around scripts and groups ([`d0075c3`](https://github.com/jolars/panache/commit/d0075c39ebaa794c0b60e409e78277361b884773))
+- **formatter:** add presets for badness and arity ([`6a57811`](https://github.com/jolars/panache/commit/6a57811886b65fc47eb2dcaca987c6d3f1edf415))
+- **lsp:** stream partial pull diagnostics ([`1983a7d`](https://github.com/jolars/panache/commit/1983a7df1cf954531f86a18e204025b5cd1d364d))
+- **lsp:** add `textDocument/linkedEditingRange` ([`1a9d07b`](https://github.com/jolars/panache/commit/1a9d07b1e75a5ce1f70bcbb23b099d20a1731be7))
+- **lsp:** reload config on `didChangeConfiguration` ([`c1595be`](https://github.com/jolars/panache/commit/c1595be10b33cb079a6ed4f7be36cfd382998ce3))
+
+### Bug Fixes
+- **formatter:** drop leading blank line in display math ([`6700a54`](https://github.com/jolars/panache/commit/6700a54b489619040c4cea78e79e917105c9a403)), closes [#381](https://github.com/jolars/panache/issues/381), [#382](https://github.com/jolars/panache/issues/382), and [#383](https://github.com/jolars/panache/issues/383)
+
+### Performance Improvements
+- **parser:** de-duplicate definition marker parsing ([`91a1f10`](https://github.com/jolars/panache/commit/91a1f10bc53d92294082a2acfc3442487f49ad2d))
+
+### Dependencies
+- updated crates/panache-formatter to v0.16.0
+- updated crates/panache-parser to v0.19.0
+
 ## [2.57.0](https://github.com/jolars/panache/compare/v2.56.0...v2.57.0) (2026-06-21)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,7 +1182,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "panache"
-version = "2.57.0"
+version = "2.58.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "insta",
  "log",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "entities",
  "insta",
@@ -1434,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "2.57.0"
+version = "2.58.0"
 edition.workspace = true
 # `distill_quarto_schema` is a dev-only vendoring bin (src/bin/); keep bare
 # `cargo run` resolving to the CLI for tooling like the pre-commit format hook.
@@ -48,8 +48,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.15.0" }
-panache-parser = { path = "crates/panache-parser", version = "0.18.0", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.16.0" }
+panache-parser = { path = "crates/panache-parser", version = "0.19.0", features = [
     "serde",
     "schema",
 ] }

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.16.0](https://github.com/jolars/panache/compare/panache-formatter-v0.15.0...panache-formatter-v0.16.0) (2026-06-23)
+
+### Features
+- add `crossref-prefixes` for extension crossrefs ([`0b190cc`](https://github.com/jolars/panache/commit/0b190cc1ad00e1ca146c758226a325b0c7a16017))
+- **formatter:** tighten spacing around scripts and groups ([`d0075c3`](https://github.com/jolars/panache/commit/d0075c39ebaa794c0b60e409e78277361b884773))
+
+### Bug Fixes
+- **formatter:** drop leading blank line in display math ([`6700a54`](https://github.com/jolars/panache/commit/6700a54b489619040c4cea78e79e917105c9a403)), closes [#381](https://github.com/jolars/panache/issues/381), [#382](https://github.com/jolars/panache/issues/382), and [#383](https://github.com/jolars/panache/issues/383)
+
+### Dependencies
+- updated crates/panache-parser to v0.19.0
+
 ## [0.15.0](https://github.com/jolars/panache/compare/panache-formatter-v0.14.0...panache-formatter-v0.15.0) (2026-06-21)
 
 ### Features

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 include = [
     "/src/**/*",
@@ -18,7 +18,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.18.0" }
+panache-parser = { path = "../panache-parser", version = "0.19.0" }
 log = { version = "0.4.31", features = ["release_max_level_debug"] }
 rowan = "0.16.1"
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.19.0](https://github.com/jolars/panache/compare/panache-parser-v0.18.0...panache-parser-v0.19.0) (2026-06-23)
+
+### Features
+- add `crossref-prefixes` for extension crossrefs ([`0b190cc`](https://github.com/jolars/panache/commit/0b190cc1ad00e1ca146c758226a325b0c7a16017))
+
+### Performance Improvements
+- **parser:** de-duplicate definition marker parsing ([`91a1f10`](https://github.com/jolars/panache/commit/91a1f10bc53d92294082a2acfc3442487f49ad2d))
+
 ## [0.18.0](https://github.com/jolars/panache/compare/panache-parser-v0.17.2...panache-parser-v0.18.0) (2026-06-21)
 
 ### Features

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 readme = "README.md"
 include = [

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.51.0](https://github.com/jolars/panache/compare/panache-code-v2.50.0...panache-code-v2.51.0) (2026-06-23)
+
+### Features
+- **lsp:** reload config on `didChangeConfiguration` ([`c1595be`](https://github.com/jolars/panache/commit/c1595be10b33cb079a6ed4f7be36cfd382998ce3))
+
+### Dependencies
+- updated panache to v2.58.0
+
 ## [2.50.0](https://github.com/jolars/panache/compare/panache-code-v2.49.0...panache-code-v2.50.0) (2026-06-21)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "2.50.0",
+  "version": "2.51.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -407,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "2.57.0",
+  "version": "2.58.0",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "2.57.0",
-    "@panache-cli/linux-arm64-gnu": "2.57.0",
-    "@panache-cli/linux-x64-musl": "2.57.0",
-    "@panache-cli/linux-arm64-musl": "2.57.0",
-    "@panache-cli/darwin-x64": "2.57.0",
-    "@panache-cli/darwin-arm64": "2.57.0",
-    "@panache-cli/win32-x64": "2.57.0",
-    "@panache-cli/win32-arm64": "2.57.0"
+    "@panache-cli/linux-x64-gnu": "2.58.0",
+    "@panache-cli/linux-arm64-gnu": "2.58.0",
+    "@panache-cli/linux-x64-musl": "2.58.0",
+    "@panache-cli/linux-arm64-musl": "2.58.0",
+    "@panache-cli/darwin-x64": "2.58.0",
+    "@panache-cli/darwin-arm64": "2.58.0",
+    "@panache-cli/win32-x64": "2.58.0",
+    "@panache-cli/win32-arm64": "2.58.0"
   }
 }


### PR DESCRIPTION
## [panache: 2.58.0](https://github.com/jolars/panache/compare/v2.57.0...v2.58.0) (2026-06-23)

### Features
- **linter:** add `consumer-divergence` rule ([`39c799f`](https://github.com/jolars/panache/commit/39c799fdeac2adb4087a7a50de3c447269958986))
- **linter:** add opt-in unsafe auto-fixes ([`0267d9d`](https://github.com/jolars/panache/commit/0267d9d47fd88d41ed4a092ccb34036f21bf524f))
- **linter:** add `empty-values` rule ([`aac9a11`](https://github.com/jolars/panache/commit/aac9a112d09ebd0176f1f1ae30d1dea144833921))
- **config:** add `[compat]` section for quarto, pandoc ([`3d16467`](https://github.com/jolars/panache/commit/3d164679b7f3cfd8326a6de8e7cb10ffc6ce8279))
- **linter:** validate Quarto YAML schema options ([`7b3d363`](https://github.com/jolars/panache/commit/7b3d36353fcc1db8a9318f867c024c3dcd81fa44)), closes [#385](https://github.com/jolars/panache/issues/385)
- add `crossref-prefixes` for extension crossrefs ([`0b190cc`](https://github.com/jolars/panache/commit/0b190cc1ad00e1ca146c758226a325b0c7a16017))
- **formatter:** tighten spacing around scripts and groups ([`d0075c3`](https://github.com/jolars/panache/commit/d0075c39ebaa794c0b60e409e78277361b884773))
- **formatter:** add presets for badness and arity ([`6a57811`](https://github.com/jolars/panache/commit/6a57811886b65fc47eb2dcaca987c6d3f1edf415))
- **lsp:** stream partial pull diagnostics ([`1983a7d`](https://github.com/jolars/panache/commit/1983a7df1cf954531f86a18e204025b5cd1d364d))
- **lsp:** add `textDocument/linkedEditingRange` ([`1a9d07b`](https://github.com/jolars/panache/commit/1a9d07b1e75a5ce1f70bcbb23b099d20a1731be7))
- **lsp:** reload config on `didChangeConfiguration` ([`c1595be`](https://github.com/jolars/panache/commit/c1595be10b33cb079a6ed4f7be36cfd382998ce3))

### Bug Fixes
- **formatter:** drop leading blank line in display math ([`6700a54`](https://github.com/jolars/panache/commit/6700a54b489619040c4cea78e79e917105c9a403)), closes [#381](https://github.com/jolars/panache/issues/381), [#382](https://github.com/jolars/panache/issues/382), and [#383](https://github.com/jolars/panache/issues/383)

### Performance Improvements
- **parser:** de-duplicate definition marker parsing ([`91a1f10`](https://github.com/jolars/panache/commit/91a1f10bc53d92294082a2acfc3442487f49ad2d))

### Dependencies
- updated crates/panache-formatter to v0.16.0
- updated crates/panache-parser to v0.19.0

## [crates/panache-formatter: 0.16.0](https://github.com/jolars/panache/compare/panache-formatter-v0.15.0...panache-formatter-v0.16.0) (2026-06-23)

### Features
- add `crossref-prefixes` for extension crossrefs ([`0b190cc`](https://github.com/jolars/panache/commit/0b190cc1ad00e1ca146c758226a325b0c7a16017))
- **formatter:** tighten spacing around scripts and groups ([`d0075c3`](https://github.com/jolars/panache/commit/d0075c39ebaa794c0b60e409e78277361b884773))

### Bug Fixes
- **formatter:** drop leading blank line in display math ([`6700a54`](https://github.com/jolars/panache/commit/6700a54b489619040c4cea78e79e917105c9a403)), closes [#381](https://github.com/jolars/panache/issues/381), [#382](https://github.com/jolars/panache/issues/382), and [#383](https://github.com/jolars/panache/issues/383)

### Dependencies
- updated crates/panache-parser to v0.19.0

## [crates/panache-parser: 0.19.0](https://github.com/jolars/panache/compare/panache-parser-v0.18.0...panache-parser-v0.19.0) (2026-06-23)

### Features
- add `crossref-prefixes` for extension crossrefs ([`0b190cc`](https://github.com/jolars/panache/commit/0b190cc1ad00e1ca146c758226a325b0c7a16017))

### Performance Improvements
- **parser:** de-duplicate definition marker parsing ([`91a1f10`](https://github.com/jolars/panache/commit/91a1f10bc53d92294082a2acfc3442487f49ad2d))

## [editors/code: 2.51.0](https://github.com/jolars/panache/compare/panache-code-v2.50.0...panache-code-v2.51.0) (2026-06-23)

### Features
- **lsp:** reload config on `didChangeConfiguration` ([`c1595be`](https://github.com/jolars/panache/commit/c1595be10b33cb079a6ed4f7be36cfd382998ce3))

### Dependencies
- updated panache to v2.58.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).