### PR TITLE
fix(cli): scope deprecation quoting to `--check`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -70,4 +70,4 @@ jobs:
         run: cargo run -- format --check docs/
 
       - name: Panache lint check (docs)
-        run: cargo run -- lint --check docs/
+        run: cargo run -- lint docs/

--- a/docs/guide/integrations.qmd
+++ b/docs/guide/integrations.qmd
@@ -157,5 +157,5 @@ jobs:
       - name: Check formatting
         run: panache format --check .
       - name: Run linter
-        run: panache lint --check .
+        run: panache lint .
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -1522,7 +1522,7 @@ fn main() -> io::Result<()> {
         } => {
             if check {
                 eprintln!(
-                    "Warning: `panache lint --check` is deprecated; linting exits non-zero on \
+                    "Warning: the `--check` flag is deprecated; linting exits non-zero on \
                      violations by default. The flag is now a no-op."
                 );
             }


### PR DESCRIPTION
The warning backticked the whole `panache lint --check` invocation, which
read as if the command were deprecated rather than just the flag. Match
the phrasing already used in the docs and other deprecation warnings.

Closes #443

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TY7wsDP4o2eS3A4mcMg9fG