### PR TITLE
chore(release): v3.0.1 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "d3094071f71fff990ffe453a01fda50c46ba15db",
+  "baseline-sha": "ae99cc0e7b67421f7b101da631d05b74e0a43953",
   "release-targets": [
     {
       "path": ".",
-      "version": "3.0.0",
-      "tag": "v3.0.0"
+      "version": "3.0.1",
+      "tag": "v3.0.1"
     },
     {
       "path": "crates/panache-dprint",
@@ -14,18 +14,18 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.20.0",
-      "tag": "panache-formatter-v0.20.0"
+      "version": "0.20.1",
+      "tag": "panache-formatter-v0.20.1"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.22.0",
-      "tag": "panache-parser-v0.22.0"
+      "version": "0.22.1",
+      "tag": "panache-parser-v0.22.1"
     },
     {
       "path": "editors/code",
-      "version": "3.0.0",
-      "tag": "panache-code-v3.0.0"
+      "version": "3.0.1",
+      "tag": "panache-code-v3.0.1"
     },
     {
       "path": "editors/zed",
@@ -36,23 +36,23 @@
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "3.0.0",
-      "tag": "v3.0.0"
+      "version": "3.0.1",
+      "tag": "v3.0.1"
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.20.0",
-      "tag": "panache-formatter-v0.20.0"
+      "version": "0.20.1",
+      "tag": "panache-formatter-v0.20.1"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.22.0",
-      "tag": "panache-parser-v0.22.0"
+      "version": "0.22.1",
+      "tag": "panache-parser-v0.22.1"
     },
     {
       "path": "editors/code",
-      "version": "3.0.0",
-      "tag": "panache-code-v3.0.0"
+      "version": "3.0.1",
+      "tag": "panache-code-v3.0.1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [3.0.1](https://github.com/jolars/panache/compare/v3.0.0...v3.0.1) (2026-07-25)
+
+### Bug Fixes
+- **parser:** emit simple table closer as separator ([`0db2620`](https://github.com/jolars/panache/commit/0db2620eb1e34ac86c7e2c0eae070f4d9f39be30))
+- **parser:** require closer for headerless simple tables ([`83dd8c5`](https://github.com/jolars/panache/commit/83dd8c526325cab3a33caba9da6a01b3a16ad330))
+- **parser:** accept 2-dash multiline table borders ([`9be4e59`](https://github.com/jolars/panache/commit/9be4e597c4d45b4ccfc62e79e7df1852d8472d37))
+- **parser:** detect headerless single-column multiline tables ([`a573220`](https://github.com/jolars/panache/commit/a57322065d8ff3b26bde55c990f728a56a42aab7))
+- **formatter:** guard heading markers in reflow wrap ([`ad8b1a0`](https://github.com/jolars/panache/commit/ad8b1a01278510188faeff0e14e9d8b77b030a91))
+- **parser:** track display math inside list items ([`6708303`](https://github.com/jolars/panache/commit/67083031fa8f89429510ae5164b22c9ffc769152))
+- **parser:** skip link destinations in citation scan ([`46d2201`](https://github.com/jolars/panache/commit/46d220132e53a52dd164b291f360f9e979a765c9))
+- **parser:** track bracket display math across lines ([`cb6b70b`](https://github.com/jolars/panache/commit/cb6b70b55c25036415e29dfc4ab27c8e8c2c3f98)), closes [#437](https://github.com/jolars/panache/issues/437)
+- **parser:** reject simple tables with only a closer ([`b926900`](https://github.com/jolars/panache/commit/b9269008989d63edc3b406d587252c710f43a5e8))
+- **deps:** resolve npm security alerts in VS Code extension ([`2f99759`](https://github.com/jolars/panache/commit/2f9975910fae13cf64c5ff65d358d9682bf3a8d0))
+
+### Dependencies
+- updated crates/panache-formatter to v0.20.1
+- updated crates/panache-parser to v0.22.1
+
 ## [3.0.0](https://github.com/jolars/panache/compare/v2.61.0...v3.0.0) (2026-07-20)
 
 This is a major release with breaking changes. Most importantly, `snake_case`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -447,9 +447,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "email_address"
@@ -988,9 +988,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
@@ -1205,7 +1205,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "panache"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "insta",
  "log",
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "entities",
  "insta",
@@ -1511,7 +1511,7 @@ checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1719,7 +1719,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1754,7 +1754,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1862,9 +1862,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1930,7 +1930,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2281,18 +2281,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "3.0.0"
+version = "3.0.1"
 edition.workspace = true
 # `distill_quarto_schema` is a dev-only vendoring bin (src/bin/); keep bare
 # `cargo run` resolving to the CLI for tooling like the pre-commit format hook.
@@ -52,8 +52,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.20.0" }
-panache-parser = { path = "crates/panache-parser", version = "0.22.0", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.20.1" }
+panache-parser = { path = "crates/panache-parser", version = "0.22.1", features = [
     "serde",
     "schema",
 ] }

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.20.1](https://github.com/jolars/panache/compare/panache-formatter-v0.20.0...panache-formatter-v0.20.1) (2026-07-25)
+
+### Bug Fixes
+- **parser:** emit simple table closer as separator ([`0db2620`](https://github.com/jolars/panache/commit/0db2620eb1e34ac86c7e2c0eae070f4d9f39be30))
+- **formatter:** guard heading markers in reflow wrap ([`ad8b1a0`](https://github.com/jolars/panache/commit/ad8b1a01278510188faeff0e14e9d8b77b030a91))
+- **parser:** track display math inside list items ([`6708303`](https://github.com/jolars/panache/commit/67083031fa8f89429510ae5164b22c9ffc769152))
+- **parser:** track bracket display math across lines ([`cb6b70b`](https://github.com/jolars/panache/commit/cb6b70b55c25036415e29dfc4ab27c8e8c2c3f98)), closes [#437](https://github.com/jolars/panache/issues/437)
+
+### Dependencies
+- updated crates/panache-parser to v0.22.1
+
 ## [0.20.0](https://github.com/jolars/panache/compare/panache-formatter-v0.19.0...panache-formatter-v0.20.0) (2026-07-20)
 
 ### Breaking changes

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.20.0"
+version = "0.20.1"
 edition.workspace = true
 include = [
     "/src/**/*",
@@ -18,7 +18,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.22.0" }
+panache-parser = { path = "../panache-parser", version = "0.22.1" }
 log = { version = "0.4.31", features = ["release_max_level_debug"] }
 rowan = "0.16.1"
 serde = { version = "1.0.228", features = ["derive"], optional = true }

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.22.1](https://github.com/jolars/panache/compare/panache-parser-v0.22.0...panache-parser-v0.22.1) (2026-07-25)
+
+### Bug Fixes
+- **parser:** reject simple tables with only a closer ([`b926900`](https://github.com/jolars/panache/commit/b9269008989d63edc3b406d587252c710f43a5e8))
+- **parser:** emit simple table closer as separator ([`0db2620`](https://github.com/jolars/panache/commit/0db2620eb1e34ac86c7e2c0eae070f4d9f39be30))
+- **parser:** require closer for headerless simple tables ([`83dd8c5`](https://github.com/jolars/panache/commit/83dd8c526325cab3a33caba9da6a01b3a16ad330))
+- **parser:** accept 2-dash multiline table borders ([`9be4e59`](https://github.com/jolars/panache/commit/9be4e597c4d45b4ccfc62e79e7df1852d8472d37))
+- **parser:** detect headerless single-column multiline tables ([`a573220`](https://github.com/jolars/panache/commit/a57322065d8ff3b26bde55c990f728a56a42aab7))
+- **parser:** track display math inside list items ([`6708303`](https://github.com/jolars/panache/commit/67083031fa8f89429510ae5164b22c9ffc769152))
+- **parser:** track bracket display math across lines ([`cb6b70b`](https://github.com/jolars/panache/commit/cb6b70b55c25036415e29dfc4ab27c8e8c2c3f98)), closes [#437](https://github.com/jolars/panache/issues/437)
+- **parser:** skip link destinations in citation scan ([`46d2201`](https://github.com/jolars/panache/commit/46d220132e53a52dd164b291f360f9e979a765c9))
+
 ## [0.22.0](https://github.com/jolars/panache/compare/panache-parser-v0.21.0...panache-parser-v0.22.0) (2026-07-20)
 
 ### Breaking changes

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.22.0"
+version = "0.22.1"
 edition.workspace = true
 readme = "README.md"
 include = [

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.0.1](https://github.com/jolars/panache/compare/panache-code-v3.0.0...panache-code-v3.0.1) (2026-07-25)
+
+### Bug Fixes
+- **deps:** resolve npm security alerts in VS Code extension ([`2f99759`](https://github.com/jolars/panache/commit/2f9975910fae13cf64c5ff65d358d9682bf3a8d0))
+
+### Dependencies
+- updated panache to v3.0.1
+
 ## [3.0.0](https://github.com/jolars/panache/compare/panache-code-v2.54.0...panache-code-v3.0.0) (2026-07-20)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -451,7 +451,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -513,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         panache = pkgs.rustPlatform.buildRustPackage {
           pname = "panache";
-          version = "3.0.0";
+          version = "3.0.1";
 
           src = ./.;
 

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "3.0.0",
-    "@panache-cli/linux-arm64-gnu": "3.0.0",
-    "@panache-cli/linux-x64-musl": "3.0.0",
-    "@panache-cli/linux-arm64-musl": "3.0.0",
-    "@panache-cli/darwin-x64": "3.0.0",
-    "@panache-cli/darwin-arm64": "3.0.0",
-    "@panache-cli/win32-x64": "3.0.0",
-    "@panache-cli/win32-arm64": "3.0.0"
+    "@panache-cli/linux-x64-gnu": "3.0.1",
+    "@panache-cli/linux-arm64-gnu": "3.0.1",
+    "@panache-cli/linux-x64-musl": "3.0.1",
+    "@panache-cli/linux-arm64-musl": "3.0.1",
+    "@panache-cli/darwin-x64": "3.0.1",
+    "@panache-cli/darwin-arm64": "3.0.1",
+    "@panache-cli/win32-x64": "3.0.1",
+    "@panache-cli/win32-arm64": "3.0.1"
   }
 }


### PR DESCRIPTION
## [panache: 3.0.1](https://github.com/jolars/panache/compare/v3.0.0...v3.0.1) (2026-07-25)

### Bug Fixes
- **parser:** emit simple table closer as separator ([`0db2620`](https://github.com/jolars/panache/commit/0db2620eb1e34ac86c7e2c0eae070f4d9f39be30))
- **parser:** require closer for headerless simple tables ([`83dd8c5`](https://github.com/jolars/panache/commit/83dd8c526325cab3a33caba9da6a01b3a16ad330))
- **parser:** accept 2-dash multiline table borders ([`9be4e59`](https://github.com/jolars/panache/commit/9be4e597c4d45b4ccfc62e79e7df1852d8472d37))
- **parser:** detect headerless single-column multiline tables ([`a573220`](https://github.com/jolars/panache/commit/a57322065d8ff3b26bde55c990f728a56a42aab7))
- **formatter:** guard heading markers in reflow wrap ([`ad8b1a0`](https://github.com/jolars/panache/commit/ad8b1a01278510188faeff0e14e9d8b77b030a91))
- **parser:** track display math inside list items ([`6708303`](https://github.com/jolars/panache/commit/67083031fa8f89429510ae5164b22c9ffc769152))
- **parser:** skip link destinations in citation scan ([`46d2201`](https://github.com/jolars/panache/commit/46d220132e53a52dd164b291f360f9e979a765c9))
- **parser:** track bracket display math across lines ([`cb6b70b`](https://github.com/jolars/panache/commit/cb6b70b55c25036415e29dfc4ab27c8e8c2c3f98)), closes [#437](https://github.com/jolars/panache/issues/437)
- **parser:** reject simple tables with only a closer ([`b926900`](https://github.com/jolars/panache/commit/b9269008989d63edc3b406d587252c710f43a5e8))
- **deps:** resolve npm security alerts in VS Code extension ([`2f99759`](https://github.com/jolars/panache/commit/2f9975910fae13cf64c5ff65d358d9682bf3a8d0))

### Dependencies
- updated crates/panache-formatter to v0.20.1
- updated crates/panache-parser to v0.22.1

## [crates/panache-formatter: 0.20.1](https://github.com/jolars/panache/compare/panache-formatter-v0.20.0...panache-formatter-v0.20.1) (2026-07-25)

### Bug Fixes
- **parser:** emit simple table closer as separator ([`0db2620`](https://github.com/jolars/panache/commit/0db2620eb1e34ac86c7e2c0eae070f4d9f39be30))
- **formatter:** guard heading markers in reflow wrap ([`ad8b1a0`](https://github.com/jolars/panache/commit/ad8b1a01278510188faeff0e14e9d8b77b030a91))
- **parser:** track display math inside list items ([`6708303`](https://github.com/jolars/panache/commit/67083031fa8f89429510ae5164b22c9ffc769152))
- **parser:** track bracket display math across lines ([`cb6b70b`](https://github.com/jolars/panache/commit/cb6b70b55c25036415e29dfc4ab27c8e8c2c3f98)), closes [#437](https://github.com/jolars/panache/issues/437)

### Dependencies
- updated crates/panache-parser to v0.22.1

## [crates/panache-parser: 0.22.1](https://github.com/jolars/panache/compare/panache-parser-v0.22.0...panache-parser-v0.22.1) (2026-07-25)

### Bug Fixes
- **parser:** reject simple tables with only a closer ([`b926900`](https://github.com/jolars/panache/commit/b9269008989d63edc3b406d587252c710f43a5e8))
- **parser:** emit simple table closer as separator ([`0db2620`](https://github.com/jolars/panache/commit/0db2620eb1e34ac86c7e2c0eae070f4d9f39be30))
- **parser:** require closer for headerless simple tables ([`83dd8c5`](https://github.com/jolars/panache/commit/83dd8c526325cab3a33caba9da6a01b3a16ad330))
- **parser:** accept 2-dash multiline table borders ([`9be4e59`](https://github.com/jolars/panache/commit/9be4e597c4d45b4ccfc62e79e7df1852d8472d37))
- **parser:** detect headerless single-column multiline tables ([`a573220`](https://github.com/jolars/panache/commit/a57322065d8ff3b26bde55c990f728a56a42aab7))
- **parser:** track display math inside list items ([`6708303`](https://github.com/jolars/panache/commit/67083031fa8f89429510ae5164b22c9ffc769152))
- **parser:** track bracket display math across lines ([`cb6b70b`](https://github.com/jolars/panache/commit/cb6b70b55c25036415e29dfc4ab27c8e8c2c3f98)), closes [#437](https://github.com/jolars/panache/issues/437)
- **parser:** skip link destinations in citation scan ([`46d2201`](https://github.com/jolars/panache/commit/46d220132e53a52dd164b291f360f9e979a765c9))

## [editors/code: 3.0.1](https://github.com/jolars/panache/compare/panache-code-v3.0.0...panache-code-v3.0.1) (2026-07-25)

### Bug Fixes
- **deps:** resolve npm security alerts in VS Code extension ([`2f99759`](https://github.com/jolars/panache/commit/2f9975910fae13cf64c5ff65d358d9682bf3a8d0))

### Dependencies
- updated panache to v3.0.1

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).