### PR TITLE
fix(formatter): keep block markers inline in sentence wrap

### DIFF
--- a/crates/panache-formatter/src/formatter/inline_layout.rs
+++ b/crates/panache-formatter/src/formatter/inline_layout.rs
@@ -240,6 +240,10 @@ pub(super) struct NodeWrapOptions<'a> {
     pub strip_standalone_blockquote_markers: bool,
     pub avoid_unsafe_line_start: bool,
     pub avoid_blockquote_line_start: bool,
+    /// Avoid starting a wrapped line with an ATX heading (`#`) or setext/thematic
+    /// (`---`/`===`) marker. Set by the sentence/semantic modes; left off for
+    /// reflow, whose width-driven breaks rarely land on such a marker.
+    pub avoid_heading_line_start: bool,
     /// Force a line break at every existing soft break (`NEWLINE`) in addition
     /// to the breaks `mode` produces. Set by the `Semantic` wrap mode, which
     /// layers sembr break-preservation on top of the sentence-break path.
@@ -255,18 +259,23 @@ impl<'a> NodeWrapOptions<'a> {
             strip_standalone_blockquote_markers: false,
             avoid_unsafe_line_start: false,
             avoid_blockquote_line_start: false,
+            avoid_heading_line_start: false,
             preserve_newlines: false,
         }
     }
 
     pub(super) fn sentence() -> Self {
+        // Unlike reflow's flavor-gated guards, sentence/semantic breaks are
+        // structural and could land before a marker, so guard every block-start
+        // token unconditionally; keeping the marker inline is always parse-safe.
         Self {
             widths: &[],
             mode: NodeWrapMode::Sentence,
             atomic_links_root: true,
             strip_standalone_blockquote_markers: false,
-            avoid_unsafe_line_start: false,
-            avoid_blockquote_line_start: false,
+            avoid_unsafe_line_start: true,
+            avoid_blockquote_line_start: true,
+            avoid_heading_line_start: true,
             preserve_newlines: false,
         }
     }
@@ -305,16 +314,14 @@ impl WrapStrategy {
                 avoid_blockquote_line_start: avoid_blockquote_start,
                 ..NodeWrapOptions::reflow(widths)
             },
+            // `sentence()` already guards every block-start token, so list items
+            // only add blockquote-marker stripping when nested in a blockquote.
             Self::ListSentence { in_blockquote } => NodeWrapOptions {
                 strip_standalone_blockquote_markers: in_blockquote,
-                avoid_unsafe_line_start: true,
-                avoid_blockquote_line_start: avoid_blockquote_start,
                 ..NodeWrapOptions::sentence()
             },
             Self::ListSemantic { in_blockquote } => NodeWrapOptions {
                 strip_standalone_blockquote_markers: in_blockquote,
-                avoid_unsafe_line_start: true,
-                avoid_blockquote_line_start: avoid_blockquote_start,
                 ..NodeWrapOptions::semantic()
             },
         }
@@ -437,6 +444,18 @@ fn is_unsafe_list_line_start_piece(piece: &str) -> bool {
         || is_bullet_list_marker_piece(piece)
 }
 
+// A standalone 1--6 `#` run opens an ATX heading at a line start (7+ `#`, or a
+// glued `#word`, does not).
+fn is_atx_heading_marker_piece(piece: &str) -> bool {
+    !piece.is_empty() && piece.len() <= 6 && piece.bytes().all(|b| b == b'#')
+}
+
+// A pure `=`/`-` run is a setext underline or thematic break at a line start.
+// `*`/`_` rules can't reach here: the inline escaper backslash-escapes them.
+fn is_setext_or_thematic_marker_piece(piece: &str) -> bool {
+    !piece.is_empty() && (piece.bytes().all(|b| b == b'=') || piece.bytes().all(|b| b == b'-'))
+}
+
 struct StreamingCoreSink<'a> {
     default_line_width: usize,
     line_widths: &'a [usize],
@@ -452,9 +471,11 @@ struct StreamingCoreSink<'a> {
     profile: ResolvedProfile<'a>,
     avoid_unsafe_line_start: bool,
     avoid_blockquote_line_start: bool,
