### PR TITLE
fix(cli): discover ancestor `panache.toml` for relative targets

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -598,6 +598,17 @@ fn project_boundary(start_dir: &Path) -> Option<PathBuf> {
     None
 }
 
+/// Resolve a possibly CWD-relative `start_dir` to an absolute path so that
+/// ancestor walks see the real filesystem parents. The empty path (the parent
+/// of a bare filename) means the working directory. Falls back to the path as
+/// given when the working directory is unavailable.
+fn absolutize_start_dir(start_dir: &Path) -> PathBuf {
+    if start_dir.as_os_str().is_empty() {
+        return env::current_dir().unwrap_or_else(|_| start_dir.to_path_buf());
+    }
+    std::path::absolute(start_dir).unwrap_or_else(|_| start_dir.to_path_buf())
+}
+
 fn xdg_config_path() -> Option<PathBuf> {
     if let Ok(xdg) = env::var("XDG_CONFIG_HOME") {
         let p = Path::new(&xdg).join("panache").join("config.toml");
@@ -679,6 +690,13 @@ pub fn load_with_chain(
     input_file: Option<&Path>,
     flavor_override: Option<Flavor>,
 ) -> io::Result<(Config, ConfigSource, Vec<PathBuf>)> {
+    // CLI callers derive `start_dir` from user-supplied targets, so it is
+    // often CWD-relative (`.`, `subdir`, or even empty for a bare filename).
+    // `Path::ancestors()` is purely lexical: a relative walk ends at the
+    // working directory and never reaches its real filesystem parents, so
+    // discovery and the `.git` boundary would miss ancestor configs (#441).
+    let start_dir = absolutize_start_dir(start_dir);
+    let start_dir = start_dir.as_path();
     let boundary = project_boundary(start_dir);
     let (mut cfg, source, extensions, chain) = if let Some(path) = explicit {
         let (cfg, ext, chain) = read_config_with_chain(path).map_err(io::Error::from)?;

--- a/tests/cli/format.rs
+++ b/tests/cli/format.rs
@@ -963,3 +963,27 @@ fn test_format_global_xdg_config_exclude_anchors_at_traversal_dir() {
         .stdout(predicate::str::contains("1 file left unchanged"))
         .stdout(predicate::str::contains("snapshot.md").not());
 }
+
+#[test]
+fn test_format_discovers_parent_config_from_relative_target() {
+    // Issue #441: `panache format --check .` inside a subdirectory must
+    // discover a `panache.toml` in an ancestor directory. With the parent
+    // config's `wrap = "preserve"` the manual line break survives; without it
+    // the default reflow joins the lines and `--check` fails.
+    let temp_dir = TempDir::new().unwrap();
+    fs::create_dir(temp_dir.path().join(".git")).unwrap();
+    fs::write(
+        temp_dir.path().join("panache.toml"),
+        "[format]\nwrap = \"preserve\"\n",
+    )
+    .unwrap();
+    let subdir = temp_dir.path().join("subdir");
+    fs::create_dir(&subdir).unwrap();
+    fs::write(subdir.join("doc.md"), "Alpha\nbravo.\n").unwrap();
+
+    cargo_bin_cmd!("panache")
+        .current_dir(&subdir)
+        .args(["format", "--no-cache", "--check", "."])
+        .assert()
+        .success();
+}

--- a/tests/cli/lint.rs
+++ b/tests/cli/lint.rs
@@ -1332,3 +1332,37 @@ fn test_lint_metadata_yml_validates_against_front_matter() {
         .failure()
         .stdout(predicate::str::contains("quarto-schema-type-mismatch"));
 }
+
+#[test]
+fn test_lint_discovers_parent_config_from_relative_target() {
+    // Issue #441: `panache lint .` inside a subdirectory must discover a
+    // `panache.toml` in an ancestor directory. Discovery walks
+    // `start_dir.ancestors()`, which for a relative start dir never climbs
+    // above the working directory.
+    let temp_dir = TempDir::new().unwrap();
+    fs::create_dir(temp_dir.path().join(".git")).unwrap();
+    fs::write(
+        temp_dir.path().join("panache.toml"),
+        "[lint.rules]\nheading-hierarchy = false\n",
+    )
+    .unwrap();
+    let subdir = temp_dir.path().join("subdir");
+    fs::create_dir(&subdir).unwrap();
+    fs::write(subdir.join("doc.md"), "# Title\n\n### Skipped level\n").unwrap();
+
+    cargo_bin_cmd!("panache")
+        .current_dir(&subdir)
+        .args(["lint", "--no-cache", "."])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No issues found"));
+
+    // A bare relative filename yields an empty start dir; it must resolve to
+    // the working directory and walk up from there.
+    cargo_bin_cmd!("panache")
+        .current_dir(&subdir)
+        .args(["lint", "--no-cache", "doc.md"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No issues found"));
+}


### PR DESCRIPTION
Config discovery walked `start_dir.ancestors()`, but CLI targets like
`panache lint .` or a bare filename produce a CWD-relative (or empty)
start dir, and a lexical ancestor walk never climbs above the working
directory. Ancestor configs and the `.git` project boundary were both
missed. Absolutize the start dir in `load_with_chain` so every caller
walks the real filesystem parents.

Fixes #441

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C1QsVi3ShfJ3YAkyqgbfxD