### PR TITLE
fix(parser): preserve order for interrupting ATX headings

### DIFF
--- a/crates/panache-formatter/tests/format/headings.rs
+++ b/crates/panache-formatter/tests/format/headings.rs
@@ -28,6 +28,24 @@ fn consecutive_atx_headings_without_blank_lines_stay_separate() {
 }
 
 #[test]
+fn atx_heading_interrupting_paragraph_keeps_document_order() {
+    let mut cfg = panache_formatter::Config::default();
+    cfg.parser_extensions.blank_before_header = false;
+    cfg.formatter_extensions.blank_before_header = false;
+
+    let input = "Text\n## Title\nMore\n";
+    let expected = "Text\n\n## Title\n\nMore\n";
+    let out = format(input, Some(cfg.clone()), None);
+
+    assert_eq!(out, expected);
+    assert_eq!(
+        format(&out, Some(cfg), None),
+        expected,
+        "must be idempotent"
+    );
+}
+
+#[test]
 fn horizontal_rule_before_setext_like_paragraph_stays_idempotent() {
     let input = "---\nSIL OPEN FONT LICENSE Version 1.1 - 26 February 2007\n-----------------------------------------------------------\n";
     let first = format(input, None, None);

--- a/crates/panache-parser/src/parser/block_dispatcher.rs
+++ b/crates/panache-parser/src/parser/block_dispatcher.rs
@@ -315,14 +315,16 @@ impl BlockParser for AtxHeadingParser {
         }
 
         let level = try_parse_atx_heading(lines.first())?;
-        // CommonMark §4.2: an ATX heading can interrupt a paragraph (no blank
-        // line required between the paragraph and the heading). Pandoc-markdown
-        // disagrees: without a blank line, `# foo` inside a paragraph stays
-        // text. Branch on dialect — `YesCanInterrupt` triggers the dispatcher
-        // path that closes an open paragraph before emitting the heading.
-        let detection = match ctx.config.dialect {
-            crate::options::Dialect::CommonMark => BlockDetectionResult::YesCanInterrupt,
-            crate::options::Dialect::Pandoc => BlockDetectionResult::Yes,
+        // CommonMark §4.2 allows an ATX heading to interrupt a paragraph.
+        // Pandoc does the same when its `blank_before_header` extension is
+        // disabled. `YesCanInterrupt` closes and flushes the open paragraph
+        // before the heading is emitted, preserving source order.
+        let can_interrupt = ctx.config.dialect == crate::options::Dialect::CommonMark
+            || !ctx.config.extensions.blank_before_header;
+        let detection = if can_interrupt {
+            BlockDetectionResult::YesCanInterrupt
+        } else {
+            BlockDetectionResult::Yes
         };
         Some((detection, Some(Box::new(level))))
     }

--- a/crates/panache-parser/src/parser/blocks/tests/headings.rs
+++ b/crates/panache-parser/src/parser/blocks/tests/headings.rs
@@ -97,12 +97,23 @@ fn parses_empty_atx_heading_before_table_caption_table() {
 fn parses_heading_without_blank_line_when_extension_disabled() {
     let mut config = ParserOptions::default();
     config.extensions.blank_before_header = false;
-    let node = Parser::new("text\n# Heading\n", &config).parse();
-    let headings: Vec<_> = node
-        .descendants()
-        .filter(|n| n.kind() == SyntaxKind::HEADING)
-        .collect();
-    assert_eq!(headings.len(), 1);
+    let input = "Text\n# Heading\nMore\n";
+    let node = Parser::new(input, &config).parse();
+    let blocks: Vec<_> = node.children().map(|node| node.kind()).collect();
+
+    assert_eq!(
+        node.text().to_string(),
+        input,
+        "parser must remain lossless"
+    );
+    assert_eq!(
+        blocks,
+        vec![
+            SyntaxKind::PARAGRAPH,
+            SyntaxKind::HEADING,
+            SyntaxKind::PARAGRAPH
+        ]
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- treat ATX headings as paragraph-interrupting when Pandoc's `blank_before_header` extension is disabled
- flush an open paragraph before emitting the heading so CST and formatted output preserve source order
- strengthen parser losslessness/order coverage and add formatter output/idempotency coverage

## Root cause

`AtxHeadingParser` only returned `YesCanInterrupt` for the CommonMark dialect. Pandoc also permits an ATX heading to interrupt a paragraph when `blank_before_header` is explicitly disabled. Returning plain `Yes` in that configuration emitted the heading before the buffered paragraph and merged the surrounding text.

## Validation

- `cargo check --workspace`
- `cargo test -p panache-parser --lib` (1516 passed)
- `cargo test -p panache-formatter --test format` (453 passed)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`
- compared CLI output with Pandoc 3.10 using `markdown-blank_before_header`

The pre-change full `cargo test --workspace` baseline did not complete within a 10-minute local timeout; the affected parser and formatter suites pass in full.