### PR TITLE
chore(release): v3.0.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "42a99f873143668e0701ed2dae98831394698b8d",
+  "baseline-sha": "d3094071f71fff990ffe453a01fda50c46ba15db",
   "release-targets": [
     {
       "path": ".",
-      "version": "2.61.0",
-      "tag": "v2.61.0"
+      "version": "3.0.0",
+      "tag": "v3.0.0"
     },
     {
       "path": "crates/panache-dprint",
@@ -14,18 +14,18 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.19.0",
-      "tag": "panache-formatter-v0.19.0"
+      "version": "0.20.0",
+      "tag": "panache-formatter-v0.20.0"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.21.0",
-      "tag": "panache-parser-v0.21.0"
+      "version": "0.22.0",
+      "tag": "panache-parser-v0.22.0"
     },
     {
       "path": "editors/code",
-      "version": "2.54.0",
-      "tag": "panache-code-v2.54.0"
+      "version": "3.0.0",
+      "tag": "panache-code-v3.0.0"
     },
     {
       "path": "editors/zed",
@@ -36,23 +36,23 @@
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "2.61.0",
-      "tag": "v2.61.0"
+      "version": "3.0.0",
+      "tag": "v3.0.0"
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.19.0",
-      "tag": "panache-formatter-v0.19.0"
+      "version": "0.20.0",
+      "tag": "panache-formatter-v0.20.0"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.21.0",
-      "tag": "panache-parser-v0.21.0"
+      "version": "0.22.0",
+      "tag": "panache-parser-v0.22.0"
     },
     {
       "path": "editors/code",
-      "version": "2.54.0",
-      "tag": "panache-code-v2.54.0"
+      "version": "3.0.0",
+      "tag": "panache-code-v3.0.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [3.0.0](https://github.com/jolars/panache/compare/v2.61.0...v3.0.0) (2026-07-20)
 
 This is a major release with breaking changes. Most importantly, `snake_case`
 style configurations keys, which have been deprecated since a few months back,
@@ -12,6 +12,52 @@ non-zero on lint violations. The `--check` CLI flag no longer has any effect on
 Other than that, this release brings major performance improvements to the
 language server, a new style configuration for horizontal rules (`horizontal-rule-style`)
 and a number of bug fixes.
+
+### Breaking changes
+- remove long-deprecated config, CLI, and API surface ([`6af736d`](https://github.com/jolars/panache/commit/6af736d8ab38ecebfaa62d40fbfbe83a2a300adf))
+- **cli:** exit non-zero on lint violations by default ([`f31317a`](https://github.com/jolars/panache/commit/f31317a45147c6cb2982e328f38d59d1d74440d7))
+
+### Features
+- **linter:** add `citation-nonbreaking-space` rule ([`6f8fb28`](https://github.com/jolars/panache/commit/6f8fb28fb4f49384295a10cea9ae807debcc89d9))
+- **formatter:** add `horizontal-rule-style` format option ([`e2b0abe`](https://github.com/jolars/panache/commit/e2b0abe51cfe62514defa4c476ca4be175ba216b)), closes [#417](https://github.com/jolars/panache/issues/417)
+- remove long-deprecated config, CLI, and API surface ([`6af736d`](https://github.com/jolars/panache/commit/6af736d8ab38ecebfaa62d40fbfbe83a2a300adf))
+- **cli:** exit non-zero on lint violations by default ([`f31317a`](https://github.com/jolars/panache/commit/f31317a45147c6cb2982e328f38d59d1d74440d7))
+- **parser:** lift later-line HTML block in def/footnote body ([`21d448a`](https://github.com/jolars/panache/commit/21d448a3972261d6ec8472a0ccc74cd37f75688b))
+- **parser:** fuse comment trailing softbreak in def body ([`1a2c8b9`](https://github.com/jolars/panache/commit/1a2c8b9728dae63989d7eddc3b348b85f8ae1f71))
+- **parser:** lift HTML block on footnote marker line ([`cab5f61`](https://github.com/jolars/panache/commit/cab5f6125e51c22a07d7cfe3768885f3d4299b45))
+- **parser:** dispatch HTML block on definition marker line ([`8eb6f6a`](https://github.com/jolars/panache/commit/8eb6f6a4657e807df5da154f169b50dbe9d4beb0))
+- **parser:** fuse comment softbreak in blockquote ([`8a29570`](https://github.com/jolars/panache/commit/8a295706c62421157c59ea4282e49a2c15c4660b))
+- **parser:** fuse comment softbreak in fenced div ([`baccde0`](https://github.com/jolars/panache/commit/baccde0247c1344c49a97c809c26f4a067a8728c))
+
+### Bug Fixes
+- adapt to salsa 0.28 and lsp-server 0.10 APIs ([`54bd3ae`](https://github.com/jolars/panache/commit/54bd3ae83051a86850114ffc35aab179ed8a673f))
+- **formatter:** keep space after crossref in footnote ([`bfa9da0`](https://github.com/jolars/panache/commit/bfa9da007ac7c43ac8480abeee0ed28af6fffed7)), closes [#430](https://github.com/jolars/panache/issues/430)
+- **parser:** let blocks end reduced-marker lazy lines ([`edd18ee`](https://github.com/jolars/panache/commit/edd18eeeac33f2dcfd5d443192d387e6d3e27231)), closes [#429](https://github.com/jolars/panache/issues/429)
+- **parser:** let ATX heading end a lazy blockquote line ([`71f46a4`](https://github.com/jolars/panache/commit/71f46a4bd8d971ec9d73d09d8bbcb220827d7779)), closes [#428](https://github.com/jolars/panache/issues/428)
+- **parser:** detect headerless single-column simple tables ([`0de4afc`](https://github.com/jolars/panache/commit/0de4afcbe0ecb23b1d5581078b2107dafa7a9a7b))
+- **parser:** gate YAML metadata on top-level mapping ([`8f135bc`](https://github.com/jolars/panache/commit/8f135bc760e0961f89d8b6d7735e1f4526005ae0))
+- **parser:** restrict mid-document YAML to pandoc dialect ([`53fabd9`](https://github.com/jolars/panache/commit/53fabd92e163272212fc9387bd82fc6e54b886aa))
+- **formatter:** blank line between trailing rule and div fence ([`1abf3f8`](https://github.com/jolars/panache/commit/1abf3f8f35d58e5ccfafe66e0b88b7ca003f6e71))
+- **formatter:** indent headings in list items ([`7690f1d`](https://github.com/jolars/panache/commit/7690f1ddf36be642eeeffe04952379e597524504))
+- **formatter:** indent horizontal rules in list items ([`2033e2b`](https://github.com/jolars/panache/commit/2033e2b98256e5d8892fa8ff4b218f069570b65b))
+- **config:** add migration hints for removed 3.0 keys ([`aa35d17`](https://github.com/jolars/panache/commit/aa35d17cfad01a856c8e77af16bdeb88015c77b0))
+- **parser:** lift multi-line `<div>` body on definition marker line ([`9a78ab8`](https://github.com/jolars/panache/commit/9a78ab893532143cbefd69c74042b01d01241eb6))
+- **lsp:** report server name and version at initialize ([`79fe479`](https://github.com/jolars/panache/commit/79fe4798ac62cfe985bbffcf7b639129d9b9b64a))
+- **lsp:** drop global state before joining IO threads ([`df57721`](https://github.com/jolars/panache/commit/df57721e038576eb3ac577e44dbc0e60808e4334))
+- **formatter:** match `[formatters]` keys by language alias ([`08c39bc`](https://github.com/jolars/panache/commit/08c39bced6f90745dbfe47bd507020afe941bce6))
+- **formatter:** collapse newline inside inline math ([`28266ed`](https://github.com/jolars/panache/commit/28266ed461bc4e551224aa985f40f47cbf3ebd36))
+- **formatter:** anchor LHS binary math breaks flush ([`a4a86ec`](https://github.com/jolars/panache/commit/a4a86ec454a7bb564ab6bbfec9c182778b5a433e))
+- **lsp:** serve pull diagnostics off the event loop ([`b60c779`](https://github.com/jolars/panache/commit/b60c779274b17d78e4443fd801b28a52fb658a48))
+- **parser:** preserve order for interrupting ATX headings ([`6620829`](https://github.com/jolars/panache/commit/662082943cd049aba7427d20975a383abe929839))
+- **parser:** keep setext from interrupting a paragraph ([`a1b9fa1`](https://github.com/jolars/panache/commit/a1b9fa1ff82c5f0d4f953413a08eaa3b12695e68))
+- **parser:** detect rules and headings in nested list items ([`4de51b7`](https://github.com/jolars/panache/commit/4de51b78a4ae7235c6307383f870518e42862e0f))
+
+### Performance Improvements
+- **lsp:** share one `FileConfig` per config value ([`16ae29b`](https://github.com/jolars/panache/commit/16ae29b5bcb7c02c4dc14874340875670f704302))
+
+### Dependencies
+- updated crates/panache-formatter to v0.20.0
+- updated crates/panache-parser to v0.22.0
 
 ## [2.61.0](https://github.com/jolars/panache/compare/v2.60.0...v2.61.0) (2026-07-04)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,9 +142,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "borrow-or-share"
@@ -160,9 +160,9 @@ checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
 
 [[package]]
 name = "bstr"
-version = "1.12.3"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -189,9 +189,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -236,7 +236,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -298,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -317,18 +317,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "darling"
@@ -350,7 +350,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -361,7 +361,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -389,7 +389,7 @@ dependencies = [
  "defmt-parser",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -436,7 +436,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -533,9 +533,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "flate2"
@@ -594,21 +594,21 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -684,9 +684,9 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -814,9 +814,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ffa3a0547a138e59ddd6fa3b7c672ed47e6ad6a3cd177984ff1116aa5ba742"
+checksum = "7b009b6744c1445efd7244084e25e498636412effb6760b55067553baa925cc7"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -883,11 +883,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.31"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
+checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
 dependencies = [
  "defmt",
+ "jiff-core",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -896,14 +897,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.31"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1080,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -1114,11 +1125,10 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -1179,7 +1189,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "panache"
-version = "2.61.0"
+version = "3.0.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -1223,7 +1233,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "insta",
  "log",
@@ -1241,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "entities",
  "insta",
@@ -1326,9 +1336,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "portable-atomic-util"
@@ -1391,9 +1401,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1409,9 +1419,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1454,7 +1464,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -1470,22 +1480,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -1507,9 +1517,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1519,9 +1529,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1570,7 +1580,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1579,9 +1589,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "salsa"
@@ -1623,7 +1633,7 @@ checksum = "8b26cb1c61fc424f7ff36e0606491429f58d1738bb0917cd999d680baae0c52c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1657,7 +1667,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1668,9 +1678,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1678,22 +1688,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -1704,14 +1714,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1722,13 +1732,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -1742,9 +1752,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "similar"
@@ -1804,9 +1814,20 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1821,7 +1842,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1857,22 +1878,22 @@ checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -1903,7 +1924,7 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -1921,7 +1942,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -1993,9 +2014,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.5"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -2090,7 +2111,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -2143,7 +2164,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2172,9 +2193,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"
@@ -2217,28 +2238,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2258,7 +2279,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -2292,11 +2313,11 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "2.61.0"
+version = "3.0.0"
 edition.workspace = true
 # `distill_quarto_schema` is a dev-only vendoring bin (src/bin/); keep bare
 # `cargo run` resolving to the CLI for tooling like the pre-commit format hook.
@@ -52,8 +52,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.19.0" }
-panache-parser = { path = "crates/panache-parser", version = "0.21.0", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.20.0" }
+panache-parser = { path = "crates/panache-parser", version = "0.22.0", features = [
     "serde",
     "schema",
 ] }

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.20.0](https://github.com/jolars/panache/compare/panache-formatter-v0.19.0...panache-formatter-v0.20.0) (2026-07-20)
+
+### Breaking changes
+- remove long-deprecated config, CLI, and API surface ([`6af736d`](https://github.com/jolars/panache/commit/6af736d8ab38ecebfaa62d40fbfbe83a2a300adf))
+
+### Features
+- **formatter:** add `horizontal-rule-style` format option ([`e2b0abe`](https://github.com/jolars/panache/commit/e2b0abe51cfe62514defa4c476ca4be175ba216b)), closes [#417](https://github.com/jolars/panache/issues/417)
+- remove long-deprecated config, CLI, and API surface ([`6af736d`](https://github.com/jolars/panache/commit/6af736d8ab38ecebfaa62d40fbfbe83a2a300adf))
+- **parser:** lift HTML block on footnote marker line ([`cab5f61`](https://github.com/jolars/panache/commit/cab5f6125e51c22a07d7cfe3768885f3d4299b45))
+
+### Bug Fixes
+- **formatter:** keep space after crossref in footnote ([`bfa9da0`](https://github.com/jolars/panache/commit/bfa9da007ac7c43ac8480abeee0ed28af6fffed7)), closes [#430](https://github.com/jolars/panache/issues/430)
+- **parser:** preserve order for interrupting ATX headings ([`6620829`](https://github.com/jolars/panache/commit/662082943cd049aba7427d20975a383abe929839))
+- **formatter:** blank line between trailing rule and div fence ([`1abf3f8`](https://github.com/jolars/panache/commit/1abf3f8f35d58e5ccfafe66e0b88b7ca003f6e71))
+- **formatter:** indent headings in list items ([`7690f1d`](https://github.com/jolars/panache/commit/7690f1ddf36be642eeeffe04952379e597524504))
+- **formatter:** indent horizontal rules in list items ([`2033e2b`](https://github.com/jolars/panache/commit/2033e2b98256e5d8892fa8ff4b218f069570b65b))
+- **formatter:** collapse newline inside inline math ([`28266ed`](https://github.com/jolars/panache/commit/28266ed461bc4e551224aa985f40f47cbf3ebd36))
+- **formatter:** anchor LHS binary math breaks flush ([`a4a86ec`](https://github.com/jolars/panache/commit/a4a86ec454a7bb564ab6bbfec9c182778b5a433e))
+
+### Dependencies
+- updated crates/panache-parser to v0.22.0
+
 ## [0.19.0](https://github.com/jolars/panache/compare/panache-formatter-v0.18.0...panache-formatter-v0.19.0) (2026-07-04)
 
 ### Features

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 include = [
     "/src/**/*",
@@ -18,7 +18,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.21.0" }
+panache-parser = { path = "../panache-parser", version = "0.22.0" }
 log = { version = "0.4.31", features = ["release_max_level_debug"] }
 rowan = "0.16.1"
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.22.0](https://github.com/jolars/panache/compare/panache-parser-v0.21.0...panache-parser-v0.22.0) (2026-07-20)
+
+### Breaking changes
+- remove long-deprecated config, CLI, and API surface ([`6af736d`](https://github.com/jolars/panache/commit/6af736d8ab38ecebfaa62d40fbfbe83a2a300adf))
+
+### Features
+- remove long-deprecated config, CLI, and API surface ([`6af736d`](https://github.com/jolars/panache/commit/6af736d8ab38ecebfaa62d40fbfbe83a2a300adf))
+- **parser:** lift later-line HTML block in def/footnote body ([`21d448a`](https://github.com/jolars/panache/commit/21d448a3972261d6ec8472a0ccc74cd37f75688b))
+- **parser:** fuse comment trailing softbreak in def body ([`1a2c8b9`](https://github.com/jolars/panache/commit/1a2c8b9728dae63989d7eddc3b348b85f8ae1f71))
+- **parser:** lift HTML block on footnote marker line ([`cab5f61`](https://github.com/jolars/panache/commit/cab5f6125e51c22a07d7cfe3768885f3d4299b45))
+- **parser:** dispatch HTML block on definition marker line ([`8eb6f6a`](https://github.com/jolars/panache/commit/8eb6f6a4657e807df5da154f169b50dbe9d4beb0))
+- **parser:** fuse comment softbreak in blockquote ([`8a29570`](https://github.com/jolars/panache/commit/8a295706c62421157c59ea4282e49a2c15c4660b))
+- **parser:** fuse comment softbreak in fenced div ([`baccde0`](https://github.com/jolars/panache/commit/baccde0247c1344c49a97c809c26f4a067a8728c))
+
+### Bug Fixes
+- **parser:** let blocks end reduced-marker lazy lines ([`edd18ee`](https://github.com/jolars/panache/commit/edd18eeeac33f2dcfd5d443192d387e6d3e27231)), closes [#429](https://github.com/jolars/panache/issues/429)
+- **parser:** let ATX heading end a lazy blockquote line ([`71f46a4`](https://github.com/jolars/panache/commit/71f46a4bd8d971ec9d73d09d8bbcb220827d7779)), closes [#428](https://github.com/jolars/panache/issues/428)
+- **parser:** keep setext from interrupting a paragraph ([`a1b9fa1`](https://github.com/jolars/panache/commit/a1b9fa1ff82c5f0d4f953413a08eaa3b12695e68))
+- **parser:** preserve order for interrupting ATX headings ([`6620829`](https://github.com/jolars/panache/commit/662082943cd049aba7427d20975a383abe929839))
+- **parser:** detect headerless single-column simple tables ([`0de4afc`](https://github.com/jolars/panache/commit/0de4afcbe0ecb23b1d5581078b2107dafa7a9a7b))
+- **parser:** gate YAML metadata on top-level mapping ([`8f135bc`](https://github.com/jolars/panache/commit/8f135bc760e0961f89d8b6d7735e1f4526005ae0))
+- **parser:** restrict mid-document YAML to pandoc dialect ([`53fabd9`](https://github.com/jolars/panache/commit/53fabd92e163272212fc9387bd82fc6e54b886aa))
+- **parser:** detect rules and headings in nested list items ([`4de51b7`](https://github.com/jolars/panache/commit/4de51b78a4ae7235c6307383f870518e42862e0f))
+- **parser:** lift multi-line `<div>` body on definition marker line ([`9a78ab8`](https://github.com/jolars/panache/commit/9a78ab893532143cbefd69c74042b01d01241eb6))
+
 ## [0.21.0](https://github.com/jolars/panache/compare/panache-parser-v0.20.0...panache-parser-v0.21.0) (2026-07-04)
 
 ### Features

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.21.0"
+version = "0.22.0"
 edition.workspace = true
 readme = "README.md"
 include = [

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.0.0](https://github.com/jolars/panache/compare/panache-code-v2.54.0...panache-code-v3.0.0) (2026-07-20)
+
+### Dependencies
+- updated panache to v3.0.0
+
 ## [2.54.0](https://github.com/jolars/panache/compare/panache-code-v2.53.0...panache-code-v2.54.0) (2026-07-04)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "2.54.0",
+  "version": "3.0.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "auditable-serde"
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "cfg-if"
@@ -55,7 +55,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -116,15 +116,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -133,38 +133,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -345,9 +345,9 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miniz_oxide"
@@ -393,23 +393,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -426,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -436,29 +436,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -469,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "slab"
@@ -502,9 +502,20 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -519,7 +530,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -651,7 +662,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.119",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -667,7 +678,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -734,7 +745,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -773,7 +784,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -807,11 +818,11 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         panache = pkgs.rustPlatform.buildRustPackage {
           pname = "panache";
-          version = "2.61.0";
+          version = "3.0.0";
 
           src = ./.;
 

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "2.61.0",
+  "version": "3.0.0",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "2.61.0",
-    "@panache-cli/linux-arm64-gnu": "2.61.0",
-    "@panache-cli/linux-x64-musl": "2.61.0",
-    "@panache-cli/linux-arm64-musl": "2.61.0",
-    "@panache-cli/darwin-x64": "2.61.0",
-    "@panache-cli/darwin-arm64": "2.61.0",
-    "@panache-cli/win32-x64": "2.61.0",
-    "@panache-cli/win32-arm64": "2.61.0"
+    "@panache-cli/linux-x64-gnu": "3.0.0",
+    "@panache-cli/linux-arm64-gnu": "3.0.0",
+    "@panache-cli/linux-x64-musl": "3.0.0",
+    "@panache-cli/linux-arm64-musl": "3.0.0",
+    "@panache-cli/darwin-x64": "3.0.0",
+    "@panache-cli/darwin-arm64": "3.0.0",
+    "@panache-cli/win32-x64": "3.0.0",
+    "@panache-cli/win32-arm64": "3.0.0"
   }
 }


### PR DESCRIPTION
## [panache: 3.0.0](https://github.com/jolars/panache/compare/v2.61.0...v3.0.0) (2026-07-20)

This is a major release with breaking changes. Most importantly, `snake_case`
style configurations keys, which have been deprecated since a few months back,
are now removed. Please update your configuration files to use `kebab-case`
keys instead. It also brings a breaking change to the linter, which now exits
non-zero on lint violations. The `--check` CLI flag no longer has any effect on
`panache lint` and has been removed.

Other than that, this release brings major performance improvements to the
language server, a new style configuration for horizontal rules (`horizontal-rule-style`)
and a number of bug fixes.

### Breaking changes
- remove long-deprecated config, CLI, and API surface ([`6af736d`](https://github.com/jolars/panache/commit/6af736d8ab38ecebfaa62d40fbfbe83a2a300adf))
- **cli:** exit non-zero on lint violations by default ([`f31317a`](https://github.com/jolars/panache/commit/f31317a45147c6cb2982e328f38d59d1d74440d7))

### Features
- **linter:** add `citation-nonbreaking-space` rule ([`6f8fb28`](https://github.com/jolars/panache/commit/6f8fb28fb4f49384295a10cea9ae807debcc89d9))
- **formatter:** add `horizontal-rule-style` format option ([`e2b0abe`](https://github.com/jolars/panache/commit/e2b0abe51cfe62514defa4c476ca4be175ba216b)), closes [#417](https://github.com/jolars/panache/issues/417)
- remove long-deprecated config, CLI, and API surface ([`6af736d`](https://github.com/jolars/panache/commit/6af736d8ab38ecebfaa62d40fbfbe83a2a300adf))
- **cli:** exit non-zero on lint violations by default ([`f31317a`](https://github.com/jolars/panache/commit/f31317a45147c6cb2982e328f38d59d1d74440d7))
- **parser:** lift later-line HTML block in def/footnote body ([`21d448a`](https://github.com/jolars/panache/commit/21d448a3972261d6ec8472a0ccc74cd37f75688b))
- **parser:** fuse comment trailing softbreak in def body ([`1a2c8b9`](https://github.com/jolars/panache/commit/1a2c8b9728dae63989d7eddc3b348b85f8ae1f71))
- **parser:** lift HTML block on footnote marker line ([`cab5f61`](https://github.com/jolars/panache/commit/cab5f6125e51c22a07d7cfe3768885f3d4299b45))
- **parser:** dispatch HTML block on definition marker line ([`8eb6f6a`](https://github.com/jolars/panache/commit/8eb6f6a4657e807df5da154f169b50dbe9d4beb0))
- **parser:** fuse comment softbreak in blockquote ([`8a29570`](https://github.com/jolars/panache/commit/8a295706c62421157c59ea4282e49a2c15c4660b))
- **parser:** fuse comment softbreak in fenced div ([`baccde0`](https://github.com/jolars/panache/commit/baccde0247c1344c49a97c809c26f4a067a8728c))

### Bug Fixes
- adapt to salsa 0.28 and lsp-server 0.10 APIs ([`54bd3ae`](https://github.com/jolars/panache/commit/54bd3ae83051a86850114ffc35aab179ed8a673f))
- **formatter:** keep space after crossref in footnote ([`bfa9da0`](https://github.com/jolars/panache/commit/bfa9da007ac7c43ac8480abeee0ed28af6fffed7)), closes [#430](https://github.com/jolars/panache/issues/430)
- **parser:** let blocks end reduced-marker lazy lines ([`edd18ee`](https://github.com/jolars/panache/commit/edd18eeeac33f2dcfd5d443192d387e6d3e27231)), closes [#429](https://github.com/jolars/panache/issues/429)
- **parser:** let ATX heading end a lazy blockquote line ([`71f46a4`](https://github.com/jolars/panache/commit/71f46a4bd8d971ec9d73d09d8bbcb220827d7779)), closes [#428](https://github.com/jolars/panache/issues/428)
- **parser:** detect headerless single-column simple tables ([`0de4afc`](https://github.com/jolars/panache/commit/0de4afcbe0ecb23b1d5581078b2107dafa7a9a7b))
- **parser:** gate YAML metadata on top-level mapping ([`8f135bc`](https://github.com/jolars/panache/commit/8f135bc760e0961f89d8b6d7735e1f4526005ae0))
- **parser:** restrict mid-document YAML to pandoc dialect ([`53fabd9`](https://github.com/jolars/panache/commit/53fabd92e163272212fc9387bd82fc6e54b886aa))
- **formatter:** blank line between trailing rule and div fence ([`1abf3f8`](https://github.com/jolars/panache/commit/1abf3f8f35d58e5ccfafe66e0b88b7ca003f6e71))
- **formatter:** indent headings in list items ([`7690f1d`](https://github.com/jolars/panache/commit/7690f1ddf36be642eeeffe04952379e597524504))
- **formatter:** indent horizontal rules in list items ([`2033e2b`](https://github.com/jolars/panache/commit/2033e2b98256e5d8892fa8ff4b218f069570b65b))
- **config:** add migration hints for removed 3.0 keys ([`aa35d17`](https://github.com/jolars/panache/commit/aa35d17cfad01a856c8e77af16bdeb88015c77b0))
- **parser:** lift multi-line `<div>` body on definition marker line ([`9a78ab8`](https://github.com/jolars/panache/commit/9a78ab893532143cbefd69c74042b01d01241eb6))
- **lsp:** report server name and version at initialize ([`79fe479`](https://github.com/jolars/panache/commit/79fe4798ac62cfe985bbffcf7b639129d9b9b64a))
- **lsp:** drop global state before joining IO threads ([`df57721`](https://github.com/jolars/panache/commit/df57721e038576eb3ac577e44dbc0e60808e4334))
- **formatter:** match `[formatters]` keys by language alias ([`08c39bc`](https://github.com/jolars/panache/commit/08c39bced6f90745dbfe47bd507020afe941bce6))
- **formatter:** collapse newline inside inline math ([`28266ed`](https://github.com/jolars/panache/commit/28266ed461bc4e551224aa985f40f47cbf3ebd36))
- **formatter:** anchor LHS binary math breaks flush ([`a4a86ec`](https://github.com/jolars/panache/commit/a4a86ec454a7bb564ab6bbfec9c182778b5a433e))
- **lsp:** serve pull diagnostics off the event loop ([`b60c779`](https://github.com/jolars/panache/commit/b60c779274b17d78e4443fd801b28a52fb658a48))
- **parser:** preserve order for interrupting ATX headings ([`6620829`](https://github.com/jolars/panache/commit/662082943cd049aba7427d20975a383abe929839))
- **parser:** keep setext from interrupting a paragraph ([`a1b9fa1`](https://github.com/jolars/panache/commit/a1b9fa1ff82c5f0d4f953413a08eaa3b12695e68))
- **parser:** detect rules and headings in nested list items ([`4de51b7`](https://github.com/jolars/panache/commit/4de51b78a4ae7235c6307383f870518e42862e0f))

### Performance Improvements
- **lsp:** share one `FileConfig` per config value ([`16ae29b`](https://github.com/jolars/panache/commit/16ae29b5bcb7c02c4dc14874340875670f704302))

### Dependencies
- updated crates/panache-formatter to v0.20.0
- updated crates/panache-parser to v0.22.0

## [crates/panache-formatter: 0.20.0](https://github.com/jolars/panache/compare/panache-formatter-v0.19.0...panache-formatter-v0.20.0) (2026-07-20)

### Breaking changes
- remove long-deprecated config, CLI, and API surface ([`6af736d`](https://github.com/jolars/panache/commit/6af736d8ab38ecebfaa62d40fbfbe83a2a300adf))

### Features
- **formatter:** add `horizontal-rule-style` format option ([`e2b0abe`](https://github.com/jolars/panache/commit/e2b0abe51cfe62514defa4c476ca4be175ba216b)), closes [#417](https://github.com/jolars/panache/issues/417)
- remove long-deprecated config, CLI, and API surface ([`6af736d`](https://github.com/jolars/panache/commit/6af736d8ab38ecebfaa62d40fbfbe83a2a300adf))
- **parser:** lift HTML block on footnote marker line ([`cab5f61`](https://github.com/jolars/panache/commit/cab5f6125e51c22a07d7cfe3768885f3d4299b45))

### Bug Fixes
- **formatter:** keep space after crossref in footnote ([`bfa9da0`](https://github.com/jolars/panache/commit/bfa9da007ac7c43ac8480abeee0ed28af6fffed7)), closes [#430](https://github.com/jolars/panache/issues/430)
- **parser:** preserve order for interrupting ATX headings ([`6620829`](https://github.com/jolars/panache/commit/662082943cd049aba7427d20975a383abe929839))
- **formatter:** blank line between trailing rule and div fence ([`1abf3f8`](https://github.com/jolars/panache/commit/1abf3f8f35d58e5ccfafe66e0b88b7ca003f6e71))
- **formatter:** indent headings in list items ([`7690f1d`](https://github.com/jolars/panache/commit/7690f1ddf36be642eeeffe04952379e597524504))
- **formatter:** indent horizontal rules in list items ([`2033e2b`](https://github.com/jolars/panache/commit/2033e2b98256e5d8892fa8ff4b218f069570b65b))
- **formatter:** collapse newline inside inline math ([`28266ed`](https://github.com/jolars/panache/commit/28266ed461bc4e551224aa985f40f47cbf3ebd36))
- **formatter:** anchor LHS binary math breaks flush ([`a4a86ec`](https://github.com/jolars/panache/commit/a4a86ec454a7bb564ab6bbfec9c182778b5a433e))

### Dependencies
- updated crates/panache-parser to v0.22.0

## [crates/panache-parser: 0.22.0](https://github.com/jolars/panache/compare/panache-parser-v0.21.0...panache-parser-v0.22.0) (2026-07-20)

### Breaking changes
- remove long-deprecated config, CLI, and API surface ([`6af736d`](https://github.com/jolars/panache/commit/6af736d8ab38ecebfaa62d40fbfbe83a2a300adf))

### Features
- remove long-deprecated config, CLI, and API surface ([`6af736d`](https://github.com/jolars/panache/commit/6af736d8ab38ecebfaa62d40fbfbe83a2a300adf))
- **parser:** lift later-line HTML block in def/footnote body ([`21d448a`](https://github.com/jolars/panache/commit/21d448a3972261d6ec8472a0ccc74cd37f75688b))
- **parser:** fuse comment trailing softbreak in def body ([`1a2c8b9`](https://github.com/jolars/panache/commit/1a2c8b9728dae63989d7eddc3b348b85f8ae1f71))
- **parser:** lift HTML block on footnote marker line ([`cab5f61`](https://github.com/jolars/panache/commit/cab5f6125e51c22a07d7cfe3768885f3d4299b45))
- **parser:** dispatch HTML block on definition marker line ([`8eb6f6a`](https://github.com/jolars/panache/commit/8eb6f6a4657e807df5da154f169b50dbe9d4beb0))
- **parser:** fuse comment softbreak in blockquote ([`8a29570`](https://github.com/jolars/panache/commit/8a295706c62421157c59ea4282e49a2c15c4660b))
- **parser:** fuse comment softbreak in fenced div ([`baccde0`](https://github.com/jolars/panache/commit/baccde0247c1344c49a97c809c26f4a067a8728c))

### Bug Fixes
- **parser:** let blocks end reduced-marker lazy lines ([`edd18ee`](https://github.com/jolars/panache/commit/edd18eeeac33f2dcfd5d443192d387e6d3e27231)), closes [#429](https://github.com/jolars/panache/issues/429)
- **parser:** let ATX heading end a lazy blockquote line ([`71f46a4`](https://github.com/jolars/panache/commit/71f46a4bd8d971ec9d73d09d8bbcb220827d7779)), closes [#428](https://github.com/jolars/panache/issues/428)
- **parser:** keep setext from interrupting a paragraph ([`a1b9fa1`](https://github.com/jolars/panache/commit/a1b9fa1ff82c5f0d4f953413a08eaa3b12695e68))
- **parser:** preserve order for interrupting ATX headings ([`6620829`](https://github.com/jolars/panache/commit/662082943cd049aba7427d20975a383abe929839))
- **parser:** detect headerless single-column simple tables ([`0de4afc`](https://github.com/jolars/panache/commit/0de4afcbe0ecb23b1d5581078b2107dafa7a9a7b))
- **parser:** gate YAML metadata on top-level mapping ([`8f135bc`](https://github.com/jolars/panache/commit/8f135bc760e0961f89d8b6d7735e1f4526005ae0))
- **parser:** restrict mid-document YAML to pandoc dialect ([`53fabd9`](https://github.com/jolars/panache/commit/53fabd92e163272212fc9387bd82fc6e54b886aa))
- **parser:** detect rules and headings in nested list items ([`4de51b7`](https://github.com/jolars/panache/commit/4de51b78a4ae7235c6307383f870518e42862e0f))
- **parser:** lift multi-line `<div>` body on definition marker line ([`9a78ab8`](https://github.com/jolars/panache/commit/9a78ab893532143cbefd69c74042b01d01241eb6))

## [editors/code: 3.0.0](https://github.com/jolars/panache/compare/panache-code-v2.54.0...panache-code-v3.0.0) (2026-07-20)

### Dependencies
- updated panache to v3.0.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).