### PR TITLE
chore(release): v3.0.2 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "ae99cc0e7b67421f7b101da631d05b74e0a43953",
+  "baseline-sha": "7d400b3000f6e157acf1b138e05f492638df18fc",
   "release-targets": [
     {
       "path": ".",
-      "version": "3.0.1",
-      "tag": "v3.0.1"
+      "version": "3.0.2",
+      "tag": "v3.0.2"
     },
     {
       "path": "crates/panache-dprint",
@@ -14,18 +14,18 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.20.1",
-      "tag": "panache-formatter-v0.20.1"
+      "version": "0.20.2",
+      "tag": "panache-formatter-v0.20.2"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.22.1",
-      "tag": "panache-parser-v0.22.1"
+      "version": "0.22.2",
+      "tag": "panache-parser-v0.22.2"
     },
     {
       "path": "editors/code",
-      "version": "3.0.1",
-      "tag": "panache-code-v3.0.1"
+      "version": "3.0.2",
+      "tag": "panache-code-v3.0.2"
     },
     {
       "path": "editors/zed",
@@ -36,23 +36,23 @@
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "3.0.1",
-      "tag": "v3.0.1"
+      "version": "3.0.2",
+      "tag": "v3.0.2"
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.20.1",
-      "tag": "panache-formatter-v0.20.1"
+      "version": "0.20.2",
+      "tag": "panache-formatter-v0.20.2"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.22.1",
-      "tag": "panache-parser-v0.22.1"
+      "version": "0.22.2",
+      "tag": "panache-parser-v0.22.2"
     },
     {
       "path": "editors/code",
-      "version": "3.0.1",
-      "tag": "panache-code-v3.0.1"
+      "version": "3.0.2",
+      "tag": "panache-code-v3.0.2"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [3.0.2](https://github.com/jolars/panache/compare/v3.0.1...v3.0.2) (2026-07-28)
+
+### Bug Fixes
+- **cli:** scope deprecation quoting to `--check` ([`16742ee`](https://github.com/jolars/panache/commit/16742eeb863cee5383c2554e608965d61bf53103)), closes [#443](https://github.com/jolars/panache/issues/443)
+- **cli:** discover ancestor `panache.toml` for relative targets ([`3947284`](https://github.com/jolars/panache/commit/394728481ce30bbdfe34c937b39c4e441a1428be)), fixes [#441](https://github.com/jolars/panache/issues/441)
+- stabilize divs and code blocks in list items ([`3c47658`](https://github.com/jolars/panache/commit/3c476588af1cbdcf1e9f002a5dc904373fbc800e)), closes [#439](https://github.com/jolars/panache/issues/439)
+- **parser:** inline-parse single-column multiline table cells ([`f69d2bb`](https://github.com/jolars/panache/commit/f69d2bbc7847a15f67c1b5322f9d529962fe0521)), closes [#438](https://github.com/jolars/panache/issues/438)
+
+### Dependencies
+- updated crates/panache-formatter to v0.20.2
+- updated crates/panache-parser to v0.22.2
+
 ## [3.0.1](https://github.com/jolars/panache/compare/v3.0.0...v3.0.1) (2026-07-25)
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+checksum = "b1f84a88507dbd05c695f2cb5e8558e747179134005e9893882dec964190ed89"
 dependencies = [
  "clap",
 ]
@@ -430,13 +430,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -883,9 +883,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
  "defmt",
  "jiff-core",
@@ -907,9 +907,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
 dependencies = [
  "jiff-core",
  "proc-macro2",
@@ -1205,7 +1205,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "panache"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "insta",
  "log",
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "entities",
  "insta",
@@ -1663,9 +1663,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -1676,14 +1676,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1724,13 +1724,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1909,9 +1909,9 @@ checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "thin-vec"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
+checksum = "79def32ffcd477db1ff26f76dab9e3a91f0bd42a85ca96577089b24623056f9d"
 
 [[package]]
 name = "thiserror"
@@ -1951,9 +1951,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -1975,9 +1975,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow 1.0.4",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "3.0.1"
+version = "3.0.2"
 edition.workspace = true
 # `distill_quarto_schema` is a dev-only vendoring bin (src/bin/); keep bare
 # `cargo run` resolving to the CLI for tooling like the pre-commit format hook.
@@ -52,8 +52,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.20.1" }
-panache-parser = { path = "crates/panache-parser", version = "0.22.1", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.20.2" }
+panache-parser = { path = "crates/panache-parser", version = "0.22.2", features = [
     "serde",
     "schema",
 ] }

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.20.2](https://github.com/jolars/panache/compare/panache-formatter-v0.20.1...panache-formatter-v0.20.2) (2026-07-28)
+
+### Bug Fixes
+- stabilize divs and code blocks in list items ([`3c47658`](https://github.com/jolars/panache/commit/3c476588af1cbdcf1e9f002a5dc904373fbc800e)), closes [#439](https://github.com/jolars/panache/issues/439)
+
+### Dependencies
+- updated crates/panache-parser to v0.22.2
+
 ## [0.20.1](https://github.com/jolars/panache/compare/panache-formatter-v0.20.0...panache-formatter-v0.20.1) (2026-07-25)
 
 ### Bug Fixes

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.20.1"
+version = "0.20.2"
 edition.workspace = true
 include = [
     "/src/**/*",
@@ -18,7 +18,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.22.1" }
+panache-parser = { path = "../panache-parser", version = "0.22.2" }
 log = { version = "0.4.31", features = ["release_max_level_debug"] }
 rowan = "0.16.1"
 serde = { version = "1.0.228", features = ["derive"], optional = true }

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.22.2](https://github.com/jolars/panache/compare/panache-parser-v0.22.1...panache-parser-v0.22.2) (2026-07-28)
+
+### Bug Fixes
+- stabilize divs and code blocks in list items ([`3c47658`](https://github.com/jolars/panache/commit/3c476588af1cbdcf1e9f002a5dc904373fbc800e)), closes [#439](https://github.com/jolars/panache/issues/439)
+- **parser:** inline-parse single-column multiline table cells ([`f69d2bb`](https://github.com/jolars/panache/commit/f69d2bbc7847a15f67c1b5322f9d529962fe0521)), closes [#438](https://github.com/jolars/panache/issues/438)
+
 ## [0.22.1](https://github.com/jolars/panache/compare/panache-parser-v0.22.0...panache-parser-v0.22.1) (2026-07-25)
 
 ### Bug Fixes

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.22.1"
+version = "0.22.2"
 edition.workspace = true
 readme = "README.md"
 include = [

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.0.2](https://github.com/jolars/panache/compare/panache-code-v3.0.1...panache-code-v3.0.2) (2026-07-28)
+
+### Dependencies
+- updated panache to v3.0.2
+
 ## [3.0.1](https://github.com/jolars/panache/compare/panache-code-v3.0.0...panache-code-v3.0.1) (2026-07-25)
 
 ### Bug Fixes

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -49,13 +49,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         panache = pkgs.rustPlatform.buildRustPackage {
           pname = "panache";
-          version = "3.0.1";
+          version = "3.0.2";
 
           src = ./.;
 

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "3.0.1",
-    "@panache-cli/linux-arm64-gnu": "3.0.1",
-    "@panache-cli/linux-x64-musl": "3.0.1",
-    "@panache-cli/linux-arm64-musl": "3.0.1",
-    "@panache-cli/darwin-x64": "3.0.1",
-    "@panache-cli/darwin-arm64": "3.0.1",
-    "@panache-cli/win32-x64": "3.0.1",
-    "@panache-cli/win32-arm64": "3.0.1"
+    "@panache-cli/linux-x64-gnu": "3.0.2",
+    "@panache-cli/linux-arm64-gnu": "3.0.2",
+    "@panache-cli/linux-x64-musl": "3.0.2",
+    "@panache-cli/linux-arm64-musl": "3.0.2",
+    "@panache-cli/darwin-x64": "3.0.2",
+    "@panache-cli/darwin-arm64": "3.0.2",
+    "@panache-cli/win32-x64": "3.0.2",
+    "@panache-cli/win32-arm64": "3.0.2"
   }
 }


### PR DESCRIPTION
## [panache: 3.0.2](https://github.com/jolars/panache/compare/v3.0.1...v3.0.2) (2026-07-28)

### Bug Fixes
- **cli:** scope deprecation quoting to `--check` ([`16742ee`](https://github.com/jolars/panache/commit/16742eeb863cee5383c2554e608965d61bf53103)), closes [#443](https://github.com/jolars/panache/issues/443)
- **cli:** discover ancestor `panache.toml` for relative targets ([`3947284`](https://github.com/jolars/panache/commit/394728481ce30bbdfe34c937b39c4e441a1428be)), fixes [#441](https://github.com/jolars/panache/issues/441)
- stabilize divs and code blocks in list items ([`3c47658`](https://github.com/jolars/panache/commit/3c476588af1cbdcf1e9f002a5dc904373fbc800e)), closes [#439](https://github.com/jolars/panache/issues/439)
- **parser:** inline-parse single-column multiline table cells ([`f69d2bb`](https://github.com/jolars/panache/commit/f69d2bbc7847a15f67c1b5322f9d529962fe0521)), closes [#438](https://github.com/jolars/panache/issues/438)

### Dependencies
- updated crates/panache-formatter to v0.20.2
- updated crates/panache-parser to v0.22.2

## [crates/panache-formatter: 0.20.2](https://github.com/jolars/panache/compare/panache-formatter-v0.20.1...panache-formatter-v0.20.2) (2026-07-28)

### Bug Fixes
- stabilize divs and code blocks in list items ([`3c47658`](https://github.com/jolars/panache/commit/3c476588af1cbdcf1e9f002a5dc904373fbc800e)), closes [#439](https://github.com/jolars/panache/issues/439)

### Dependencies
- updated crates/panache-parser to v0.22.2

## [crates/panache-parser: 0.22.2](https://github.com/jolars/panache/compare/panache-parser-v0.22.1...panache-parser-v0.22.2) (2026-07-28)

### Bug Fixes
- stabilize divs and code blocks in list items ([`3c47658`](https://github.com/jolars/panache/commit/3c476588af1cbdcf1e9f002a5dc904373fbc800e)), closes [#439](https://github.com/jolars/panache/issues/439)
- **parser:** inline-parse single-column multiline table cells ([`f69d2bb`](https://github.com/jolars/panache/commit/f69d2bbc7847a15f67c1b5322f9d529962fe0521)), closes [#438](https://github.com/jolars/panache/issues/438)

## [editors/code: 3.0.2](https://github.com/jolars/panache/compare/panache-code-v3.0.1...panache-code-v3.0.2) (2026-07-28)

### Dependencies
- updated panache to v3.0.2

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).