### PR TITLE
chore(release): v3.1.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "7d400b3000f6e157acf1b138e05f492638df18fc",
+  "baseline-sha": "eea7b2ecfdff0fe0c178a757ff0cf0dab2819495",
   "release-targets": [
     {
       "path": ".",
-      "version": "3.0.2",
-      "tag": "v3.0.2"
+      "version": "3.1.0",
+      "tag": "v3.1.0"
     },
     {
       "path": "crates/panache-dprint",
@@ -14,18 +14,18 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.20.2",
-      "tag": "panache-formatter-v0.20.2"
+      "version": "0.20.3",
+      "tag": "panache-formatter-v0.20.3"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.22.2",
-      "tag": "panache-parser-v0.22.2"
+      "version": "0.23.0",
+      "tag": "panache-parser-v0.23.0"
     },
     {
       "path": "editors/code",
-      "version": "3.0.2",
-      "tag": "panache-code-v3.0.2"
+      "version": "3.1.0",
+      "tag": "panache-code-v3.1.0"
     },
     {
       "path": "editors/zed",
@@ -36,23 +36,23 @@
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "3.0.2",
-      "tag": "v3.0.2"
+      "version": "3.1.0",
+      "tag": "v3.1.0"
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.20.2",
-      "tag": "panache-formatter-v0.20.2"
+      "version": "0.20.3",
+      "tag": "panache-formatter-v0.20.3"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.22.2",
-      "tag": "panache-parser-v0.22.2"
+      "version": "0.23.0",
+      "tag": "panache-parser-v0.23.0"
     },
     {
       "path": "editors/code",
-      "version": "3.0.2",
-      "tag": "panache-code-v3.0.2"
+      "version": "3.1.0",
+      "tag": "panache-code-v3.1.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## [3.1.0](https://github.com/jolars/panache/compare/v3.0.2...v3.1.0) (2026-08-03)
+
+### Features
+- **parser:** recognize bare `:` definition marker ([`cfa9eec`](https://github.com/jolars/panache/commit/cfa9eec19c010a810e906424040736067d036192))
+- **lsp:** pull settings via workspace/configuration ([`a40ed7f`](https://github.com/jolars/panache/commit/a40ed7fba0604967be92ae1a1f36bcb71f96e956))
+- **linter:** add `unspaced-citation` rule ([`b36baed`](https://github.com/jolars/panache/commit/b36baedc4902c55f7bbfce151a3e0dcfde422c0e)), closes [#448](https://github.com/jolars/panache/issues/448)
+- **linter:** warn on duplicate and unused YAML anchors ([`d234921`](https://github.com/jolars/panache/commit/d2349212289ef8129798e59e2dc710a3d75cb245)), closes [#385](https://github.com/jolars/panache/issues/385)
+- **parser:** reject undeclared YAML alias ([`4dbdfe6`](https://github.com/jolars/panache/commit/4dbdfe6e6aa2f3f298221c2f4e3f19772608cf33))
+- **parser:** lift unclosed `<div>` as list-item body ([`4801192`](https://github.com/jolars/panache/commit/48011921ad9ec24041a9f647f7ecfaa086e4b8d4))
+- **parser:** lift unclosed `<div>` on later content-body line ([`151515d`](https://github.com/jolars/panache/commit/151515da464940007eb32a66055b3340ad9319a4))
+
+### Bug Fixes
+- **formatter:** preserve inline code-span whitespace ([`eea7b2e`](https://github.com/jolars/panache/commit/eea7b2ecfdff0fe0c178a757ff0cf0dab2819495))
+- **formatter:** keep blockquote definitions prefixed ([`1110029`](https://github.com/jolars/panache/commit/1110029153ecb21f90bc14a51350e9b9809948cf))
+- **parser:** require a term before a definition marker ([`cc8a4fc`](https://github.com/jolars/panache/commit/cc8a4fc4b71eab6cd11a5760d66102ef6a6579cf))
+- **formatter:** tidy bare-marker definition body ([`0ca8a0c`](https://github.com/jolars/panache/commit/0ca8a0ca12c0b17a38a05704a64e6e85eb5dcf9f))
+- **parser:** keep def-list para open across `>` line ([`cbb55c4`](https://github.com/jolars/panache/commit/cbb55c41021e289438e475b47751740c79d05a6c))
+- **lsp:** key project symbol aggregate on raw path ([`5e18853`](https://github.com/jolars/panache/commit/5e1885318c7502d7bf531126f9207a0829499776))
+- **formatter:** keep display math inline in table cells ([`32f45b3`](https://github.com/jolars/panache/commit/32f45b34e4c9ff28d313a8b359b8805e65559713)), closes [#449](https://github.com/jolars/panache/issues/449)
+- **linter:** scope cross-doc label duplicates per render target ([`20c7335`](https://github.com/jolars/panache/commit/20c733528c8ef64805ff895450a9fe8db21f8e84))
+- **parser:** suppress bare `@key` after emphasis closer ([`d6a3f87`](https://github.com/jolars/panache/commit/d6a3f8702e926769452bdd340616b3ed7f78bd15))
+- **parser:** lift bq-nested def later-line HTML block ([`d4549fd`](https://github.com/jolars/panache/commit/d4549fd3ae66f52723df30e3a5772b97fd2f6cbb))
+- **parser:** don't retag `HTML_BLOCK_DIV` in bq content body ([`34d9a4a`](https://github.com/jolars/panache/commit/34d9a4aa75ccfdcc2a31328c6e28f69b7fe2a344))
+- **parser:** don't close top-level div on indented fence ([`3a603e1`](https://github.com/jolars/panache/commit/3a603e1870c48d7305cf279faaaa49e7edc27bb3))
+- **linter:** resolve cross-file refs via project aggregate ([`164e9aa`](https://github.com/jolars/panache/commit/164e9aaf3a91047cce8bf63c1f3aa2033ea879e0))
+- **cli:** report include-partial diagnostics once ([`f516fac`](https://github.com/jolars/panache/commit/f516facf9e1baa5e87c143448661050bc933e502))
+- **linter:** stop flagging inline references as duplicates ([`7a0f202`](https://github.com/jolars/panache/commit/7a0f2020f76261a0a0c4909258b9e1741c2c0dff))
+- **parser:** don't cite bare `@key` after a word char ([`291efec`](https://github.com/jolars/panache/commit/291efec5d4d3a6f571e7e69f36181dd9ba3319aa))
+
+### Performance Improvements
+- **cli:** compute project graph once per project ([`b8784bf`](https://github.com/jolars/panache/commit/b8784bf278e401d36cbeef20e66a1cf47b0062d1))
+- **linter:** reuse memoized symbol index across lint rules ([`30c7000`](https://github.com/jolars/panache/commit/30c70008fd2403be661041f26cdca97040e1dffc))
+- **lsp:** memoize `heading_outline` per top-level block ([`a3f135a`](https://github.com/jolars/panache/commit/a3f135a0b389a791abb0eb51b730586fb5ad4bf9))
+- **lsp:** memoize `symbol_usage_index` per top-level block ([`ba748e2`](https://github.com/jolars/panache/commit/ba748e248023797f21a5b10a1d7c7d471f7e7e57))
+- **lsp:** make VFS reads near-lock-free via copy-on-write ([`a1cadb8`](https://github.com/jolars/panache/commit/a1cadb85c3667062cd1a4978a1202f1f19894848))
+- **lsp:** cache a salsa `LineIndex` for position conversion ([`d1e4b27`](https://github.com/jolars/panache/commit/d1e4b27064142a559c983bd4ac6a824536b71bd1))
+
+### Dependencies
+- updated crates/panache-formatter to v0.20.3
+- updated crates/panache-parser to v0.23.0
+
 ## [3.0.2](https://github.com/jolars/panache/compare/v3.0.1...v3.0.2) (2026-07-28)
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,9 +24,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -189,9 +189,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -366,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "defmt"
@@ -814,9 +814,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8a7b8211e695a1d0cd91cace480d4d0bd57667ab10277cc412c5f7f4884f83"
+checksum = "0b17771570a2b94107741a7b033f19132c2eee21d59d21b24d2ced26500bd66e"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -930,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.49.2"
+version = "0.49.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a77951c56b6a0af03c22af6953d6ffcfba9403c765578921f3f1089b999db6"
+checksum = "508004a5500f2e1f68af048f70feea2de86d35ab115d85716530860822aef397"
 dependencies = [
  "ahash",
  "bytecount",
@@ -959,18 +959,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.49.2"
+version = "0.49.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c2e64f341a1d6a15d2daa3c967e48921cf15b9c7f23a9899e8b63c7f7c4199"
+checksum = "5a8b30cafa78358ae6cd1494a7d6410b89530e28bf567f862c869c667e900d9f"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.49.2"
+version = "0.49.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e097778f3e9c6a33862077dbf07aca0360d0b18d2a7abc323da132df49ee83"
+checksum = "5526bd381d230af94908d07e6835a33fd82a465e12f5f1e9c81f5c2aa23b3c21"
 dependencies = [
  "ahash",
  "bytecount",
@@ -994,9 +994,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "libc",
 ]
@@ -1205,7 +1205,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "panache"
-version = "3.0.2"
+version = "3.1.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "insta",
  "log",
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "entities",
  "insta",
@@ -1516,9 +1516,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.49.2"
+version = "0.49.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b772e96f8eb6badd4eb10fbc08b8a98244c09b4af37e72e8fa612c854604b870"
+checksum = "7af3eb523cce0df0af3c30d624b829b2dabd233172b5bc2615fcd03ceae8f746"
 dependencies = [
  "ahash",
  "fluent-uri 0.4.1",
@@ -1611,9 +1611,9 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "salsa"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14fdadbf856222e731756d7fdbdf193a7abf8fdab009bb45f48671a42719a84"
+checksum = "cf0e374215cd2db2b5c75d7b3a99cb0cc052c0595335dfdefc03d4eb08f4aa81"
 dependencies = [
  "boxcar",
  "crossbeam-queue",
@@ -1637,19 +1637,19 @@ dependencies = [
 
 [[package]]
 name = "salsa-macro-rules"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d7dc08ba69b9aedfa61dfc4d65548ae42c0d8b90bbd62cd121776920841bcf"
+checksum = "85f4b7d4405540bbd6d4ffa52d4322d983f3781954d3073067ac1bdb028459b3"
 
 [[package]]
 name = "salsa-macros"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec5c48c5a4a53a6e2be9762f56566f1325d4394c011c00b3ea86ba2d13411e71"
+checksum = "445be2bfbb2f67cb663225ecd7bc5a25370c0250fca30f9d8cbad9a913650370"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "3.0.2"
+version = "3.1.0"
 edition.workspace = true
 # `distill_quarto_schema` is a dev-only vendoring bin (src/bin/); keep bare
 # `cargo run` resolving to the CLI for tooling like the pre-commit format hook.
@@ -52,8 +52,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.20.2" }
-panache-parser = { path = "crates/panache-parser", version = "0.22.2", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.20.3" }
+panache-parser = { path = "crates/panache-parser", version = "0.23.0", features = [
     "serde",
     "schema",
 ] }

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.20.3](https://github.com/jolars/panache/compare/panache-formatter-v0.20.2...panache-formatter-v0.20.3) (2026-08-03)
+
+### Bug Fixes
+- **formatter:** preserve inline code-span whitespace ([`eea7b2e`](https://github.com/jolars/panache/commit/eea7b2ecfdff0fe0c178a757ff0cf0dab2819495))
+- **formatter:** keep blockquote definitions prefixed ([`1110029`](https://github.com/jolars/panache/commit/1110029153ecb21f90bc14a51350e9b9809948cf))
+- **formatter:** tidy bare-marker definition body ([`0ca8a0c`](https://github.com/jolars/panache/commit/0ca8a0ca12c0b17a38a05704a64e6e85eb5dcf9f))
+- **formatter:** keep display math inline in table cells ([`32f45b3`](https://github.com/jolars/panache/commit/32f45b34e4c9ff28d313a8b359b8805e65559713)), closes [#449](https://github.com/jolars/panache/issues/449)
+
+### Dependencies
+- updated crates/panache-parser to v0.23.0
+
 ## [0.20.2](https://github.com/jolars/panache/compare/panache-formatter-v0.20.1...panache-formatter-v0.20.2) (2026-07-28)
 
 ### Bug Fixes

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.20.2"
+version = "0.20.3"
 edition.workspace = true
 include = [
     "/src/**/*",
@@ -18,7 +18,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.22.2" }
+panache-parser = { path = "../panache-parser", version = "0.23.0" }
 log = { version = "0.4.31", features = ["release_max_level_debug"] }
 rowan = "0.16.1"
 serde = { version = "1.0.228", features = ["derive"], optional = true }

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.23.0](https://github.com/jolars/panache/compare/panache-parser-v0.22.2...panache-parser-v0.23.0) (2026-08-03)
+
+### Features
+- **parser:** recognize bare `:` definition marker ([`cfa9eec`](https://github.com/jolars/panache/commit/cfa9eec19c010a810e906424040736067d036192))
+- **linter:** add `unspaced-citation` rule ([`b36baed`](https://github.com/jolars/panache/commit/b36baedc4902c55f7bbfce151a3e0dcfde422c0e)), closes [#448](https://github.com/jolars/panache/issues/448)
+- **parser:** reject undeclared YAML alias ([`4dbdfe6`](https://github.com/jolars/panache/commit/4dbdfe6e6aa2f3f298221c2f4e3f19772608cf33))
+- **parser:** lift unclosed `<div>` as list-item body ([`4801192`](https://github.com/jolars/panache/commit/48011921ad9ec24041a9f647f7ecfaa086e4b8d4))
+- **parser:** lift unclosed `<div>` on later content-body line ([`151515d`](https://github.com/jolars/panache/commit/151515da464940007eb32a66055b3340ad9319a4))
+
+### Bug Fixes
+- **parser:** require a term before a definition marker ([`cc8a4fc`](https://github.com/jolars/panache/commit/cc8a4fc4b71eab6cd11a5760d66102ef6a6579cf))
+- **parser:** keep def-list para open across `>` line ([`cbb55c4`](https://github.com/jolars/panache/commit/cbb55c41021e289438e475b47751740c79d05a6c))
+- **parser:** suppress bare `@key` after emphasis closer ([`d6a3f87`](https://github.com/jolars/panache/commit/d6a3f8702e926769452bdd340616b3ed7f78bd15))
+- **parser:** don't cite bare `@key` after a word char ([`291efec`](https://github.com/jolars/panache/commit/291efec5d4d3a6f571e7e69f36181dd9ba3319aa))
+- **parser:** lift bq-nested def later-line HTML block ([`d4549fd`](https://github.com/jolars/panache/commit/d4549fd3ae66f52723df30e3a5772b97fd2f6cbb))
+- **parser:** don't retag `HTML_BLOCK_DIV` in bq content body ([`34d9a4a`](https://github.com/jolars/panache/commit/34d9a4aa75ccfdcc2a31328c6e28f69b7fe2a344))
+- **parser:** don't close top-level div on indented fence ([`3a603e1`](https://github.com/jolars/panache/commit/3a603e1870c48d7305cf279faaaa49e7edc27bb3))
+
 ## [0.22.2](https://github.com/jolars/panache/compare/panache-parser-v0.22.1...panache-parser-v0.22.2) (2026-07-28)
 
 ### Bug Fixes

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.22.2"
+version = "0.23.0"
 edition.workspace = true
 readme = "README.md"
 include = [

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.1.0](https://github.com/jolars/panache/compare/panache-code-v3.0.2...panache-code-v3.1.0) (2026-08-03)
+
+### Dependencies
+- updated panache to v3.1.0
+
 ## [3.0.2](https://github.com/jolars/panache/compare/panache-code-v3.0.1...panache-code-v3.0.2) (2026-07-28)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         panache = pkgs.rustPlatform.buildRustPackage {
           pname = "panache";
-          version = "3.0.2";
+          version = "3.1.0";
 
           src = ./.;
 

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "3.0.2",
-    "@panache-cli/linux-arm64-gnu": "3.0.2",
-    "@panache-cli/linux-x64-musl": "3.0.2",
-    "@panache-cli/linux-arm64-musl": "3.0.2",
-    "@panache-cli/darwin-x64": "3.0.2",
-    "@panache-cli/darwin-arm64": "3.0.2",
-    "@panache-cli/win32-x64": "3.0.2",
-    "@panache-cli/win32-arm64": "3.0.2"
+    "@panache-cli/linux-x64-gnu": "3.1.0",
+    "@panache-cli/linux-arm64-gnu": "3.1.0",
+    "@panache-cli/linux-x64-musl": "3.1.0",
+    "@panache-cli/linux-arm64-musl": "3.1.0",
+    "@panache-cli/darwin-x64": "3.1.0",
+    "@panache-cli/darwin-arm64": "3.1.0",
+    "@panache-cli/win32-x64": "3.1.0",
+    "@panache-cli/win32-arm64": "3.1.0"
   }
 }


### PR DESCRIPTION
## [panache: 3.1.0](https://github.com/jolars/panache/compare/v3.0.2...v3.1.0) (2026-08-03)

### Features
- **parser:** recognize bare `:` definition marker ([`cfa9eec`](https://github.com/jolars/panache/commit/cfa9eec19c010a810e906424040736067d036192))
- **lsp:** pull settings via workspace/configuration ([`a40ed7f`](https://github.com/jolars/panache/commit/a40ed7fba0604967be92ae1a1f36bcb71f96e956))
- **linter:** add `unspaced-citation` rule ([`b36baed`](https://github.com/jolars/panache/commit/b36baedc4902c55f7bbfce151a3e0dcfde422c0e)), closes [#448](https://github.com/jolars/panache/issues/448)
- **linter:** warn on duplicate and unused YAML anchors ([`d234921`](https://github.com/jolars/panache/commit/d2349212289ef8129798e59e2dc710a3d75cb245)), closes [#385](https://github.com/jolars/panache/issues/385)
- **parser:** reject undeclared YAML alias ([`4dbdfe6`](https://github.com/jolars/panache/commit/4dbdfe6e6aa2f3f298221c2f4e3f19772608cf33))
- **parser:** lift unclosed `<div>` as list-item body ([`4801192`](https://github.com/jolars/panache/commit/48011921ad9ec24041a9f647f7ecfaa086e4b8d4))
- **parser:** lift unclosed `<div>` on later content-body line ([`151515d`](https://github.com/jolars/panache/commit/151515da464940007eb32a66055b3340ad9319a4))

### Bug Fixes
- **formatter:** preserve inline code-span whitespace ([`eea7b2e`](https://github.com/jolars/panache/commit/eea7b2ecfdff0fe0c178a757ff0cf0dab2819495))
- **formatter:** keep blockquote definitions prefixed ([`1110029`](https://github.com/jolars/panache/commit/1110029153ecb21f90bc14a51350e9b9809948cf))
- **parser:** require a term before a definition marker ([`cc8a4fc`](https://github.com/jolars/panache/commit/cc8a4fc4b71eab6cd11a5760d66102ef6a6579cf))
- **formatter:** tidy bare-marker definition body ([`0ca8a0c`](https://github.com/jolars/panache/commit/0ca8a0ca12c0b17a38a05704a64e6e85eb5dcf9f))
- **parser:** keep def-list para open across `>` line ([`cbb55c4`](https://github.com/jolars/panache/commit/cbb55c41021e289438e475b47751740c79d05a6c))
- **lsp:** key project symbol aggregate on raw path ([`5e18853`](https://github.com/jolars/panache/commit/5e1885318c7502d7bf531126f9207a0829499776))
- **formatter:** keep display math inline in table cells ([`32f45b3`](https://github.com/jolars/panache/commit/32f45b34e4c9ff28d313a8b359b8805e65559713)), closes [#449](https://github.com/jolars/panache/issues/449)
- **linter:** scope cross-doc label duplicates per render target ([`20c7335`](https://github.com/jolars/panache/commit/20c733528c8ef64805ff895450a9fe8db21f8e84))
- **parser:** suppress bare `@key` after emphasis closer ([`d6a3f87`](https://github.com/jolars/panache/commit/d6a3f8702e926769452bdd340616b3ed7f78bd15))
- **parser:** lift bq-nested def later-line HTML block ([`d4549fd`](https://github.com/jolars/panache/commit/d4549fd3ae66f52723df30e3a5772b97fd2f6cbb))
- **parser:** don't retag `HTML_BLOCK_DIV` in bq content body ([`34d9a4a`](https://github.com/jolars/panache/commit/34d9a4aa75ccfdcc2a31328c6e28f69b7fe2a344))
- **parser:** don't close top-level div on indented fence ([`3a603e1`](https://github.com/jolars/panache/commit/3a603e1870c48d7305cf279faaaa49e7edc27bb3))
- **linter:** resolve cross-file refs via project aggregate ([`164e9aa`](https://github.com/jolars/panache/commit/164e9aaf3a91047cce8bf63c1f3aa2033ea879e0))
- **cli:** report include-partial diagnostics once ([`f516fac`](https://github.com/jolars/panache/commit/f516facf9e1baa5e87c143448661050bc933e502))
- **linter:** stop flagging inline references as duplicates ([`7a0f202`](https://github.com/jolars/panache/commit/7a0f2020f76261a0a0c4909258b9e1741c2c0dff))
- **parser:** don't cite bare `@key` after a word char ([`291efec`](https://github.com/jolars/panache/commit/291efec5d4d3a6f571e7e69f36181dd9ba3319aa))

### Performance Improvements
- **cli:** compute project graph once per project ([`b8784bf`](https://github.com/jolars/panache/commit/b8784bf278e401d36cbeef20e66a1cf47b0062d1))
- **linter:** reuse memoized symbol index across lint rules ([`30c7000`](https://github.com/jolars/panache/commit/30c70008fd2403be661041f26cdca97040e1dffc))
- **lsp:** memoize `heading_outline` per top-level block ([`a3f135a`](https://github.com/jolars/panache/commit/a3f135a0b389a791abb0eb51b730586fb5ad4bf9))
- **lsp:** memoize `symbol_usage_index` per top-level block ([`ba748e2`](https://github.com/jolars/panache/commit/ba748e248023797f21a5b10a1d7c7d471f7e7e57))
- **lsp:** make VFS reads near-lock-free via copy-on-write ([`a1cadb8`](https://github.com/jolars/panache/commit/a1cadb85c3667062cd1a4978a1202f1f19894848))
- **lsp:** cache a salsa `LineIndex` for position conversion ([`d1e4b27`](https://github.com/jolars/panache/commit/d1e4b27064142a559c983bd4ac6a824536b71bd1))

### Dependencies
- updated crates/panache-formatter to v0.20.3
- updated crates/panache-parser to v0.23.0

## [crates/panache-formatter: 0.20.3](https://github.com/jolars/panache/compare/panache-formatter-v0.20.2...panache-formatter-v0.20.3) (2026-08-03)

### Bug Fixes
- **formatter:** preserve inline code-span whitespace ([`eea7b2e`](https://github.com/jolars/panache/commit/eea7b2ecfdff0fe0c178a757ff0cf0dab2819495))
- **formatter:** keep blockquote definitions prefixed ([`1110029`](https://github.com/jolars/panache/commit/1110029153ecb21f90bc14a51350e9b9809948cf))
- **formatter:** tidy bare-marker definition body ([`0ca8a0c`](https://github.com/jolars/panache/commit/0ca8a0ca12c0b17a38a05704a64e6e85eb5dcf9f))
- **formatter:** keep display math inline in table cells ([`32f45b3`](https://github.com/jolars/panache/commit/32f45b34e4c9ff28d313a8b359b8805e65559713)), closes [#449](https://github.com/jolars/panache/issues/449)

### Dependencies
- updated crates/panache-parser to v0.23.0

## [crates/panache-parser: 0.23.0](https://github.com/jolars/panache/compare/panache-parser-v0.22.2...panache-parser-v0.23.0) (2026-08-03)

### Features
- **parser:** recognize bare `:` definition marker ([`cfa9eec`](https://github.com/jolars/panache/commit/cfa9eec19c010a810e906424040736067d036192))
- **linter:** add `unspaced-citation` rule ([`b36baed`](https://github.com/jolars/panache/commit/b36baedc4902c55f7bbfce151a3e0dcfde422c0e)), closes [#448](https://github.com/jolars/panache/issues/448)
- **parser:** reject undeclared YAML alias ([`4dbdfe6`](https://github.com/jolars/panache/commit/4dbdfe6e6aa2f3f298221c2f4e3f19772608cf33))
- **parser:** lift unclosed `<div>` as list-item body ([`4801192`](https://github.com/jolars/panache/commit/48011921ad9ec24041a9f647f7ecfaa086e4b8d4))
- **parser:** lift unclosed `<div>` on later content-body line ([`151515d`](https://github.com/jolars/panache/commit/151515da464940007eb32a66055b3340ad9319a4))

### Bug Fixes
- **parser:** require a term before a definition marker ([`cc8a4fc`](https://github.com/jolars/panache/commit/cc8a4fc4b71eab6cd11a5760d66102ef6a6579cf))
- **parser:** keep def-list para open across `>` line ([`cbb55c4`](https://github.com/jolars/panache/commit/cbb55c41021e289438e475b47751740c79d05a6c))
- **parser:** suppress bare `@key` after emphasis closer ([`d6a3f87`](https://github.com/jolars/panache/commit/d6a3f8702e926769452bdd340616b3ed7f78bd15))
- **parser:** don't cite bare `@key` after a word char ([`291efec`](https://github.com/jolars/panache/commit/291efec5d4d3a6f571e7e69f36181dd9ba3319aa))
- **parser:** lift bq-nested def later-line HTML block ([`d4549fd`](https://github.com/jolars/panache/commit/d4549fd3ae66f52723df30e3a5772b97fd2f6cbb))
- **parser:** don't retag `HTML_BLOCK_DIV` in bq content body ([`34d9a4a`](https://github.com/jolars/panache/commit/34d9a4aa75ccfdcc2a31328c6e28f69b7fe2a344))
- **parser:** don't close top-level div on indented fence ([`3a603e1`](https://github.com/jolars/panache/commit/3a603e1870c48d7305cf279faaaa49e7edc27bb3))

## [editors/code: 3.1.0](https://github.com/jolars/panache/compare/panache-code-v3.0.2...panache-code-v3.1.0) (2026-08-03)

### Dependencies
- updated panache to v3.1.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).