### PR TITLE
chore(release): v2.60.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "3e734053b2a9a094ba60c2451b4673db4b96c1c4",
+  "baseline-sha": "4a8d1ebaae3e4a9bb71385d825c32fea6502336a",
   "release-targets": [
     {
       "path": ".",
-      "version": "2.59.0",
-      "tag": "v2.59.0"
+      "version": "2.60.0",
+      "tag": "v2.60.0"
     },
     {
       "path": "crates/panache-dprint",
@@ -14,18 +14,18 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.17.0",
-      "tag": "panache-formatter-v0.17.0"
+      "version": "0.18.0",
+      "tag": "panache-formatter-v0.18.0"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.19.1",
-      "tag": "panache-parser-v0.19.1"
+      "version": "0.20.0",
+      "tag": "panache-parser-v0.20.0"
     },
     {
       "path": "editors/code",
-      "version": "2.52.0",
-      "tag": "panache-code-v2.52.0"
+      "version": "2.53.0",
+      "tag": "panache-code-v2.53.0"
     },
     {
       "path": "editors/zed",
@@ -36,23 +36,23 @@
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "2.59.0",
-      "tag": "v2.59.0"
+      "version": "2.60.0",
+      "tag": "v2.60.0"
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.17.0",
-      "tag": "panache-formatter-v0.17.0"
+      "version": "0.18.0",
+      "tag": "panache-formatter-v0.18.0"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.19.1",
-      "tag": "panache-parser-v0.19.1"
+      "version": "0.20.0",
+      "tag": "panache-parser-v0.20.0"
     },
     {
       "path": "editors/code",
-      "version": "2.52.0",
-      "tag": "panache-code-v2.52.0"
+      "version": "2.53.0",
+      "tag": "panache-code-v2.53.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [2.60.0](https://github.com/jolars/panache/compare/v2.59.0...v2.60.0) (2026-07-01)
 
 ### Highlights
 
@@ -16,6 +16,46 @@ This release introduces experimental support for two new flavors:
   scientific and technical writing. Myst is built on top of CommonMark (which
   Panache is compliant with), but adds Quarto/R Markdown-style extensions for
   citations, cross-references, and directives.
+
+### Features
+- **parser:** add MyST AST wrappers ([`e5d7ba8`](https://github.com/jolars/panache/commit/e5d7ba838d4afda1cc6ede8b20b5274dbb50f622))
+- **config:** add Ruff-style `extend` for config inheritance ([`3202d5e`](https://github.com/jolars/panache/commit/3202d5eed89d7a59ff866aee53c99129b8989474))
+- **parser:** treat standalone Svelte spans as opaque blocks ([`414d441`](https://github.com/jolars/panache/commit/414d441f8990f8874a604b63fd13b50fa5ce0564))
+- **lsp:** add multi-root workspaces ([`3ce0f93`](https://github.com/jolars/panache/commit/3ce0f93a5ac87163721634991f343a43e4c67603))
+- **lsp:** support `textDocument/documentHighlight` ([`1436780`](https://github.com/jolars/panache/commit/14367800d3fa4c9cf5f8b155d49df632679a3c44))
+- **parser:** align myst defaults with myst-parser ([`4232185`](https://github.com/jolars/panache/commit/4232185235ffb74b898c0332e9e8400bd98f88a9))
+- **formatter:** route myst directive bodies to external tools ([`81c19f6`](https://github.com/jolars/panache/commit/81c19f659b95fdaaa335dec14e11a1c978f24f48))
+- **parser:** parse myst verbatim-bodies ([`2d8a516`](https://github.com/jolars/panache/commit/2d8a51622766163b5963626ea4fe38d299179d47))
+- **parser:** parse MyST directive option blocks ([`17990eb`](https://github.com/jolars/panache/commit/17990eb07e397762f28e2365c95c064dc590cba1))
+- **parser:** add MyST flavor scaffolding ([`b4bdd84`](https://github.com/jolars/panache/commit/b4bdd84f56d8957583b1eb2ca4527d0d4952c1a5))
+- **parser:** split standalone block-tag sequences in CST ([`9bf0005`](https://github.com/jolars/panache/commit/9bf00052b23f594281b9ef0f0025556ea1ae58b4))
+- add `llms.txt` ([`bb1630a`](https://github.com/jolars/panache/commit/bb1630aac64fbbe3591b916419de93946dcc9abf))
+- **parser:** gate YAML tab-indent diagnostics per consumer ([`dffefc8`](https://github.com/jolars/panache/commit/dffefc8d391888f08fbcbafb3200c0034e4bbe9d))
+- **config:** move `line-width`/`line-ending` under `[format]` ([`382ee5d`](https://github.com/jolars/panache/commit/382ee5d09ddf253d3ca30454a2956feb3dad4261))
+- **formatters:** add html to biome ([`bdd09a4`](https://github.com/jolars/panache/commit/bdd09a44a390b6c31b7cf4af3416531a9eb11341))
+- **formatters:** add ojs to prettier and biome ([`1d6d2d6`](https://github.com/jolars/panache/commit/1d6d2d67d1b3ab55d7781a5279b61d27d12ce97e))
+- **linter:** report bib-key duplicates against project manifest ([`074912a`](https://github.com/jolars/panache/commit/074912a5583395eb1da6bca0821da2b938e9b83d))
+- add python-markdown admonitions and pymdownx details ([`b37a5cc`](https://github.com/jolars/panache/commit/b37a5cc2887029953eeb44b673a2fed39f3550be)), fixes [#396](https://github.com/jolars/panache/issues/396)
+- wire mdsvex flavor through LSP, CLI, and editor ([`89e1e79`](https://github.com/jolars/panache/commit/89e1e792162217af7ad268ce743d8f01117c6080))
+- add mdsvex flavor with opaque Svelte template spans ([`983632a`](https://github.com/jolars/panache/commit/983632ac09ff66c469f74d834452773f59f8a960))
+
+### Bug Fixes
+- **parser:** treat `{toctree}` body as verbatim ([`1ad3e87`](https://github.com/jolars/panache/commit/1ad3e878d63b967db18a083e8c622f00039a6132))
+- **linter:** skip verbatim MyST bodies in `html-entities` ([`fa41d83`](https://github.com/jolars/panache/commit/fa41d831cc21c68fd27e9dfd0a7a7aea2f892e1e))
+- **formatter:** keep block markers inline in sentence wrap ([`3d8717d`](https://github.com/jolars/panache/commit/3d8717d2d3bbfb69dac24fef7715329d54588df0))
+- **linter:** tailor chunk-label prefix to language ([`fd66a98`](https://github.com/jolars/panache/commit/fd66a98995f0ab4ad44c43a51368c6b9caebf449))
+- **parser:** parse headerless multiline tables with a dash-run closer ([`ab7e7d3`](https://github.com/jolars/panache/commit/ab7e7d315433e6e11d220c2735d2e7d4d884c10a)), fixes [#398](https://github.com/jolars/panache/issues/398)
+- **lsp:** self-heal referenced files without watch events ([`286ae13`](https://github.com/jolars/panache/commit/286ae138dc735608b07c54054cb2c560986a7860))
+- **linter:** scope `duplicate-bibliography-key` to declaring docs ([`38a0437`](https://github.com/jolars/panache/commit/38a0437e9157cd02bf87774612e460ebe898b256))
+- **formatter:** hoist folded `>-` onto key line ([`0744175`](https://github.com/jolars/panache/commit/07441752bd5ea74e4d2325001112d3f4db4217e1)), fixes [#400](https://github.com/jolars/panache/issues/400)
+- **parser:** open brace-info code fences in CommonMark ([`179cb1c`](https://github.com/jolars/panache/commit/179cb1c6f4b876708d48cda827594b0282ff4b90))
+- **parser:** span inline math across a newline (Pandoc only) ([`9b7905e`](https://github.com/jolars/panache/commit/9b7905eba103ff61d0ecbcf624e00e8032e036d2))
+- **parser:** span inline math across a single newline ([`ace2ab4`](https://github.com/jolars/panache/commit/ace2ab429ddc017e235247a9bd077d6cdf8b199d))
+- **parser:** require left word boundary for bare URIs ([`f7b6334`](https://github.com/jolars/panache/commit/f7b6334c45902592955e5a8bb24b9545f2ba7223))
+
+### Dependencies
+- updated crates/panache-formatter to v0.18.0
+- updated crates/panache-parser to v0.20.0
 
 ## [2.59.0](https://github.com/jolars/panache/compare/v2.58.0...v2.59.0) (2026-06-24)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,13 +160,13 @@ checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -263,9 +263,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -895,9 +895,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.29"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
+checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
 dependencies = [
  "defmt",
  "jiff-static",
@@ -909,9 +909,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.29"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
+checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -920,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -970,9 +970,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
@@ -1182,7 +1182,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "panache"
-version = "2.59.0"
+version = "2.60.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "insta",
  "log",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "entities",
  "insta",
@@ -2086,9 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2099,9 +2099,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2109,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2122,9 +2122,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "2.59.0"
+version = "2.60.0"
 edition.workspace = true
 # `distill_quarto_schema` is a dev-only vendoring bin (src/bin/); keep bare
 # `cargo run` resolving to the CLI for tooling like the pre-commit format hook.
@@ -52,8 +52,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.17.0" }
-panache-parser = { path = "crates/panache-parser", version = "0.19.1", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.18.0" }
+panache-parser = { path = "crates/panache-parser", version = "0.20.0", features = [
     "serde",
     "schema",
 ] }

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.18.0](https://github.com/jolars/panache/compare/panache-formatter-v0.17.0...panache-formatter-v0.18.0) (2026-07-01)
+
+### Features
+- **parser:** treat standalone Svelte spans as opaque blocks ([`414d441`](https://github.com/jolars/panache/commit/414d441f8990f8874a604b63fd13b50fa5ce0564))
+- **parser:** align myst defaults with myst-parser ([`4232185`](https://github.com/jolars/panache/commit/4232185235ffb74b898c0332e9e8400bd98f88a9))
+- **formatter:** route myst directive bodies to external tools ([`81c19f6`](https://github.com/jolars/panache/commit/81c19f659b95fdaaa335dec14e11a1c978f24f48))
+- **parser:** parse myst verbatim-bodies ([`2d8a516`](https://github.com/jolars/panache/commit/2d8a51622766163b5963626ea4fe38d299179d47))
+- **parser:** parse MyST directive option blocks ([`17990eb`](https://github.com/jolars/panache/commit/17990eb07e397762f28e2365c95c064dc590cba1))
+- **parser:** add MyST flavor scaffolding ([`b4bdd84`](https://github.com/jolars/panache/commit/b4bdd84f56d8957583b1eb2ca4527d0d4952c1a5))
+- add python-markdown admonitions and pymdownx details ([`b37a5cc`](https://github.com/jolars/panache/commit/b37a5cc2887029953eeb44b673a2fed39f3550be)), fixes [#396](https://github.com/jolars/panache/issues/396)
+
+### Bug Fixes
+- **formatter:** keep block markers inline in sentence wrap ([`3d8717d`](https://github.com/jolars/panache/commit/3d8717d2d3bbfb69dac24fef7715329d54588df0))
+- **formatter:** hoist folded `>-` onto key line ([`0744175`](https://github.com/jolars/panache/commit/07441752bd5ea74e4d2325001112d3f4db4217e1)), fixes [#400](https://github.com/jolars/panache/issues/400)
+- **parser:** parse headerless multiline tables with a dash-run closer ([`ab7e7d3`](https://github.com/jolars/panache/commit/ab7e7d315433e6e11d220c2735d2e7d4d884c10a)), fixes [#398](https://github.com/jolars/panache/issues/398)
+
+### Dependencies
+- updated crates/panache-parser to v0.20.0
+
 ## [0.17.0](https://github.com/jolars/panache/compare/panache-formatter-v0.16.0...panache-formatter-v0.17.0) (2026-06-24)
 
 ### Features

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.17.0"
+version = "0.18.0"
 edition.workspace = true
 include = [
     "/src/**/*",
@@ -18,7 +18,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.19.1" }
+panache-parser = { path = "../panache-parser", version = "0.20.0" }
 log = { version = "0.4.31", features = ["release_max_level_debug"] }
 rowan = "0.16.1"
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.20.0](https://github.com/jolars/panache/compare/panache-parser-v0.19.1...panache-parser-v0.20.0) (2026-07-01)
+
+### Features
+- **parser:** add MyST AST wrappers ([`e5d7ba8`](https://github.com/jolars/panache/commit/e5d7ba838d4afda1cc6ede8b20b5274dbb50f622))
+- **parser:** treat standalone Svelte spans as opaque blocks ([`414d441`](https://github.com/jolars/panache/commit/414d441f8990f8874a604b63fd13b50fa5ce0564))
+- **parser:** align myst defaults with myst-parser ([`4232185`](https://github.com/jolars/panache/commit/4232185235ffb74b898c0332e9e8400bd98f88a9))
+- **parser:** parse myst verbatim-bodies ([`2d8a516`](https://github.com/jolars/panache/commit/2d8a51622766163b5963626ea4fe38d299179d47))
+- **parser:** parse MyST directive option blocks ([`17990eb`](https://github.com/jolars/panache/commit/17990eb07e397762f28e2365c95c064dc590cba1))
+- **parser:** add MyST flavor scaffolding ([`b4bdd84`](https://github.com/jolars/panache/commit/b4bdd84f56d8957583b1eb2ca4527d0d4952c1a5))
+- **parser:** split standalone block-tag sequences in CST ([`9bf0005`](https://github.com/jolars/panache/commit/9bf00052b23f594281b9ef0f0025556ea1ae58b4))
+- **parser:** gate YAML tab-indent diagnostics per consumer ([`dffefc8`](https://github.com/jolars/panache/commit/dffefc8d391888f08fbcbafb3200c0034e4bbe9d))
+- add python-markdown admonitions and pymdownx details ([`b37a5cc`](https://github.com/jolars/panache/commit/b37a5cc2887029953eeb44b673a2fed39f3550be)), fixes [#396](https://github.com/jolars/panache/issues/396)
+- add mdsvex flavor with opaque Svelte template spans ([`983632a`](https://github.com/jolars/panache/commit/983632ac09ff66c469f74d834452773f59f8a960))
+
+### Bug Fixes
+- **parser:** treat `{toctree}` body as verbatim ([`1ad3e87`](https://github.com/jolars/panache/commit/1ad3e878d63b967db18a083e8c622f00039a6132))
+- **parser:** open brace-info code fences in CommonMark ([`179cb1c`](https://github.com/jolars/panache/commit/179cb1c6f4b876708d48cda827594b0282ff4b90))
+- **parser:** span inline math across a newline (Pandoc only) ([`9b7905e`](https://github.com/jolars/panache/commit/9b7905eba103ff61d0ecbcf624e00e8032e036d2))
+- **parser:** span inline math across a single newline ([`ace2ab4`](https://github.com/jolars/panache/commit/ace2ab429ddc017e235247a9bd077d6cdf8b199d))
+- **parser:** parse headerless multiline tables with a dash-run closer ([`ab7e7d3`](https://github.com/jolars/panache/commit/ab7e7d315433e6e11d220c2735d2e7d4d884c10a)), fixes [#398](https://github.com/jolars/panache/issues/398)
+- **parser:** require left word boundary for bare URIs ([`f7b6334`](https://github.com/jolars/panache/commit/f7b6334c45902592955e5a8bb24b9545f2ba7223))
+
 ## [0.19.1](https://github.com/jolars/panache/compare/panache-parser-v0.19.0...panache-parser-v0.19.1) (2026-06-24)
 
 ### Bug Fixes

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.19.1"
+version = "0.20.0"
 edition.workspace = true
 readme = "README.md"
 include = [

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.53.0](https://github.com/jolars/panache/compare/panache-code-v2.52.0...panache-code-v2.53.0) (2026-07-01)
+
+### Features
+- wire mdsvex flavor through LSP, CLI, and editor ([`89e1e79`](https://github.com/jolars/panache/commit/89e1e792162217af7ad268ce743d8f01117c6080))
+
+### Dependencies
+- updated panache to v2.60.0
+
 ## [2.52.0](https://github.com/jolars/panache/compare/panache-code-v2.51.0...panache-code-v2.52.0) (2026-06-24)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "2.52.0",
+  "version": "2.53.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "auditable-serde"

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         panache = pkgs.rustPlatform.buildRustPackage {
           pname = "panache";
-          version = "2.32.0";
+          version = "2.60.0";
 
           src = ./.;
 

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "2.59.0",
+  "version": "2.60.0",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "2.59.0",
-    "@panache-cli/linux-arm64-gnu": "2.59.0",
-    "@panache-cli/linux-x64-musl": "2.59.0",
-    "@panache-cli/linux-arm64-musl": "2.59.0",
-    "@panache-cli/darwin-x64": "2.59.0",
-    "@panache-cli/darwin-arm64": "2.59.0",
-    "@panache-cli/win32-x64": "2.59.0",
-    "@panache-cli/win32-arm64": "2.59.0"
+    "@panache-cli/linux-x64-gnu": "2.60.0",
+    "@panache-cli/linux-arm64-gnu": "2.60.0",
+    "@panache-cli/linux-x64-musl": "2.60.0",
+    "@panache-cli/linux-arm64-musl": "2.60.0",
+    "@panache-cli/darwin-x64": "2.60.0",
+    "@panache-cli/darwin-arm64": "2.60.0",
+    "@panache-cli/win32-x64": "2.60.0",
+    "@panache-cli/win32-arm64": "2.60.0"
   }
 }


### PR DESCRIPTION
## [panache: 2.60.0](https://github.com/jolars/panache/compare/v2.59.0...v2.60.0) (2026-07-01)

### Highlights

This release introduces experimental support for two new flavors: 

- [mdsvex](https://mdsvex.com/), a Svelte-based Markdown
  preprocessor. This means that Panache can now parse and format `.svx` files,
  which are Markdown files that can contain Svelte components. The parser and
  formatter will treat Svelte components as opaque blocks, preserving their
  content and formatting them according to the surrounding Markdown context.

- [myst](https://mystmd.org/), a flavor of Markdown designed for
  scientific and technical writing. Myst is built on top of CommonMark (which
  Panache is compliant with), but adds Quarto/R Markdown-style extensions for
  citations, cross-references, and directives.

### Features
- **parser:** add MyST AST wrappers ([`e5d7ba8`](https://github.com/jolars/panache/commit/e5d7ba838d4afda1cc6ede8b20b5274dbb50f622))
- **config:** add Ruff-style `extend` for config inheritance ([`3202d5e`](https://github.com/jolars/panache/commit/3202d5eed89d7a59ff866aee53c99129b8989474))
- **parser:** treat standalone Svelte spans as opaque blocks ([`414d441`](https://github.com/jolars/panache/commit/414d441f8990f8874a604b63fd13b50fa5ce0564))
- **lsp:** add multi-root workspaces ([`3ce0f93`](https://github.com/jolars/panache/commit/3ce0f93a5ac87163721634991f343a43e4c67603))
- **lsp:** support `textDocument/documentHighlight` ([`1436780`](https://github.com/jolars/panache/commit/14367800d3fa4c9cf5f8b155d49df632679a3c44))
- **parser:** align myst defaults with myst-parser ([`4232185`](https://github.com/jolars/panache/commit/4232185235ffb74b898c0332e9e8400bd98f88a9))
- **formatter:** route myst directive bodies to external tools ([`81c19f6`](https://github.com/jolars/panache/commit/81c19f659b95fdaaa335dec14e11a1c978f24f48))
- **parser:** parse myst verbatim-bodies ([`2d8a516`](https://github.com/jolars/panache/commit/2d8a51622766163b5963626ea4fe38d299179d47))
- **parser:** parse MyST directive option blocks ([`17990eb`](https://github.com/jolars/panache/commit/17990eb07e397762f28e2365c95c064dc590cba1))
- **parser:** add MyST flavor scaffolding ([`b4bdd84`](https://github.com/jolars/panache/commit/b4bdd84f56d8957583b1eb2ca4527d0d4952c1a5))
- **parser:** split standalone block-tag sequences in CST ([`9bf0005`](https://github.com/jolars/panache/commit/9bf00052b23f594281b9ef0f0025556ea1ae58b4))
- add `llms.txt` ([`bb1630a`](https://github.com/jolars/panache/commit/bb1630aac64fbbe3591b916419de93946dcc9abf))
- **parser:** gate YAML tab-indent diagnostics per consumer ([`dffefc8`](https://github.com/jolars/panache/commit/dffefc8d391888f08fbcbafb3200c0034e4bbe9d))
- **config:** move `line-width`/`line-ending` under `[format]` ([`382ee5d`](https://github.com/jolars/panache/commit/382ee5d09ddf253d3ca30454a2956feb3dad4261))
- **formatters:** add html to biome ([`bdd09a4`](https://github.com/jolars/panache/commit/bdd09a44a390b6c31b7cf4af3416531a9eb11341))
- **formatters:** add ojs to prettier and biome ([`1d6d2d6`](https://github.com/jolars/panache/commit/1d6d2d67d1b3ab55d7781a5279b61d27d12ce97e))
- **linter:** report bib-key duplicates against project manifest ([`074912a`](https://github.com/jolars/panache/commit/074912a5583395eb1da6bca0821da2b938e9b83d))
- add python-markdown admonitions and pymdownx details ([`b37a5cc`](https://github.com/jolars/panache/commit/b37a5cc2887029953eeb44b673a2fed39f3550be)), fixes [#396](https://github.com/jolars/panache/issues/396)
- wire mdsvex flavor through LSP, CLI, and editor ([`89e1e79`](https://github.com/jolars/panache/commit/89e1e792162217af7ad268ce743d8f01117c6080))
- add mdsvex flavor with opaque Svelte template spans ([`983632a`](https://github.com/jolars/panache/commit/983632ac09ff66c469f74d834452773f59f8a960))

### Bug Fixes
- **parser:** treat `{toctree}` body as verbatim ([`1ad3e87`](https://github.com/jolars/panache/commit/1ad3e878d63b967db18a083e8c622f00039a6132))
- **linter:** skip verbatim MyST bodies in `html-entities` ([`fa41d83`](https://github.com/jolars/panache/commit/fa41d831cc21c68fd27e9dfd0a7a7aea2f892e1e))
- **formatter:** keep block markers inline in sentence wrap ([`3d8717d`](https://github.com/jolars/panache/commit/3d8717d2d3bbfb69dac24fef7715329d54588df0))
- **linter:** tailor chunk-label prefix to language ([`fd66a98`](https://github.com/jolars/panache/commit/fd66a98995f0ab4ad44c43a51368c6b9caebf449))
- **parser:** parse headerless multiline tables with a dash-run closer ([`ab7e7d3`](https://github.com/jolars/panache/commit/ab7e7d315433e6e11d220c2735d2e7d4d884c10a)), fixes [#398](https://github.com/jolars/panache/issues/398)
- **lsp:** self-heal referenced files without watch events ([`286ae13`](https://github.com/jolars/panache/commit/286ae138dc735608b07c54054cb2c560986a7860))
- **linter:** scope `duplicate-bibliography-key` to declaring docs ([`38a0437`](https://github.com/jolars/panache/commit/38a0437e9157cd02bf87774612e460ebe898b256))
- **formatter:** hoist folded `>-` onto key line ([`0744175`](https://github.com/jolars/panache/commit/07441752bd5ea74e4d2325001112d3f4db4217e1)), fixes [#400](https://github.com/jolars/panache/issues/400)
- **parser:** open brace-info code fences in CommonMark ([`179cb1c`](https://github.com/jolars/panache/commit/179cb1c6f4b876708d48cda827594b0282ff4b90))
- **parser:** span inline math across a newline (Pandoc only) ([`9b7905e`](https://github.com/jolars/panache/commit/9b7905eba103ff61d0ecbcf624e00e8032e036d2))
- **parser:** span inline math across a single newline ([`ace2ab4`](https://github.com/jolars/panache/commit/ace2ab429ddc017e235247a9bd077d6cdf8b199d))
- **parser:** require left word boundary for bare URIs ([`f7b6334`](https://github.com/jolars/panache/commit/f7b6334c45902592955e5a8bb24b9545f2ba7223))

### Dependencies
- updated crates/panache-formatter to v0.18.0
- updated crates/panache-parser to v0.20.0

## [crates/panache-formatter: 0.18.0](https://github.com/jolars/panache/compare/panache-formatter-v0.17.0...panache-formatter-v0.18.0) (2026-07-01)

### Features
- **parser:** treat standalone Svelte spans as opaque blocks ([`414d441`](https://github.com/jolars/panache/commit/414d441f8990f8874a604b63fd13b50fa5ce0564))
- **parser:** align myst defaults with myst-parser ([`4232185`](https://github.com/jolars/panache/commit/4232185235ffb74b898c0332e9e8400bd98f88a9))
- **formatter:** route myst directive bodies to external tools ([`81c19f6`](https://github.com/jolars/panache/commit/81c19f659b95fdaaa335dec14e11a1c978f24f48))
- **parser:** parse myst verbatim-bodies ([`2d8a516`](https://github.com/jolars/panache/commit/2d8a51622766163b5963626ea4fe38d299179d47))
- **parser:** parse MyST directive option blocks ([`17990eb`](https://github.com/jolars/panache/commit/17990eb07e397762f28e2365c95c064dc590cba1))
- **parser:** add MyST flavor scaffolding ([`b4bdd84`](https://github.com/jolars/panache/commit/b4bdd84f56d8957583b1eb2ca4527d0d4952c1a5))
- add python-markdown admonitions and pymdownx details ([`b37a5cc`](https://github.com/jolars/panache/commit/b37a5cc2887029953eeb44b673a2fed39f3550be)), fixes [#396](https://github.com/jolars/panache/issues/396)

### Bug Fixes
- **formatter:** keep block markers inline in sentence wrap ([`3d8717d`](https://github.com/jolars/panache/commit/3d8717d2d3bbfb69dac24fef7715329d54588df0))
- **formatter:** hoist folded `>-` onto key line ([`0744175`](https://github.com/jolars/panache/commit/07441752bd5ea74e4d2325001112d3f4db4217e1)), fixes [#400](https://github.com/jolars/panache/issues/400)
- **parser:** parse headerless multiline tables with a dash-run closer ([`ab7e7d3`](https://github.com/jolars/panache/commit/ab7e7d315433e6e11d220c2735d2e7d4d884c10a)), fixes [#398](https://github.com/jolars/panache/issues/398)

### Dependencies
- updated crates/panache-parser to v0.20.0

## [crates/panache-parser: 0.20.0](https://github.com/jolars/panache/compare/panache-parser-v0.19.1...panache-parser-v0.20.0) (2026-07-01)

### Features
- **parser:** add MyST AST wrappers ([`e5d7ba8`](https://github.com/jolars/panache/commit/e5d7ba838d4afda1cc6ede8b20b5274dbb50f622))
- **parser:** treat standalone Svelte spans as opaque blocks ([`414d441`](https://github.com/jolars/panache/commit/414d441f8990f8874a604b63fd13b50fa5ce0564))
- **parser:** align myst defaults with myst-parser ([`4232185`](https://github.com/jolars/panache/commit/4232185235ffb74b898c0332e9e8400bd98f88a9))
- **parser:** parse myst verbatim-bodies ([`2d8a516`](https://github.com/jolars/panache/commit/2d8a51622766163b5963626ea4fe38d299179d47))
- **parser:** parse MyST directive option blocks ([`17990eb`](https://github.com/jolars/panache/commit/17990eb07e397762f28e2365c95c064dc590cba1))
- **parser:** add MyST flavor scaffolding ([`b4bdd84`](https://github.com/jolars/panache/commit/b4bdd84f56d8957583b1eb2ca4527d0d4952c1a5))
- **parser:** split standalone block-tag sequences in CST ([`9bf0005`](https://github.com/jolars/panache/commit/9bf00052b23f594281b9ef0f0025556ea1ae58b4))
- **parser:** gate YAML tab-indent diagnostics per consumer ([`dffefc8`](https://github.com/jolars/panache/commit/dffefc8d391888f08fbcbafb3200c0034e4bbe9d))
- add python-markdown admonitions and pymdownx details ([`b37a5cc`](https://github.com/jolars/panache/commit/b37a5cc2887029953eeb44b673a2fed39f3550be)), fixes [#396](https://github.com/jolars/panache/issues/396)
- add mdsvex flavor with opaque Svelte template spans ([`983632a`](https://github.com/jolars/panache/commit/983632ac09ff66c469f74d834452773f59f8a960))

### Bug Fixes
- **parser:** treat `{toctree}` body as verbatim ([`1ad3e87`](https://github.com/jolars/panache/commit/1ad3e878d63b967db18a083e8c622f00039a6132))
- **parser:** open brace-info code fences in CommonMark ([`179cb1c`](https://github.com/jolars/panache/commit/179cb1c6f4b876708d48cda827594b0282ff4b90))
- **parser:** span inline math across a newline (Pandoc only) ([`9b7905e`](https://github.com/jolars/panache/commit/9b7905eba103ff61d0ecbcf624e00e8032e036d2))
- **parser:** span inline math across a single newline ([`ace2ab4`](https://github.com/jolars/panache/commit/ace2ab429ddc017e235247a9bd077d6cdf8b199d))
- **parser:** parse headerless multiline tables with a dash-run closer ([`ab7e7d3`](https://github.com/jolars/panache/commit/ab7e7d315433e6e11d220c2735d2e7d4d884c10a)), fixes [#398](https://github.com/jolars/panache/issues/398)
- **parser:** require left word boundary for bare URIs ([`f7b6334`](https://github.com/jolars/panache/commit/f7b6334c45902592955e5a8bb24b9545f2ba7223))

## [editors/code: 2.53.0](https://github.com/jolars/panache/compare/panache-code-v2.52.0...panache-code-v2.53.0) (2026-07-01)

### Features
- wire mdsvex flavor through LSP, CLI, and editor ([`89e1e79`](https://github.com/jolars/panache/commit/89e1e792162217af7ad268ce743d8f01117c6080))

### Dependencies
- updated panache to v2.60.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).