### PR TITLE
chore(release): v2.61.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "4a8d1ebaae3e4a9bb71385d825c32fea6502336a",
+  "baseline-sha": "42a99f873143668e0701ed2dae98831394698b8d",
   "release-targets": [
     {
       "path": ".",
-      "version": "2.60.0",
-      "tag": "v2.60.0"
+      "version": "2.61.0",
+      "tag": "v2.61.0"
     },
     {
       "path": "crates/panache-dprint",
@@ -14,18 +14,18 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.18.0",
-      "tag": "panache-formatter-v0.18.0"
+      "version": "0.19.0",
+      "tag": "panache-formatter-v0.19.0"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.20.0",
-      "tag": "panache-parser-v0.20.0"
+      "version": "0.21.0",
+      "tag": "panache-parser-v0.21.0"
     },
     {
       "path": "editors/code",
-      "version": "2.53.0",
-      "tag": "panache-code-v2.53.0"
+      "version": "2.54.0",
+      "tag": "panache-code-v2.54.0"
     },
     {
       "path": "editors/zed",
@@ -36,23 +36,23 @@
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "2.60.0",
-      "tag": "v2.60.0"
+      "version": "2.61.0",
+      "tag": "v2.61.0"
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.18.0",
-      "tag": "panache-formatter-v0.18.0"
+      "version": "0.19.0",
+      "tag": "panache-formatter-v0.19.0"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.20.0",
-      "tag": "panache-parser-v0.20.0"
+      "version": "0.21.0",
+      "tag": "panache-parser-v0.21.0"
     },
     {
       "path": "editors/code",
-      "version": "2.53.0",
-      "tag": "panache-code-v2.53.0"
+      "version": "2.54.0",
+      "tag": "panache-code-v2.54.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [2.61.0](https://github.com/jolars/panache/compare/v2.60.0...v2.61.0) (2026-07-04)
+
+### Features
+- **parser:** fuse comment/PI trailing softbreak lines ([`3fa513c`](https://github.com/jolars/panache/commit/3fa513ce3dc2fd72abb1a2ca739d876393467505))
+- **parser:** lift `<div>` inter-tag text to sibling blocks ([`5f04265`](https://github.com/jolars/panache/commit/5f04265dfb5a77e56fe9f448f159261297b9f80d))
+- **parser:** lift fenced div swallowing html `</div>` ([`7b11daf`](https://github.com/jolars/panache/commit/7b11daf64a0fabb6fd4774006971aef387a9c259))
+- **parser:** split same-line matched-pair inter-tag HTML ([`119014c`](https://github.com/jolars/panache/commit/119014c7f9f90a3d38d36c37562d37f4bfd1dd29))
+- **parser:** classify void strict-block HTML tags ([`fcfea15`](https://github.com/jolars/panache/commit/fcfea15ce69d9a44fe2dcc0f18b29a86e2a7b3fc))
+- **parser:** split blockquote standalone HTML tags ([`b29d46c`](https://github.com/jolars/panache/commit/b29d46c032c430bbc8e5ad561df209ffea00262c))
+- **parser:** lift blockquote open-only HTML body ([`e3b93a5`](https://github.com/jolars/panache/commit/e3b93a50453174cc5a6ba855d673c680b4823f57))
+- **config:** add `fatou` formatter preset ([`8d70ee0`](https://github.com/jolars/panache/commit/8d70ee0aaeedf0c0edfa623ac02df2adc225f898))
+- **parser:** flag unbalanced `\left`/`\right` in math ([`73750c9`](https://github.com/jolars/panache/commit/73750c9b854e8899fcd2b7180c21f9b2eb7af892))
+- **parser:** lift open-only HTML block bodies ([`7a831ff`](https://github.com/jolars/panache/commit/7a831ff881c995cc9dfa57fb2aa6650699c431d8))
+
+### Bug Fixes
+- **formatter:** route non-reflowable math verbatim ([`bd577dc`](https://github.com/jolars/panache/commit/bd577dcd7884428b83ea9034a048863c97368c28))
+- **linter:** match reference labels on raw source text ([`cb7ae6d`](https://github.com/jolars/panache/commit/cb7ae6d006d62d439f3df0e431186858d355c2f2))
+- **parser:** map simple-table columns by display width ([`c2f1b14`](https://github.com/jolars/panache/commit/c2f1b141894cf66c323831e8100e4118529a8496)), fixes [#411](https://github.com/jolars/panache/issues/411)
+
+### Dependencies
+- updated crates/panache-formatter to v0.19.0
+- updated crates/panache-parser to v0.21.0
+
 ## [2.60.0](https://github.com/jolars/panache/compare/v2.59.0...v2.60.0) (2026-07-01)
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,9 +372,9 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "defmt"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
 dependencies = [
  "bitflags 1.3.2",
  "defmt-macros",
@@ -382,12 +382,11 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
 dependencies = [
  "defmt-parser",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn",
@@ -931,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.46.8"
+version = "0.46.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fc8535da347b994f6d2fab0a84b74e3b31ad08ebe4204d95f3e755db7af49b"
+checksum = "1d865ca7ca04445fcaa1d751fda3dc43b0113ba2fcddc65d5a0fcb474a7c3bba"
 dependencies = [
  "ahash",
  "bytecount",
@@ -944,16 +943,25 @@ dependencies = [
  "getrandom 0.3.4",
  "idna",
  "itoa",
+ "jsonschema-regex",
  "num-cmp",
  "num-traits",
  "percent-encoding",
  "referencing",
  "regex",
- "regex-syntax",
  "serde",
  "serde_json",
  "unicode-general-category",
  "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.46.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b7fc96cd6677cc81b00607d43477327d719419937ef1c44b3556a40f517d54c"
+dependencies = [
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1083,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -1182,7 +1190,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "panache"
-version = "2.60.0"
+version = "2.61.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -1226,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "insta",
  "log",
@@ -1244,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "entities",
  "insta",
@@ -1393,28 +1401,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1515,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.46.8"
+version = "0.46.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c8dceb372b46fecd006be48ca335468b49ad887a7f0150cabd6098fa4fc500f"
+checksum = "77954d81b2e1c5e8ab889f9f597a92f852ab073255de9e37ee3fb443efd57051"
 dependencies = [
  "ahash",
  "fluent-uri 0.4.1",
@@ -1585,9 +1571,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustix"
@@ -1625,7 +1611,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "rayon",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "salsa-macro-rules",
  "salsa-macros",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "2.60.0"
+version = "2.61.0"
 edition.workspace = true
 # `distill_quarto_schema` is a dev-only vendoring bin (src/bin/); keep bare
 # `cargo run` resolving to the CLI for tooling like the pre-commit format hook.
@@ -52,8 +52,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.18.0" }
-panache-parser = { path = "crates/panache-parser", version = "0.20.0", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.19.0" }
+panache-parser = { path = "crates/panache-parser", version = "0.21.0", features = [
     "serde",
     "schema",
 ] }

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.19.0](https://github.com/jolars/panache/compare/panache-formatter-v0.18.0...panache-formatter-v0.19.0) (2026-07-04)
+
+### Features
+- **parser:** flag unbalanced `\left`/`\right` in math ([`73750c9`](https://github.com/jolars/panache/commit/73750c9b854e8899fcd2b7180c21f9b2eb7af892))
+
+### Bug Fixes
+- **formatter:** route non-reflowable math verbatim ([`bd577dc`](https://github.com/jolars/panache/commit/bd577dcd7884428b83ea9034a048863c97368c28))
+
+### Dependencies
+- updated crates/panache-parser to v0.21.0
+
 ## [0.18.0](https://github.com/jolars/panache/compare/panache-formatter-v0.17.0...panache-formatter-v0.18.0) (2026-07-01)
 
 ### Features

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 include = [
     "/src/**/*",
@@ -18,7 +18,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.20.0" }
+panache-parser = { path = "../panache-parser", version = "0.21.0" }
 log = { version = "0.4.31", features = ["release_max_level_debug"] }
 rowan = "0.16.1"
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.21.0](https://github.com/jolars/panache/compare/panache-parser-v0.20.0...panache-parser-v0.21.0) (2026-07-04)
+
+### Features
+- **parser:** fuse comment/PI trailing softbreak lines ([`3fa513c`](https://github.com/jolars/panache/commit/3fa513ce3dc2fd72abb1a2ca739d876393467505))
+- **parser:** lift `<div>` inter-tag text to sibling blocks ([`5f04265`](https://github.com/jolars/panache/commit/5f04265dfb5a77e56fe9f448f159261297b9f80d))
+- **parser:** lift fenced div swallowing html `</div>` ([`7b11daf`](https://github.com/jolars/panache/commit/7b11daf64a0fabb6fd4774006971aef387a9c259))
+- **parser:** split same-line matched-pair inter-tag HTML ([`119014c`](https://github.com/jolars/panache/commit/119014c7f9f90a3d38d36c37562d37f4bfd1dd29))
+- **parser:** classify void strict-block HTML tags ([`fcfea15`](https://github.com/jolars/panache/commit/fcfea15ce69d9a44fe2dcc0f18b29a86e2a7b3fc))
+- **parser:** split blockquote standalone HTML tags ([`b29d46c`](https://github.com/jolars/panache/commit/b29d46c032c430bbc8e5ad561df209ffea00262c))
+- **parser:** lift blockquote open-only HTML body ([`e3b93a5`](https://github.com/jolars/panache/commit/e3b93a50453174cc5a6ba855d673c680b4823f57))
+- **parser:** flag unbalanced `\left`/`\right` in math ([`73750c9`](https://github.com/jolars/panache/commit/73750c9b854e8899fcd2b7180c21f9b2eb7af892))
+- **parser:** lift open-only HTML block bodies ([`7a831ff`](https://github.com/jolars/panache/commit/7a831ff881c995cc9dfa57fb2aa6650699c431d8))
+
+### Bug Fixes
+- **parser:** map simple-table columns by display width ([`c2f1b14`](https://github.com/jolars/panache/commit/c2f1b141894cf66c323831e8100e4118529a8496)), fixes [#411](https://github.com/jolars/panache/issues/411)
+- **linter:** match reference labels on raw source text ([`cb7ae6d`](https://github.com/jolars/panache/commit/cb7ae6d006d62d439f3df0e431186858d355c2f2))
+
 ## [0.20.0](https://github.com/jolars/panache/compare/panache-parser-v0.19.1...panache-parser-v0.20.0) (2026-07-01)
 
 ### Features

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.20.0"
+version = "0.21.0"
 edition.workspace = true
 readme = "README.md"
 include = [

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.54.0](https://github.com/jolars/panache/compare/panache-code-v2.53.0...panache-code-v2.54.0) (2026-07-04)
+
+### Dependencies
+- updated panache to v2.61.0
+
 ## [2.53.0](https://github.com/jolars/panache/compare/panache-code-v2.52.0...panache-code-v2.53.0) (2026-07-01)
 
 ### Features

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "2.53.0",
+  "version": "2.54.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         panache = pkgs.rustPlatform.buildRustPackage {
           pname = "panache";
-          version = "2.60.0";
+          version = "2.61.0";
 
           src = ./.;
 

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "2.60.0",
+  "version": "2.61.0",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "2.60.0",
-    "@panache-cli/linux-arm64-gnu": "2.60.0",
-    "@panache-cli/linux-x64-musl": "2.60.0",
-    "@panache-cli/linux-arm64-musl": "2.60.0",
-    "@panache-cli/darwin-x64": "2.60.0",
-    "@panache-cli/darwin-arm64": "2.60.0",
-    "@panache-cli/win32-x64": "2.60.0",
-    "@panache-cli/win32-arm64": "2.60.0"
+    "@panache-cli/linux-x64-gnu": "2.61.0",
+    "@panache-cli/linux-arm64-gnu": "2.61.0",
+    "@panache-cli/linux-x64-musl": "2.61.0",
+    "@panache-cli/linux-arm64-musl": "2.61.0",
+    "@panache-cli/darwin-x64": "2.61.0",
+    "@panache-cli/darwin-arm64": "2.61.0",
+    "@panache-cli/win32-x64": "2.61.0",
+    "@panache-cli/win32-arm64": "2.61.0"
   }
 }


### PR DESCRIPTION
## [panache: 2.61.0](https://github.com/jolars/panache/compare/v2.60.0...v2.61.0) (2026-07-04)

### Features
- **parser:** fuse comment/PI trailing softbreak lines ([`3fa513c`](https://github.com/jolars/panache/commit/3fa513ce3dc2fd72abb1a2ca739d876393467505))
- **parser:** lift `<div>` inter-tag text to sibling blocks ([`5f04265`](https://github.com/jolars/panache/commit/5f04265dfb5a77e56fe9f448f159261297b9f80d))
- **parser:** lift fenced div swallowing html `</div>` ([`7b11daf`](https://github.com/jolars/panache/commit/7b11daf64a0fabb6fd4774006971aef387a9c259))
- **parser:** split same-line matched-pair inter-tag HTML ([`119014c`](https://github.com/jolars/panache/commit/119014c7f9f90a3d38d36c37562d37f4bfd1dd29))
- **parser:** classify void strict-block HTML tags ([`fcfea15`](https://github.com/jolars/panache/commit/fcfea15ce69d9a44fe2dcc0f18b29a86e2a7b3fc))
- **parser:** split blockquote standalone HTML tags ([`b29d46c`](https://github.com/jolars/panache/commit/b29d46c032c430bbc8e5ad561df209ffea00262c))
- **parser:** lift blockquote open-only HTML body ([`e3b93a5`](https://github.com/jolars/panache/commit/e3b93a50453174cc5a6ba855d673c680b4823f57))
- **config:** add `fatou` formatter preset ([`8d70ee0`](https://github.com/jolars/panache/commit/8d70ee0aaeedf0c0edfa623ac02df2adc225f898))
- **parser:** flag unbalanced `\left`/`\right` in math ([`73750c9`](https://github.com/jolars/panache/commit/73750c9b854e8899fcd2b7180c21f9b2eb7af892))
- **parser:** lift open-only HTML block bodies ([`7a831ff`](https://github.com/jolars/panache/commit/7a831ff881c995cc9dfa57fb2aa6650699c431d8))

### Bug Fixes
- **formatter:** route non-reflowable math verbatim ([`bd577dc`](https://github.com/jolars/panache/commit/bd577dcd7884428b83ea9034a048863c97368c28))
- **linter:** match reference labels on raw source text ([`cb7ae6d`](https://github.com/jolars/panache/commit/cb7ae6d006d62d439f3df0e431186858d355c2f2))
- **parser:** map simple-table columns by display width ([`c2f1b14`](https://github.com/jolars/panache/commit/c2f1b141894cf66c323831e8100e4118529a8496)), fixes [#411](https://github.com/jolars/panache/issues/411)

### Dependencies
- updated crates/panache-formatter to v0.19.0
- updated crates/panache-parser to v0.21.0

## [crates/panache-formatter: 0.19.0](https://github.com/jolars/panache/compare/panache-formatter-v0.18.0...panache-formatter-v0.19.0) (2026-07-04)

### Features
- **parser:** flag unbalanced `\left`/`\right` in math ([`73750c9`](https://github.com/jolars/panache/commit/73750c9b854e8899fcd2b7180c21f9b2eb7af892))

### Bug Fixes
- **formatter:** route non-reflowable math verbatim ([`bd577dc`](https://github.com/jolars/panache/commit/bd577dcd7884428b83ea9034a048863c97368c28))

### Dependencies
- updated crates/panache-parser to v0.21.0

## [crates/panache-parser: 0.21.0](https://github.com/jolars/panache/compare/panache-parser-v0.20.0...panache-parser-v0.21.0) (2026-07-04)

### Features
- **parser:** fuse comment/PI trailing softbreak lines ([`3fa513c`](https://github.com/jolars/panache/commit/3fa513ce3dc2fd72abb1a2ca739d876393467505))
- **parser:** lift `<div>` inter-tag text to sibling blocks ([`5f04265`](https://github.com/jolars/panache/commit/5f04265dfb5a77e56fe9f448f159261297b9f80d))
- **parser:** lift fenced div swallowing html `</div>` ([`7b11daf`](https://github.com/jolars/panache/commit/7b11daf64a0fabb6fd4774006971aef387a9c259))
- **parser:** split same-line matched-pair inter-tag HTML ([`119014c`](https://github.com/jolars/panache/commit/119014c7f9f90a3d38d36c37562d37f4bfd1dd29))
- **parser:** classify void strict-block HTML tags ([`fcfea15`](https://github.com/jolars/panache/commit/fcfea15ce69d9a44fe2dcc0f18b29a86e2a7b3fc))
- **parser:** split blockquote standalone HTML tags ([`b29d46c`](https://github.com/jolars/panache/commit/b29d46c032c430bbc8e5ad561df209ffea00262c))
- **parser:** lift blockquote open-only HTML body ([`e3b93a5`](https://github.com/jolars/panache/commit/e3b93a50453174cc5a6ba855d673c680b4823f57))
- **parser:** flag unbalanced `\left`/`\right` in math ([`73750c9`](https://github.com/jolars/panache/commit/73750c9b854e8899fcd2b7180c21f9b2eb7af892))
- **parser:** lift open-only HTML block bodies ([`7a831ff`](https://github.com/jolars/panache/commit/7a831ff881c995cc9dfa57fb2aa6650699c431d8))

### Bug Fixes
- **parser:** map simple-table columns by display width ([`c2f1b14`](https://github.com/jolars/panache/commit/c2f1b141894cf66c323831e8100e4118529a8496)), fixes [#411](https://github.com/jolars/panache/issues/411)
- **linter:** match reference labels on raw source text ([`cb7ae6d`](https://github.com/jolars/panache/commit/cb7ae6d006d62d439f3df0e431186858d355c2f2))

## [editors/code: 2.54.0](https://github.com/jolars/panache/compare/panache-code-v2.53.0...panache-code-v2.54.0) (2026-07-04)

### Dependencies
- updated panache to v2.61.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).