### PR TITLE
chore(release): v2.59.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "39c799fdeac2adb4087a7a50de3c447269958986",
+  "baseline-sha": "3e734053b2a9a094ba60c2451b4673db4b96c1c4",
   "release-targets": [
     {
       "path": ".",
-      "version": "2.58.0",
-      "tag": "v2.58.0"
+      "version": "2.59.0",
+      "tag": "v2.59.0"
     },
     {
       "path": "crates/panache-dprint",
@@ -14,18 +14,18 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.16.0",
-      "tag": "panache-formatter-v0.16.0"
+      "version": "0.17.0",
+      "tag": "panache-formatter-v0.17.0"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.19.0",
-      "tag": "panache-parser-v0.19.0"
+      "version": "0.19.1",
+      "tag": "panache-parser-v0.19.1"
     },
     {
       "path": "editors/code",
-      "version": "2.51.0",
-      "tag": "panache-code-v2.51.0"
+      "version": "2.52.0",
+      "tag": "panache-code-v2.52.0"
     },
     {
       "path": "editors/zed",
@@ -36,23 +36,23 @@
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "2.58.0",
-      "tag": "v2.58.0"
+      "version": "2.59.0",
+      "tag": "v2.59.0"
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.16.0",
-      "tag": "panache-formatter-v0.16.0"
+      "version": "0.17.0",
+      "tag": "panache-formatter-v0.17.0"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.19.0",
-      "tag": "panache-parser-v0.19.0"
+      "version": "0.19.1",
+      "tag": "panache-parser-v0.19.1"
     },
     {
       "path": "editors/code",
-      "version": "2.51.0",
-      "tag": "panache-code-v2.51.0"
+      "version": "2.52.0",
+      "tag": "panache-code-v2.52.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [2.59.0](https://github.com/jolars/panache/compare/v2.58.0...v2.59.0) (2026-06-24)
+
+### Features
+- **lsp:** add hover detail to citation previews ([`3ac7d67`](https://github.com/jolars/panache/commit/3ac7d675a6046f42d21da00dc657f3d75c4c3745))
+- **linter:** make quarto-schema unknown-key opt-in ([`730d300`](https://github.com/jolars/panache/commit/730d3004fcb645ea426f159805d25d4f82fffd3b))
+- **formatter:** normalize simple table column spacing ([`ff3be98`](https://github.com/jolars/panache/commit/ff3be98f74687f37b80d91a3eb372dbd4d24301a))
+- **formatter:** normalize multiline table column spacing ([`bb255a9`](https://github.com/jolars/panache/commit/bb255a9e2f0c85cc07f6d28539771561d74f7b28)), closes [#389](https://github.com/jolars/panache/issues/389)
+- **formatter:** fold long double-quoted YAML scalars ([`ad68db1`](https://github.com/jolars/panache/commit/ad68db1d263705c24b344231c2eb68343c9e51cc)), closes [#388](https://github.com/jolars/panache/issues/388)
+- surface broken config instead of silently defaulting ([`0a99a56`](https://github.com/jolars/panache/commit/0a99a5625e0eca592277289d63377f3c8712cc6d))
+
+### Bug Fixes
+- **linter:** anchor duplicate-bib key to a real declaration ([`3e73405`](https://github.com/jolars/panache/commit/3e734053b2a9a094ba60c2451b4673db4b96c1c4))
+- **linter:** trim trailing newline from schema value spans ([`d1fedb9`](https://github.com/jolars/panache/commit/d1fedb9ef2dc3d88f99dc710422cc8f6076b9721))
+- **linter:** honor `validate-yaml: false` opt-out ([`9ee7185`](https://github.com/jolars/panache/commit/9ee71856688413cf4b8a14d99bd3b76bd8d0be54))
+- **linter:** enforce edit-distance cap in key suggestions ([`3592f13`](https://github.com/jolars/panache/commit/3592f139379858adfa2282b056b03dbdd2700aff))
+- **build:** include quarto schema in `include` ([`b4a97d0`](https://github.com/jolars/panache/commit/b4a97d0658883b1049cd72e7c6698d98d0a18ba1)), closes [#390](https://github.com/jolars/panache/issues/390)
+- **formatter:** align headerless simple tables from first row ([`ecdd482`](https://github.com/jolars/panache/commit/ecdd482201cefa800a0553b11ae30b056c4f2765))
+- **parser:** stop truncating wide simple-table cells ([`f97694a`](https://github.com/jolars/panache/commit/f97694aeedeaf9913d31853c51025a27565ae68a))
+- **parser:** consume top border of single-row multiline tables ([`0872624`](https://github.com/jolars/panache/commit/0872624d745fa56e11aa493ba41dc452b72818da))
+- **lsp:** compute pull diagnostics on demand ([`9993d69`](https://github.com/jolars/panache/commit/9993d69d0495eb191cb33c4cec7addddab5eb8c9))
+- **linter:** point bibliography span at the value ([`3a70be2`](https://github.com/jolars/panache/commit/3a70be2a5fff08a48cbcb2420d8df680b41acb13))
+- **parser:** emit bare URIs as lossless `AUTO_LINK` ([`52226d5`](https://github.com/jolars/panache/commit/52226d59067843251c71620dec29f25ffc9bcb07))
+
+### Dependencies
+- updated crates/panache-formatter to v0.17.0
+- updated crates/panache-parser to v0.19.1
+
 ## [2.58.0](https://github.com/jolars/panache/compare/v2.57.0...v2.58.0) (2026-06-23)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,11 +696,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -931,9 +931,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.46.5"
+version = "0.46.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a5fe5206f06e589caf25e79fc05ccdf91fca745685fe9fe1a13bbdfb479a631"
+checksum = "8374249b1bdce1c1773a09fa294347e19e4bfeb86d845c2d8ebaf8a8dbf11233"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1182,7 +1182,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "panache"
-version = "2.58.0"
+version = "2.59.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "insta",
  "log",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "entities",
  "insta",
@@ -1515,9 +1515,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.46.5"
+version = "0.46.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e4e17ef386c5383591d07623d3de49cbc601156e7582973e6db98d66a57de2"
+checksum = "65a910f9d63351f9c9d7dc3053d02b214ea3a005917140c70087d7b59cbc5bb1"
 dependencies = [
  "ahash",
  "fluent-uri 0.4.1",
@@ -1610,9 +1610,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "salsa"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfc1e32b8d1a486e3a45a5480fb5dca7912f49262a8916a67378064da4fe1ab"
+checksum = "0b903173b7867d2b5837bad8fe38cb08928b6ec11a27641ff0d9c3f97d2d3860"
 dependencies = [
  "boxcar",
  "crossbeam-queue",
@@ -1636,15 +1636,15 @@ dependencies = [
 
 [[package]]
 name = "salsa-macro-rules"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67dad477a3e3a484a7c2311c1d25160fb270214981be24022de7de8a206a3300"
+checksum = "536f8ea9f7cbcf2e58872bae5a78c95839021facafdab8462324337f89f6d1eb"
 
 [[package]]
 name = "salsa-macros"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943f70e101fb3bd599960e79e719e70d85142730e5b45f3269246086ed218562"
+checksum = "5c49f4d53ec8fa201e74a27dd9eb8320146b0e45ad2b11ae503437109a502965"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "2.58.0"
+version = "2.59.0"
 edition.workspace = true
 # `distill_quarto_schema` is a dev-only vendoring bin (src/bin/); keep bare
 # `cargo run` resolving to the CLI for tooling like the pre-commit format hook.
@@ -52,8 +52,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.16.0" }
-panache-parser = { path = "crates/panache-parser", version = "0.19.0", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.17.0" }
+panache-parser = { path = "crates/panache-parser", version = "0.19.1", features = [
     "serde",
     "schema",
 ] }

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.17.0](https://github.com/jolars/panache/compare/panache-formatter-v0.16.0...panache-formatter-v0.17.0) (2026-06-24)
+
+### Features
+- **formatter:** normalize simple table column spacing ([`ff3be98`](https://github.com/jolars/panache/commit/ff3be98f74687f37b80d91a3eb372dbd4d24301a))
+- **formatter:** normalize multiline table column spacing ([`bb255a9`](https://github.com/jolars/panache/commit/bb255a9e2f0c85cc07f6d28539771561d74f7b28)), closes [#389](https://github.com/jolars/panache/issues/389)
+- **formatter:** fold long double-quoted YAML scalars ([`ad68db1`](https://github.com/jolars/panache/commit/ad68db1d263705c24b344231c2eb68343c9e51cc)), closes [#388](https://github.com/jolars/panache/issues/388)
+
+### Bug Fixes
+- **parser:** emit bare URIs as lossless `AUTO_LINK` ([`52226d5`](https://github.com/jolars/panache/commit/52226d59067843251c71620dec29f25ffc9bcb07))
+- **formatter:** align headerless simple tables from first row ([`ecdd482`](https://github.com/jolars/panache/commit/ecdd482201cefa800a0553b11ae30b056c4f2765))
+- **parser:** stop truncating wide simple-table cells ([`f97694a`](https://github.com/jolars/panache/commit/f97694aeedeaf9913d31853c51025a27565ae68a))
+- **parser:** consume top border of single-row multiline tables ([`0872624`](https://github.com/jolars/panache/commit/0872624d745fa56e11aa493ba41dc452b72818da))
+
+### Dependencies
+- updated crates/panache-parser to v0.19.1
+
 ## [0.16.0](https://github.com/jolars/panache/compare/panache-formatter-v0.15.0...panache-formatter-v0.16.0) (2026-06-23)
 
 ### Features

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.16.0"
+version = "0.17.0"
 edition.workspace = true
 include = [
     "/src/**/*",
@@ -18,7 +18,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.19.0" }
+panache-parser = { path = "../panache-parser", version = "0.19.1" }
 log = { version = "0.4.31", features = ["release_max_level_debug"] }
 rowan = "0.16.1"
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.19.1](https://github.com/jolars/panache/compare/panache-parser-v0.19.0...panache-parser-v0.19.1) (2026-06-24)
+
+### Bug Fixes
+- **parser:** emit bare URIs as lossless `AUTO_LINK` ([`52226d5`](https://github.com/jolars/panache/commit/52226d59067843251c71620dec29f25ffc9bcb07))
+- **linter:** trim trailing newline from schema value spans ([`d1fedb9`](https://github.com/jolars/panache/commit/d1fedb9ef2dc3d88f99dc710422cc8f6076b9721))
+- **parser:** stop truncating wide simple-table cells ([`f97694a`](https://github.com/jolars/panache/commit/f97694aeedeaf9913d31853c51025a27565ae68a))
+- **parser:** consume top border of single-row multiline tables ([`0872624`](https://github.com/jolars/panache/commit/0872624d745fa56e11aa493ba41dc452b72818da))
+
 ## [0.19.0](https://github.com/jolars/panache/compare/panache-parser-v0.18.0...panache-parser-v0.19.0) (2026-06-23)
 
 ### Features

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.19.0"
+version = "0.19.1"
 edition.workspace = true
 readme = "README.md"
 include = [

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.52.0](https://github.com/jolars/panache/compare/panache-code-v2.51.0...panache-code-v2.52.0) (2026-06-24)
+
+### Dependencies
+- updated panache to v2.59.0
+
 ## [2.51.0](https://github.com/jolars/panache/compare/panache-code-v2.50.0...panache-code-v2.51.0) (2026-06-23)
 
 ### Features

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "2.51.0",
+  "version": "2.52.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "2.58.0",
+  "version": "2.59.0",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "2.58.0",
-    "@panache-cli/linux-arm64-gnu": "2.58.0",
-    "@panache-cli/linux-x64-musl": "2.58.0",
-    "@panache-cli/linux-arm64-musl": "2.58.0",
-    "@panache-cli/darwin-x64": "2.58.0",
-    "@panache-cli/darwin-arm64": "2.58.0",
-    "@panache-cli/win32-x64": "2.58.0",
-    "@panache-cli/win32-arm64": "2.58.0"
+    "@panache-cli/linux-x64-gnu": "2.59.0",
+    "@panache-cli/linux-arm64-gnu": "2.59.0",
+    "@panache-cli/linux-x64-musl": "2.59.0",
+    "@panache-cli/linux-arm64-musl": "2.59.0",
+    "@panache-cli/darwin-x64": "2.59.0",
+    "@panache-cli/darwin-arm64": "2.59.0",
+    "@panache-cli/win32-x64": "2.59.0",
+    "@panache-cli/win32-arm64": "2.59.0"
   }
 }


### PR DESCRIPTION
## [panache: 2.59.0](https://github.com/jolars/panache/compare/v2.58.0...v2.59.0) (2026-06-24)

### Features
- **lsp:** add hover detail to citation previews ([`3ac7d67`](https://github.com/jolars/panache/commit/3ac7d675a6046f42d21da00dc657f3d75c4c3745))
- **linter:** make quarto-schema unknown-key opt-in ([`730d300`](https://github.com/jolars/panache/commit/730d3004fcb645ea426f159805d25d4f82fffd3b))
- **formatter:** normalize simple table column spacing ([`ff3be98`](https://github.com/jolars/panache/commit/ff3be98f74687f37b80d91a3eb372dbd4d24301a))
- **formatter:** normalize multiline table column spacing ([`bb255a9`](https://github.com/jolars/panache/commit/bb255a9e2f0c85cc07f6d28539771561d74f7b28)), closes [#389](https://github.com/jolars/panache/issues/389)
- **formatter:** fold long double-quoted YAML scalars ([`ad68db1`](https://github.com/jolars/panache/commit/ad68db1d263705c24b344231c2eb68343c9e51cc)), closes [#388](https://github.com/jolars/panache/issues/388)
- surface broken config instead of silently defaulting ([`0a99a56`](https://github.com/jolars/panache/commit/0a99a5625e0eca592277289d63377f3c8712cc6d))

### Bug Fixes
- **linter:** anchor duplicate-bib key to a real declaration ([`3e73405`](https://github.com/jolars/panache/commit/3e734053b2a9a094ba60c2451b4673db4b96c1c4))
- **linter:** trim trailing newline from schema value spans ([`d1fedb9`](https://github.com/jolars/panache/commit/d1fedb9ef2dc3d88f99dc710422cc8f6076b9721))
- **linter:** honor `validate-yaml: false` opt-out ([`9ee7185`](https://github.com/jolars/panache/commit/9ee71856688413cf4b8a14d99bd3b76bd8d0be54))
- **linter:** enforce edit-distance cap in key suggestions ([`3592f13`](https://github.com/jolars/panache/commit/3592f139379858adfa2282b056b03dbdd2700aff))
- **build:** include quarto schema in `include` ([`b4a97d0`](https://github.com/jolars/panache/commit/b4a97d0658883b1049cd72e7c6698d98d0a18ba1)), closes [#390](https://github.com/jolars/panache/issues/390)
- **formatter:** align headerless simple tables from first row ([`ecdd482`](https://github.com/jolars/panache/commit/ecdd482201cefa800a0553b11ae30b056c4f2765))
- **parser:** stop truncating wide simple-table cells ([`f97694a`](https://github.com/jolars/panache/commit/f97694aeedeaf9913d31853c51025a27565ae68a))
- **parser:** consume top border of single-row multiline tables ([`0872624`](https://github.com/jolars/panache/commit/0872624d745fa56e11aa493ba41dc452b72818da))
- **lsp:** compute pull diagnostics on demand ([`9993d69`](https://github.com/jolars/panache/commit/9993d69d0495eb191cb33c4cec7addddab5eb8c9))
- **linter:** point bibliography span at the value ([`3a70be2`](https://github.com/jolars/panache/commit/3a70be2a5fff08a48cbcb2420d8df680b41acb13))
- **parser:** emit bare URIs as lossless `AUTO_LINK` ([`52226d5`](https://github.com/jolars/panache/commit/52226d59067843251c71620dec29f25ffc9bcb07))

### Dependencies
- updated crates/panache-formatter to v0.17.0
- updated crates/panache-parser to v0.19.1

## [crates/panache-formatter: 0.17.0](https://github.com/jolars/panache/compare/panache-formatter-v0.16.0...panache-formatter-v0.17.0) (2026-06-24)

### Features
- **formatter:** normalize simple table column spacing ([`ff3be98`](https://github.com/jolars/panache/commit/ff3be98f74687f37b80d91a3eb372dbd4d24301a))
- **formatter:** normalize multiline table column spacing ([`bb255a9`](https://github.com/jolars/panache/commit/bb255a9e2f0c85cc07f6d28539771561d74f7b28)), closes [#389](https://github.com/jolars/panache/issues/389)
- **formatter:** fold long double-quoted YAML scalars ([`ad68db1`](https://github.com/jolars/panache/commit/ad68db1d263705c24b344231c2eb68343c9e51cc)), closes [#388](https://github.com/jolars/panache/issues/388)

### Bug Fixes
- **parser:** emit bare URIs as lossless `AUTO_LINK` ([`52226d5`](https://github.com/jolars/panache/commit/52226d59067843251c71620dec29f25ffc9bcb07))
- **formatter:** align headerless simple tables from first row ([`ecdd482`](https://github.com/jolars/panache/commit/ecdd482201cefa800a0553b11ae30b056c4f2765))
- **parser:** stop truncating wide simple-table cells ([`f97694a`](https://github.com/jolars/panache/commit/f97694aeedeaf9913d31853c51025a27565ae68a))
- **parser:** consume top border of single-row multiline tables ([`0872624`](https://github.com/jolars/panache/commit/0872624d745fa56e11aa493ba41dc452b72818da))

### Dependencies
- updated crates/panache-parser to v0.19.1

## [crates/panache-parser: 0.19.1](https://github.com/jolars/panache/compare/panache-parser-v0.19.0...panache-parser-v0.19.1) (2026-06-24)

### Bug Fixes
- **parser:** emit bare URIs as lossless `AUTO_LINK` ([`52226d5`](https://github.com/jolars/panache/commit/52226d59067843251c71620dec29f25ffc9bcb07))
- **linter:** trim trailing newline from schema value spans ([`d1fedb9`](https://github.com/jolars/panache/commit/d1fedb9ef2dc3d88f99dc710422cc8f6076b9721))
- **parser:** stop truncating wide simple-table cells ([`f97694a`](https://github.com/jolars/panache/commit/f97694aeedeaf9913d31853c51025a27565ae68a))
- **parser:** consume top border of single-row multiline tables ([`0872624`](https://github.com/jolars/panache/commit/0872624d745fa56e11aa493ba41dc452b72818da))

## [editors/code: 2.52.0](https://github.com/jolars/panache/compare/panache-code-v2.51.0...panache-code-v2.52.0) (2026-06-24)

### Dependencies
- updated panache to v2.59.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).