### PR TITLE
fix(parser): track bracket display math

### DIFF
--- a/crates/panache-formatter/tests/format/math.rs
+++ b/crates/panache-formatter/tests/format/math.rs
@@ -51,6 +51,16 @@ fn display_math_default_indent_multiline_idempotent() {
 }
 
 #[test]
+fn bracket_display_math_preserves_following_markdown_structure() {
+    let input = "Before\n\n\\[\n\\begin{bmatrix}1\\\\1\\\\0\\end{bmatrix}\n\\]\n\nAfter\n\n\n\n# Heading\nText\n";
+    let expected = "Before\n\n\\[ \\begin{bmatrix}1\\\\1\\\\0\\end{bmatrix} \\]\n\nAfter\n\n# Heading\n\nText\n";
+    let output = format(input, Some(math_config(false)), None);
+
+    similar_asserts::assert_eq!(output, expected);
+    similar_asserts::assert_eq!(format(&output, Some(math_config(false)), None), output);
+}
+
+#[test]
 fn display_math_indent_zero_stays_flush() {
     // Explicit `math-indent = 0` keeps the old flush-left behavior.
     let cfg = Config {

--- a/crates/panache-parser/src/parser/blocks/paragraphs.rs
+++ b/crates/panache-parser/src/parser/blocks/paragraphs.rs
@@ -41,6 +41,14 @@ fn update_display_math_dollar_state(
     }
 }
 
+fn update_display_math_bracket_state(line_no_newline: &str, open_display_math_brackets: &mut bool) {
+    match line_no_newline.trim() {
+        "\\[" => *open_display_math_brackets = true,
+        "\\]" => *open_display_math_brackets = false,
+        _ => {}
+    }
+}
+
 fn extract_end_environment_name(line: &str) -> Option<&str> {
     let trimmed = line.trim_start();
     if !trimmed.starts_with("\\end{") {
@@ -71,6 +79,7 @@ pub(in crate::parser) fn start_paragraph_if_needed(
             buffer: ParagraphBuffer::new(),
             open_inline_math_envs: Vec::new(),
             open_display_math_dollar_count: None,
+            open_display_math_brackets: false,
             start_checkpoint,
         });
     }
@@ -89,6 +98,7 @@ pub(in crate::parser) fn append_paragraph_line(
         buffer,
         open_inline_math_envs,
         open_display_math_dollar_count,
+        open_display_math_brackets,
         ..
     }) = containers.stack.last_mut()
     {
@@ -100,6 +110,7 @@ pub(in crate::parser) fn append_paragraph_line(
         // This prevents `$$` + `\begin{...}` forms from being split into
         // PARAGRAPH + TEX_BLOCK across parse passes.
         update_display_math_dollar_state(line_no_newline, open_display_math_dollar_count);
+        update_display_math_bracket_state(line_no_newline, open_display_math_brackets);
         if let Some(env_name) = extract_environment_name(line_no_newline)
             && is_inline_math_environment(env_name)
         {
@@ -149,6 +160,16 @@ pub(in crate::parser) fn has_open_display_math_dollars(containers: &ContainerSta
             open_display_math_dollar_count,
             ..
         }) if open_display_math_dollar_count.is_some()
+    )
+}
+
+pub(in crate::parser) fn has_open_display_math_brackets(containers: &ContainerStack) -> bool {
+    matches!(
+        containers.last(),
+        Some(Container::Paragraph {
+            open_display_math_brackets: true,
+            ..
+        })
     )
 }
 

--- a/crates/panache-parser/src/parser/blocks/tests/code_blocks.rs
+++ b/crates/panache-parser/src/parser/blocks/tests/code_blocks.rs
@@ -710,6 +710,21 @@ fn standalone_dollar_math_delimiters_do_not_split_into_tex_block() {
     );
 }
 
+#[test]
+fn bracket_display_math_does_not_split_into_tex_block() {
+    let input = "Before\n\n\\[\nN(A)=\\operatorname{span}\n\\left\\{\n\\begin{bmatrix}1\\\\1\\\\0\\end{bmatrix},\n\\begin{bmatrix}0\\\\0\\\\1\\end{bmatrix}\n\\right\\}\n\\]\n\nAfter\n\n# Heading\n\nText\n";
+    let tree = parse_blocks(input);
+
+    assert!(
+        find_first(&tree, SyntaxKind::TEX_BLOCK).is_none(),
+        "display math delimited by standalone \\[ and \\] lines should stay paragraph-inline, not TEX_BLOCK"
+    );
+    assert!(
+        find_first(&tree, SyntaxKind::HEADING).is_some(),
+        "a heading after bracket-delimited display math should remain a HEADING"
+    );
+}
+
 // Indented code block tests
 
 #[test]

--- a/crates/panache-parser/src/parser/core.rs
+++ b/crates/panache-parser/src/parser/core.rs
@@ -3735,7 +3735,8 @@ impl<'a> Parser<'a> {
 
         if self.is_paragraph_open()
             && (paragraphs::has_open_inline_math_environment(&self.containers)
-                || paragraphs::has_open_display_math_dollars(&self.containers))
+                || paragraphs::has_open_display_math_dollars(&self.containers)
+                || paragraphs::has_open_display_math_brackets(&self.containers))
         {
             paragraphs::append_paragraph_line(
                 &mut self.containers,

--- a/crates/panache-parser/src/parser/utils/container_stack.rs
+++ b/crates/panache-parser/src/parser/utils/container_stack.rs
@@ -66,6 +66,7 @@ pub(crate) enum Container {
         buffer: ParagraphBuffer, // Interleaved buffer for paragraph content with markers
         open_inline_math_envs: Vec<String>,
         open_display_math_dollar_count: Option<usize>,
+        open_display_math_brackets: bool,
         // Checkpoint at the position the paragraph started; used to retroactively
         // wrap buffered content as PARAGRAPH (or HEADING for multi-line setext)
         // when the paragraph is closed.


### PR DESCRIPTION
## Summary

- track standalone `\[` / `\]` display-math delimiters across paragraph lines
- keep LaTeX environments inside bracket-delimited math from becoming raw `TEX_BLOCK`s
- preserve subsequent Markdown structure and formatting

## Root cause

The paragraph parser tracked multiline `$$ ... $$` regions but not `\[ ... \]`.
A line such as `\begin{bmatrix}...\end{bmatrix}` inside bracket-delimited
display math could therefore start a raw TeX block and consume following
Markdown, including headings.

## Validation

- `cargo test -p panache-parser --lib` (1530 passed)
- `cargo test -p panache-formatter --test format` (454 passed)
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`

The full workspace baseline reached an existing Windows CLI-test hang in three
`format --stdin-filename` tests; the parser and formatter suites affected by
this change pass completely.