+    avoid_heading_line_start: bool,
 }
 
 impl<'a> StreamingCoreSink<'a> {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         line_widths: &'a [usize],
         sentence_mode: bool,
@@ -463,6 +484,7 @@ impl<'a> StreamingCoreSink<'a> {
         profile: ResolvedProfile<'a>,
         avoid_unsafe_line_start: bool,
         avoid_blockquote_line_start: bool,
+        avoid_heading_line_start: bool,
     ) -> Self {
         Self {
             default_line_width: line_widths.last().copied().unwrap_or(0),
@@ -479,7 +501,20 @@ impl<'a> StreamingCoreSink<'a> {
             profile,
             avoid_unsafe_line_start,
             avoid_blockquote_line_start,
+            avoid_heading_line_start,
         }
+    }
+
+    /// Whether `text` at the start of a line would open a block-level construct
+    /// (list item, blockquote, heading, rule, or definition) and split the
+    /// paragraph. Each category is gated by its `avoid_*` flag; `:` is always
+    /// unsafe.
+    fn piece_would_start_unsafe_line(&self, text: &str) -> bool {
+        is_definition_marker_piece(text)
+            || (self.avoid_blockquote_line_start && is_unsafe_block_line_start_piece(text))
+            || (self.avoid_unsafe_line_start && is_unsafe_list_line_start_piece(text))
+            || (self.avoid_heading_line_start
+                && (is_atx_heading_marker_piece(text) || is_setext_or_thematic_marker_piece(text)))
     }
 
     fn consume(
@@ -496,12 +531,8 @@ impl<'a> StreamingCoreSink<'a> {
                 .copied()
                 .unwrap_or(self.default_line_width);
             let spacer_width = usize::from(self.line_has_piece && self.prev_ws_after);
-            let would_start_line_with_unsafe_piece = self.prev_ws_after
-                && (is_definition_marker_piece(segment.text.as_str())
-                    || (self.avoid_blockquote_line_start
-                        && is_unsafe_block_line_start_piece(segment.text.as_str()))
-                    || (self.avoid_unsafe_line_start
-                        && is_unsafe_list_line_start_piece(segment.text.as_str())));
+            let would_start_line_with_unsafe_piece =
+                self.prev_ws_after && self.piece_would_start_unsafe_line(segment.text.as_str());
             if self.line_has_piece
                 && self.line_width + spacer_width + piece_width > width_limit
                 && !would_start_line_with_unsafe_piece
@@ -521,8 +552,12 @@ impl<'a> StreamingCoreSink<'a> {
         self.line_has_piece = true;
         self.prev_ws_after = segment.has_whitespace_after;
 
+        // Break after a sentence boundary -- but not when it would push the next
+        // piece to a line start where it opens a block; keeping it inline leaves
+        // the paragraph's parse (and so idempotency) intact.
         if self.sentence_mode
             && is_sentence_boundary_segment(&segment, next_segment, is_last, self.profile)
+            && !next_segment.is_some_and(|next| self.piece_would_start_unsafe_line(&next.text))
         {
             self.out.push(std::mem::take(&mut self.line));
             self.line_width = 0;
@@ -604,6 +639,7 @@ pub(super) fn wrap_text_first_fit(text: &str, line_width: usize) -> Vec<String> 
         false,
         false,
         ResolvedProfile::builtin_only(SentenceLanguage::English),
+        false,
         false,
         false,
     );
@@ -758,6 +794,7 @@ struct TraversalBuilder<'a> {
 }
 
 impl<'a> TraversalBuilder<'a> {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         line_widths: &'a [usize],
         sentence_mode: bool,
@@ -765,6 +802,7 @@ impl<'a> TraversalBuilder<'a> {
         profile: ResolvedProfile<'a>,
         avoid_unsafe_line_start: bool,
         avoid_blockquote_line_start: bool,
+        avoid_heading_line_start: bool,
         preserve_newlines: bool,
     ) -> Self {
         Self {
@@ -776,6 +814,7 @@ impl<'a> TraversalBuilder<'a> {
                 profile,
                 avoid_unsafe_line_start,
                 avoid_blockquote_line_start,
+                avoid_heading_line_start,
             ),
             current_piece: None,
             current_piece_boundary_class: SentenceBoundaryClass::Normal,
@@ -1424,6 +1463,7 @@ pub(super) fn wrapped_lines_for_node(
         profile,
         options.avoid_unsafe_line_start,
         options.avoid_blockquote_line_start,
+        options.avoid_heading_line_start,
         options.preserve_newlines,
     );
     process_node_recursive(
@@ -1534,10 +1574,12 @@ fn looks_like_div_fence_line(content: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        WrapStrategy, is_bullet_list_marker_piece, is_decimal_ordered_list_marker_piece,
-        is_definition_marker_piece, is_example_list_marker_piece, is_fancy_alpha_marker_piece,
+        WrapStrategy, is_atx_heading_marker_piece, is_bullet_list_marker_piece,
+        is_decimal_ordered_list_marker_piece, is_definition_marker_piece,
+        is_example_list_marker_piece, is_fancy_alpha_marker_piece,
         is_fancy_paren_alpha_or_roman_marker_piece, is_fancy_paren_decimal_marker_piece,
-        is_fancy_roman_marker_piece, is_unsafe_list_line_start_piece, wrap_text_first_fit,
+        is_fancy_roman_marker_piece, is_setext_or_thematic_marker_piece,
+        is_unsafe_list_line_start_piece, wrap_text_first_fit,
     };
 
     #[test]
@@ -1578,6 +1620,29 @@ mod tests {
         assert!(!is_bullet_list_marker_piece("+foo"));
         assert!(!is_decimal_ordered_list_marker_piece("v2.0"));
         assert!(!is_decimal_ordered_list_marker_piece("2024.05"));
+    }
+
+    #[test]
+    fn atx_heading_marker_rule_matches_hash_runs() {
+        assert!(is_atx_heading_marker_piece("#"));
+        assert!(is_atx_heading_marker_piece("######"));
+        // Seven or more hashes is not a heading.
+        assert!(!is_atx_heading_marker_piece("#######"));
+        // A glued `#word` piece (no following space) is not a heading marker.
+        assert!(!is_atx_heading_marker_piece("#foo"));
+        assert!(!is_atx_heading_marker_piece(""));
+    }
+
+    #[test]
+    fn setext_thematic_marker_rule_matches_dash_and_equals_runs() {
+        assert!(is_setext_or_thematic_marker_piece("="));
+        assert!(is_setext_or_thematic_marker_piece("==="));
+        assert!(is_setext_or_thematic_marker_piece("-"));
+        assert!(is_setext_or_thematic_marker_piece("---"));
+        // Mixed or non-rule pieces are left alone.
+        assert!(!is_setext_or_thematic_marker_piece("=-="));
+        assert!(!is_setext_or_thematic_marker_piece("--x"));
+        assert!(!is_setext_or_thematic_marker_piece(""));
     }
 
     #[test]

--- a/crates/panache-formatter/tests/format/preserve_wrap.rs
+++ b/crates/panache-formatter/tests/format/preserve_wrap.rs
@@ -115,3 +115,38 @@ fn list_item_sentence_wraps_per_sentence() {
     assert_eq!(out, out2);
     assert_eq!(out, expected);
 }
+
+#[test]
+fn sentence_keeps_inline_enumeration_in_one_paragraph() {
+    let input =
+        "You must hear from us within 60 days. 1. Tell us your name. 2. Describe the error.\n";
+    let expected =
+        "You must hear from us within 60 days. 1.\nTell us your name. 2.\nDescribe the error.\n";
+
+    let out = format(input, Some(cfg_sentence()), None);
+    let out2 = format(&out, Some(cfg_sentence()), None);
+    assert_eq!(out, out2);
+    assert_eq!(out, expected);
+}
+
+#[test]
+fn sentence_keeps_inline_heading_marker_off_line_start() {
+    let input = "Some intro text here. # Not a heading at all. More words come after it.\n";
+    let expected = "Some intro text here. # Not a heading at all.\nMore words come after it.\n";
+
+    let out = format(input, Some(cfg_sentence()), None);
+    let out2 = format(&out, Some(cfg_sentence()), None);
+    assert_eq!(out, out2);
+    assert_eq!(out, expected);
+}
+
+#[test]
+fn sentence_keeps_inline_blockquote_marker_off_line_start() {
+    let input = "Look at this remark. > Not a blockquote. Trailing words appear here too.\n";
+    let expected = "Look at this remark. > Not a blockquote.\nTrailing words appear here too.\n";
+
+    let out = format(input, Some(cfg_sentence()), None);
+    let out2 = format(&out, Some(cfg_sentence()), None);
+    assert_eq!(out, out2);
+    assert_eq!(out, expected);
+}

--- a/crates/panache-formatter/tests/format/semantic_wrap.rs
+++ b/crates/panache-formatter/tests/format/semantic_wrap.rs
@@ -62,3 +62,12 @@ fn abbreviations_do_not_trigger_breaks() {
     let expected = "We use tools, e.g. the parser,\nand more.\nEnd.\n";
     assert_eq!(run(input), expected);
 }
+
+#[test]
+fn sentence_break_keeps_inline_list_markers_off_line_start() {
+    // A sentence break before `1.`/`2.` would reparse the prose as an ordered
+    // list, so the markers stay inline and the text stays one paragraph.
+    let input = "Hear from us in 60 days. 1. Tell us your name. 2. Describe the error.\n";
+    let expected = "Hear from us in 60 days. 1.\nTell us your name. 2.\nDescribe the error.\n";
+    assert_eq!(run(input), expected);
+}

--- a/docs/guide/formatting.qmd
+++ b/docs/guide/formatting.qmd
@@ -54,6 +54,18 @@ In `sentence` and `semantic` modes, Panache applies conservative no-break rules
 for common abbreviations (for example `i.e.` and `e.g.`), so these do not
 trigger sentence splits by themselves.
 
+A sentence break is also suppressed when it would push the next token to the
+start of a line where the parser would read it as the opening of a block---an
+ordered or unordered list marker (`1.`, `-`, `+`, `1)`), an ATX heading (`#`), a
+blockquote (`>`), or a setext/thematic rule (`---`, `===`). For example, prose
+that embeds an inline enumeration stays one paragraph:
+`Hear from us. 1. Tell us your name. 2. Describe it.` keeps each marker inline
+rather than promoting the text into a list. This guarantees wrapping never
+changes how the document parses, which in turn keeps `sentence`/`semantic`
+formatting idempotent (`panache format` followed by `panache format --check`
+always succeeds). Genuine, well-formed lists are unaffected and continue to wrap
+normally.
+
 The abbreviation list follows the document language. When metadata provides
 `lang` (as in Quarto and Pandoc frontmatter), Panache selects a built-in profile
 for it; profiles ship for English, Czech, German, Spanish, and French, and

--- a/tests/fixtures/cases/sentence_wrap_block_markers_commonmark/expected.md
+++ b/tests/fixtures/cases/sentence_wrap_block_markers_commonmark/expected.md
@@ -1,0 +1,14 @@
+See the following items. - First point is here. - Second point follows.
+
+Some introductory text. # This is not a heading.
+More words come after it.
+
+Look at this remark. > This is not a blockquote.
+Trailing words appear here.
+
+This sentence ends a clause. === And the next clause keeps going.
+
+1. A genuine list item.
+   Its second sentence wraps normally.
+2. Another genuine item here.
+   With a trailing sentence too.

--- a/tests/fixtures/cases/sentence_wrap_block_markers_commonmark/input.md
+++ b/tests/fixtures/cases/sentence_wrap_block_markers_commonmark/input.md
@@ -1,0 +1,10 @@
+See the following items. - First point is here. - Second point follows.
+
+Some introductory text. # This is not a heading. More words come after it.
+
+Look at this remark. > This is not a blockquote. Trailing words appear here.
+
+This sentence ends a clause. === And the next clause keeps going.
+
+1. A genuine list item. Its second sentence wraps normally.
+2. Another genuine item here. With a trailing sentence too.

--- a/tests/fixtures/cases/sentence_wrap_block_markers_commonmark/panache.toml
+++ b/tests/fixtures/cases/sentence_wrap_block_markers_commonmark/panache.toml
@@ -1,0 +1,4 @@
+flavor = "commonmark"
+
+[format]
+wrap = "sentence"

--- a/tests/golden_cases.rs
+++ b/tests/golden_cases.rs
@@ -389,6 +389,7 @@ golden_test_cases!(
     sentence_wrap_lazy_continuation,
     sentence_wrap_links_figures,
     sentence_wrap_lists,
+    sentence_wrap_block_markers_commonmark,
     sentence_wrap_ellipsis,
     sentence_wrap_inline_code_sentence_end,
     sentence_wrap_quote_multisentence,


### PR DESCRIPTION
## Summary

Currently, `wrap = "sentence"`/`"semantic"` places a soft break after every sentence boundary without checking the next token. So if a sentence ends just before an inline block-start marker (a list marker like `1.`/`-`, an ATX `#`, a `>`, or a `---`/`===` rule), the break pushes that marker to the start of the next line and the re-parse promoted the prose into a list/heading/blockquote. As a result, `format(format(x)) !== format(x)`, and `panache format --check` fails after a `panache format`. 

This PR suppresses the break when the next piece would open a block, so the marker stays inline and the paragraph parses unchanged; the guard is flavor-independent because keeping a marker inline is always parse-safe, and genuine well-formed lists are unaffected.

## Related issue

None found — searched open and closed issues for sentence/semantic wrap, list-marker, and idempotency terms; the nearest matches (#78, #79, #344) are unrelated idempotency bugs.

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] Added or updated tests for behavior changes
- [x] Ran `cargo check`
- [x] Ran `cargo test`
- [x] Ran `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Ran `cargo fmt -- --check`
- [x] Updated docs or README if needed
- [x] Did not manually edit `CHANGELOG.md`