### PR TITLE
chore(release): v3.3.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "8562ead020e906550cd004e4eb9b0cf4d19c011e",
+  "baseline-sha": "6ec04f57851382e2c0c356a6dbac3c3598e8529d",
   "release-targets": [
     {
       "path": ".",
-      "version": "3.2.0",
-      "tag": "v3.2.0"
+      "version": "3.3.0",
+      "tag": "v3.3.0"
     },
     {
       "path": "crates/panache-dprint",
@@ -14,18 +14,18 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.20.4",
-      "tag": "panache-formatter-v0.20.4"
+      "version": "0.20.5",
+      "tag": "panache-formatter-v0.20.5"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.24.0",
-      "tag": "panache-parser-v0.24.0"
+      "version": "0.25.0",
+      "tag": "panache-parser-v0.25.0"
     },
     {
       "path": "editors/code",
-      "version": "3.2.0",
-      "tag": "panache-code-v3.2.0"
+      "version": "3.3.0",
+      "tag": "panache-code-v3.3.0"
     },
     {
       "path": "editors/zed",
@@ -36,23 +36,23 @@
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "3.2.0",
-      "tag": "v3.2.0"
+      "version": "3.3.0",
+      "tag": "v3.3.0"
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.20.4",
-      "tag": "panache-formatter-v0.20.4"
+      "version": "0.20.5",
+      "tag": "panache-formatter-v0.20.5"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.24.0",
-      "tag": "panache-parser-v0.24.0"
+      "version": "0.25.0",
+      "tag": "panache-parser-v0.25.0"
     },
     {
       "path": "editors/code",
-      "version": "3.2.0",
-      "tag": "panache-code-v3.2.0"
+      "version": "3.3.0",
+      "tag": "panache-code-v3.3.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## [3.3.0](https://github.com/jolars/panache/compare/v3.2.0...v3.3.0) (2026-08-07)
+
+### Features
+- **linter:** add `reversed-footnote-marker` rule ([`1487eca`](https://github.com/jolars/panache/commit/1487ecaea8ed15fd1d094f709505c059027f0e98)), closes [#460](https://github.com/jolars/panache/issues/460)
+- **linter:** add `badness` external linter for LaTeX ([`86f9059`](https://github.com/jolars/panache/commit/86f9059561b32819c58278baca50e61fd4295a17))
+- **cli:** suppress `format --check` diff under `--quiet` ([`688cd5f`](https://github.com/jolars/panache/commit/688cd5ff3a35b6d01fccbd30cc2bb2397c46a8cc))
+- **parser:** decode entities in HTML attributes ([`88103d6`](https://github.com/jolars/panache/commit/88103d64871ad4767916546c529f5f38c8f72eda))
+
+### Bug Fixes
+- **parser:** gobble a footnote body's indent ([`6ec04f5`](https://github.com/jolars/panache/commit/6ec04f57851382e2c0c356a6dbac3c3598e8529d))
+- **parser:** gobble a definition body's indent ([`f7cdf8a`](https://github.com/jolars/panache/commit/f7cdf8a21c45328c7801c2a247c9623760b47133))
+- **parser:** expand a code span's tabs by source column ([`33a5e4a`](https://github.com/jolars/panache/commit/33a5e4a8d02d722e150c055f2454c81382a3fcd0))
+- **parser:** gobble a list item's continuation indent ([`42429b0`](https://github.com/jolars/panache/commit/42429b0bb70df7b721b52496fd8bde50790f881b))
+- **linter:** make `missing-bibliography-key` more precise ([`362d183`](https://github.com/jolars/panache/commit/362d18317e6a10129b35df7733595519106a0401))
+- **parser:** keep an over-indented fence lazy ([`00f5f44`](https://github.com/jolars/panache/commit/00f5f441fb7a104e77b64602863e652c8c2e2e73))
+- strip a fenced block's own indent from its payload ([`290e3ab`](https://github.com/jolars/panache/commit/290e3abb1f04dbad29451c3abe70aa6a6f8738e0))
+- **formatter:** drop a quoted fence's container indent ([`a7d4d4c`](https://github.com/jolars/panache/commit/a7d4d4c490d1d79a7772134a0ea3273855daaef6))
+- **parser:** open a lazy fence in a quoted list item ([`ee3167c`](https://github.com/jolars/panache/commit/ee3167ceb37acc3631acc9d723ef45f3482ed740))
+- **parser:** strip container prefix from code payloads ([`e31f0b9`](https://github.com/jolars/panache/commit/e31f0b9489619d24783ddb4642d7c6f79bafe084))
+- **parser:** loosen a list on a para-breaking block ([`fc14e4f`](https://github.com/jolars/panache/commit/fc14e4f826da2d5d22a582f7f66c484e7042eeaf))
+- **parser:** gobble every lazy line in a blockquote ([`354eafe`](https://github.com/jolars/panache/commit/354eafe33086cc0a101e89b085b5760cb999767c))
+- **parser:** open a line block on a list-marker line ([`5f55d89`](https://github.com/jolars/panache/commit/5f55d89ab91d29ebfa41a9facf6fb469ed05e1ed))
+- **parser:** fold an indented line-block marker ([`e564273`](https://github.com/jolars/panache/commit/e56427397b26ff6d67def2fca15d7b6629b278c6))
+- **parser:** gate the setext-after-setext escape ([`729098f`](https://github.com/jolars/panache/commit/729098f4c0a2055560e4a0df39ac2a4f6dbcd098))
+- **parser:** fold a lazy line into its blockquote ([`03d1339`](https://github.com/jolars/panache/commit/03d13398d0ead663bad983b7e02ef6e8e6d38575))
+- **parser:** fold a lazy line into its line block ([`7d732b9`](https://github.com/jolars/panache/commit/7d732b91ab4cecb48d6868edb73d78c0b7b6bf5c))
+- **formatter:** keep a line block inside its blockquote ([`8bdf53c`](https://github.com/jolars/panache/commit/8bdf53cbed1f296c3e978cbfeb87903facb5b560))
+- **formatter:** indent a line block inside a list item ([`35db18a`](https://github.com/jolars/panache/commit/35db18a5e8e2d135355355524057b2cd0e2ed1cc))
+- **parser:** keep a quoted definition list intact ([`b361fe0`](https://github.com/jolars/panache/commit/b361fe04a4377ea0c1f5861e687d735e8b3aa82e))
+- **parser:** accept a pipe table with no body rows ([`070f20a`](https://github.com/jolars/panache/commit/070f20a5981bcea6689ac7d02a3f37533d70f717))
+- **parser:** cap blockquote depth by registry rank ([`fcc0f9f`](https://github.com/jolars/panache/commit/fcc0f9f4ca87d8b277654eb0f3c30f2109aee9e4))
+- **parser:** apply the setext same-container rule to pandoc ([`489510e`](https://github.com/jolars/panache/commit/489510e4059922aa234e04df20a3beee1af5ad30))
+- **parser:** count underline markers on the raw line ([`7f9e9c3`](https://github.com/jolars/panache/commit/7f9e9c3a91b25af5b3e04d342aeb1e0e4bfafca1))
+- **parser:** let the registry's verdict outrank `>` count ([`5d97a32`](https://github.com/jolars/panache/commit/5d97a32b2fc4f1d2e172fded2e0ee1dfa3d9a8a0))
+- **parser:** keep div opener whitespace before label ([`864cc90`](https://github.com/jolars/panache/commit/864cc903e6625b48e93f5e8e693596b3540dfa3f))
+- **parser:** stop dropping surplus display-math dollars ([`33b6404`](https://github.com/jolars/panache/commit/33b64047b5e39f53f46602942234c61e36d95ec3))
+- **parser:** keep `:::` openers from interrupting list items ([`37d95e1`](https://github.com/jolars/panache/commit/37d95e1106bcde0f6e20588f167bec6268f7128f))
+- **parser:** match line-block peek to emitted prefix ([`f7d50ee`](https://github.com/jolars/panache/commit/f7d50eeb7b2889072e2b0fa2a5e793457353c768))
+- **parser:** emit blockquote setext from stripped lines ([`985aba2`](https://github.com/jolars/panache/commit/985aba26f812dbb2a75a4d1129a1a5ca13b2d79b))
+- **parser:** let setext claim a quoted line at top level ([`c60043c`](https://github.com/jolars/panache/commit/c60043cb290958c9d7c7a2bd0dd6a2826f4cb024))
+- **parser:** keep refdefs from interrupting list items ([`6f36287`](https://github.com/jolars/panache/commit/6f3628743614dfdbbb078e2161284c21c18ca469))
+
+### Dependencies
+- updated crates/panache-formatter to v0.20.5
+- updated crates/panache-parser to v0.25.0
+
 ## [3.2.0](https://github.com/jolars/panache/compare/v3.1.0...v3.2.0) (2026-08-05)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,9 +189,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -199,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -211,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.8"
+version = "4.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f84a88507dbd05c695f2cb5e8558e747179134005e9893882dec964190ed89"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
 dependencies = [
  "clap",
 ]
@@ -238,9 +238,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clap_mangen"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82842b45bf9f6a3be090dd860095ac30728042c08e0d6261ca7259b5d850f07"
+checksum = "c630ddc90572b3d9abd3f887f0007b4e048faf5c5a59ae607f8ac1c5e3790873"
 dependencies = [
  "clap",
  "roff",
@@ -927,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.49.5"
+version = "0.49.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da60094fc1968bbd091e2cfa004415cb7b19e25e592376e66a64aa832bb6039"
+checksum = "7e17384278234b10419a63c93fc85695ac9fc2da0833e3c59167f9986499590c"
 dependencies = [
  "ahash",
  "bytecount",
@@ -956,18 +956,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.49.5"
+version = "0.49.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36539f34ef9e5da418433fbbf7294522d8f930ecf6a540ccd1ec6481c9ff9056"
+checksum = "ac634e339e73bf9629f6fb207f7b064d872253ae3b3f5c6e0ce8fd762b16e40f"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.49.5"
+version = "0.49.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bc513dfee68c6fe29498451df95a32951ea227801b476f4a1f236433986c891"
+checksum = "92b8e258eb4515a3fc912a9c46e3987040dc07280592280097ea2085527870b8"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1202,7 +1202,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "panache"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.20.4"
+version = "0.20.5"
 dependencies = [
  "insta",
  "log",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "entities",
  "insta",
@@ -1513,9 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.49.5"
+version = "0.49.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05915176d843da9ec5c925e5e2631be9aa61b27430acfdd562e79cae8f559725"
+checksum = "42902112f88a27e9afd5683e2ba31956fed2a5d43395f166dd26775ae9c0dedb"
 dependencies = [
  "ahash",
  "fluent-uri 0.4.1",
@@ -2291,18 +2291,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "3.2.0"
+version = "3.3.0"
 edition.workspace = true
 # `distill_quarto_schema` is a dev-only vendoring bin (src/bin/); keep bare
 # `cargo run` resolving to the CLI for tooling like the pre-commit format hook.
@@ -52,8 +52,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.20.4" }
-panache-parser = { path = "crates/panache-parser", version = "0.24.0", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.20.5" }
+panache-parser = { path = "crates/panache-parser", version = "0.25.0", features = [
     "serde",
     "schema",
 ] }

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.20.5](https://github.com/jolars/panache/compare/panache-formatter-v0.20.4...panache-formatter-v0.20.5) (2026-08-07)
+
+### Bug Fixes
+- strip a fenced block's own indent from its payload ([`290e3ab`](https://github.com/jolars/panache/commit/290e3abb1f04dbad29451c3abe70aa6a6f8738e0))
+- **formatter:** drop a quoted fence's container indent ([`a7d4d4c`](https://github.com/jolars/panache/commit/a7d4d4c490d1d79a7772134a0ea3273855daaef6))
+- **parser:** open a line block on a list-marker line ([`5f55d89`](https://github.com/jolars/panache/commit/5f55d89ab91d29ebfa41a9facf6fb469ed05e1ed))
+- **parser:** fold a lazy line into its line block ([`7d732b9`](https://github.com/jolars/panache/commit/7d732b91ab4cecb48d6868edb73d78c0b7b6bf5c))
+- **formatter:** keep a line block inside its blockquote ([`8bdf53c`](https://github.com/jolars/panache/commit/8bdf53cbed1f296c3e978cbfeb87903facb5b560))
+- **formatter:** indent a line block inside a list item ([`35db18a`](https://github.com/jolars/panache/commit/35db18a5e8e2d135355355524057b2cd0e2ed1cc))
+
+### Dependencies
+- updated crates/panache-parser to v0.25.0
+
 ## [0.20.4](https://github.com/jolars/panache/compare/panache-formatter-v0.20.3...panache-formatter-v0.20.4) (2026-08-05)
 
 ### Bug Fixes

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.20.4"
+version = "0.20.5"
 edition.workspace = true
 include = [
     "/src/**/*",
@@ -18,7 +18,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.24.0" }
+panache-parser = { path = "../panache-parser", version = "0.25.0" }
 log = { version = "0.4.31", features = ["release_max_level_debug"] }
 rowan = "0.17.0"
 serde = { version = "1.0.228", features = ["derive"], optional = true }

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## [0.25.0](https://github.com/jolars/panache/compare/panache-parser-v0.24.0...panache-parser-v0.25.0) (2026-08-07)
+
+### Features
+- **parser:** decode entities in HTML attributes ([`88103d6`](https://github.com/jolars/panache/commit/88103d64871ad4767916546c529f5f38c8f72eda))
+
+### Bug Fixes
+- **parser:** gobble a footnote body's indent ([`6ec04f5`](https://github.com/jolars/panache/commit/6ec04f57851382e2c0c356a6dbac3c3598e8529d))
+- **parser:** gobble a definition body's indent ([`f7cdf8a`](https://github.com/jolars/panache/commit/f7cdf8a21c45328c7801c2a247c9623760b47133))
+- **parser:** expand a code span's tabs by source column ([`33a5e4a`](https://github.com/jolars/panache/commit/33a5e4a8d02d722e150c055f2454c81382a3fcd0))
+- **parser:** gobble a list item's continuation indent ([`42429b0`](https://github.com/jolars/panache/commit/42429b0bb70df7b721b52496fd8bde50790f881b))
+- **linter:** make `missing-bibliography-key` more precise ([`362d183`](https://github.com/jolars/panache/commit/362d18317e6a10129b35df7733595519106a0401))
+- **parser:** keep an over-indented fence lazy ([`00f5f44`](https://github.com/jolars/panache/commit/00f5f441fb7a104e77b64602863e652c8c2e2e73))
+- strip a fenced block's own indent from its payload ([`290e3ab`](https://github.com/jolars/panache/commit/290e3abb1f04dbad29451c3abe70aa6a6f8738e0))
+- **parser:** open a lazy fence in a quoted list item ([`ee3167c`](https://github.com/jolars/panache/commit/ee3167ceb37acc3631acc9d723ef45f3482ed740))
+- **parser:** strip container prefix from code payloads ([`e31f0b9`](https://github.com/jolars/panache/commit/e31f0b9489619d24783ddb4642d7c6f79bafe084))
+- **parser:** loosen a list on a para-breaking block ([`fc14e4f`](https://github.com/jolars/panache/commit/fc14e4f826da2d5d22a582f7f66c484e7042eeaf))
+- **parser:** gobble every lazy line in a blockquote ([`354eafe`](https://github.com/jolars/panache/commit/354eafe33086cc0a101e89b085b5760cb999767c))
+- **parser:** open a line block on a list-marker line ([`5f55d89`](https://github.com/jolars/panache/commit/5f55d89ab91d29ebfa41a9facf6fb469ed05e1ed))
+- **parser:** fold an indented line-block marker ([`e564273`](https://github.com/jolars/panache/commit/e56427397b26ff6d67def2fca15d7b6629b278c6))
+- **parser:** gate the setext-after-setext escape ([`729098f`](https://github.com/jolars/panache/commit/729098f4c0a2055560e4a0df39ac2a4f6dbcd098))
+- **parser:** fold a lazy line into its blockquote ([`03d1339`](https://github.com/jolars/panache/commit/03d13398d0ead663bad983b7e02ef6e8e6d38575))
+- **parser:** fold a lazy line into its line block ([`7d732b9`](https://github.com/jolars/panache/commit/7d732b91ab4cecb48d6868edb73d78c0b7b6bf5c))
+- **parser:** keep a quoted definition list intact ([`b361fe0`](https://github.com/jolars/panache/commit/b361fe04a4377ea0c1f5861e687d735e8b3aa82e))
+- **parser:** accept a pipe table with no body rows ([`070f20a`](https://github.com/jolars/panache/commit/070f20a5981bcea6689ac7d02a3f37533d70f717))
+- **parser:** cap blockquote depth by registry rank ([`fcc0f9f`](https://github.com/jolars/panache/commit/fcc0f9f4ca87d8b277654eb0f3c30f2109aee9e4))
+- **parser:** apply the setext same-container rule to pandoc ([`489510e`](https://github.com/jolars/panache/commit/489510e4059922aa234e04df20a3beee1af5ad30))
+- **parser:** count underline markers on the raw line ([`7f9e9c3`](https://github.com/jolars/panache/commit/7f9e9c3a91b25af5b3e04d342aeb1e0e4bfafca1))
+- **parser:** let the registry's verdict outrank `>` count ([`5d97a32`](https://github.com/jolars/panache/commit/5d97a32b2fc4f1d2e172fded2e0ee1dfa3d9a8a0))
+- **parser:** keep div opener whitespace before label ([`864cc90`](https://github.com/jolars/panache/commit/864cc903e6625b48e93f5e8e693596b3540dfa3f))
+- **parser:** stop dropping surplus display-math dollars ([`33b6404`](https://github.com/jolars/panache/commit/33b64047b5e39f53f46602942234c61e36d95ec3))
+- **parser:** keep `:::` openers from interrupting list items ([`37d95e1`](https://github.com/jolars/panache/commit/37d95e1106bcde0f6e20588f167bec6268f7128f))
+- **parser:** match line-block peek to emitted prefix ([`f7d50ee`](https://github.com/jolars/panache/commit/f7d50eeb7b2889072e2b0fa2a5e793457353c768))
+- **parser:** emit blockquote setext from stripped lines ([`985aba2`](https://github.com/jolars/panache/commit/985aba26f812dbb2a75a4d1129a1a5ca13b2d79b))
+- **parser:** let setext claim a quoted line at top level ([`c60043c`](https://github.com/jolars/panache/commit/c60043cb290958c9d7c7a2bd0dd6a2826f4cb024))
+- **parser:** keep refdefs from interrupting list items ([`6f36287`](https://github.com/jolars/panache/commit/6f3628743614dfdbbb078e2161284c21c18ca469))
+
 ## [0.24.0](https://github.com/jolars/panache/compare/panache-parser-v0.23.0...panache-parser-v0.24.0) (2026-08-05)
 
 ### Features

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.24.0"
+version = "0.25.0"
 edition.workspace = true
 readme = "README.md"
 include = [

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.3.0](https://github.com/jolars/panache/compare/panache-code-v3.2.0...panache-code-v3.3.0) (2026-08-07)
+
+### Dependencies
+- updated panache to v3.3.0
+
 ## [3.2.0](https://github.com/jolars/panache/compare/panache-code-v3.1.0...panache-code-v3.2.0) (2026-08-05)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         panache = pkgs.rustPlatform.buildRustPackage {
           pname = "panache";
-          version = "3.2.0";
+          version = "3.3.0";
 
           src = ./.;
 

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "3.2.0",
-    "@panache-cli/linux-arm64-gnu": "3.2.0",
-    "@panache-cli/linux-x64-musl": "3.2.0",
-    "@panache-cli/linux-arm64-musl": "3.2.0",
-    "@panache-cli/darwin-x64": "3.2.0",
-    "@panache-cli/darwin-arm64": "3.2.0",
-    "@panache-cli/win32-x64": "3.2.0",
-    "@panache-cli/win32-arm64": "3.2.0"
+    "@panache-cli/linux-x64-gnu": "3.3.0",
+    "@panache-cli/linux-arm64-gnu": "3.3.0",
+    "@panache-cli/linux-x64-musl": "3.3.0",
+    "@panache-cli/linux-arm64-musl": "3.3.0",
+    "@panache-cli/darwin-x64": "3.3.0",
+    "@panache-cli/darwin-arm64": "3.3.0",
+    "@panache-cli/win32-x64": "3.3.0",
+    "@panache-cli/win32-arm64": "3.3.0"
   }
 }


### PR DESCRIPTION
## [panache: 3.3.0](https://github.com/jolars/panache/compare/v3.2.0...v3.3.0) (2026-08-07)

### Features
- **linter:** add `reversed-footnote-marker` rule ([`1487eca`](https://github.com/jolars/panache/commit/1487ecaea8ed15fd1d094f709505c059027f0e98)), closes [#460](https://github.com/jolars/panache/issues/460)
- **linter:** add `badness` external linter for LaTeX ([`86f9059`](https://github.com/jolars/panache/commit/86f9059561b32819c58278baca50e61fd4295a17))
- **cli:** suppress `format --check` diff under `--quiet` ([`688cd5f`](https://github.com/jolars/panache/commit/688cd5ff3a35b6d01fccbd30cc2bb2397c46a8cc))
- **parser:** decode entities in HTML attributes ([`88103d6`](https://github.com/jolars/panache/commit/88103d64871ad4767916546c529f5f38c8f72eda))

### Bug Fixes
- **parser:** gobble a footnote body's indent ([`6ec04f5`](https://github.com/jolars/panache/commit/6ec04f57851382e2c0c356a6dbac3c3598e8529d))
- **parser:** gobble a definition body's indent ([`f7cdf8a`](https://github.com/jolars/panache/commit/f7cdf8a21c45328c7801c2a247c9623760b47133))
- **parser:** expand a code span's tabs by source column ([`33a5e4a`](https://github.com/jolars/panache/commit/33a5e4a8d02d722e150c055f2454c81382a3fcd0))
- **parser:** gobble a list item's continuation indent ([`42429b0`](https://github.com/jolars/panache/commit/42429b0bb70df7b721b52496fd8bde50790f881b))
- **linter:** make `missing-bibliography-key` more precise ([`362d183`](https://github.com/jolars/panache/commit/362d18317e6a10129b35df7733595519106a0401))
- **parser:** keep an over-indented fence lazy ([`00f5f44`](https://github.com/jolars/panache/commit/00f5f441fb7a104e77b64602863e652c8c2e2e73))
- strip a fenced block's own indent from its payload ([`290e3ab`](https://github.com/jolars/panache/commit/290e3abb1f04dbad29451c3abe70aa6a6f8738e0))
- **formatter:** drop a quoted fence's container indent ([`a7d4d4c`](https://github.com/jolars/panache/commit/a7d4d4c490d1d79a7772134a0ea3273855daaef6))
- **parser:** open a lazy fence in a quoted list item ([`ee3167c`](https://github.com/jolars/panache/commit/ee3167ceb37acc3631acc9d723ef45f3482ed740))
- **parser:** strip container prefix from code payloads ([`e31f0b9`](https://github.com/jolars/panache/commit/e31f0b9489619d24783ddb4642d7c6f79bafe084))
- **parser:** loosen a list on a para-breaking block ([`fc14e4f`](https://github.com/jolars/panache/commit/fc14e4f826da2d5d22a582f7f66c484e7042eeaf))
- **parser:** gobble every lazy line in a blockquote ([`354eafe`](https://github.com/jolars/panache/commit/354eafe33086cc0a101e89b085b5760cb999767c))
- **parser:** open a line block on a list-marker line ([`5f55d89`](https://github.com/jolars/panache/commit/5f55d89ab91d29ebfa41a9facf6fb469ed05e1ed))
- **parser:** fold an indented line-block marker ([`e564273`](https://github.com/jolars/panache/commit/e56427397b26ff6d67def2fca15d7b6629b278c6))
- **parser:** gate the setext-after-setext escape ([`729098f`](https://github.com/jolars/panache/commit/729098f4c0a2055560e4a0df39ac2a4f6dbcd098))
- **parser:** fold a lazy line into its blockquote ([`03d1339`](https://github.com/jolars/panache/commit/03d13398d0ead663bad983b7e02ef6e8e6d38575))
- **parser:** fold a lazy line into its line block ([`7d732b9`](https://github.com/jolars/panache/commit/7d732b91ab4cecb48d6868edb73d78c0b7b6bf5c))
- **formatter:** keep a line block inside its blockquote ([`8bdf53c`](https://github.com/jolars/panache/commit/8bdf53cbed1f296c3e978cbfeb87903facb5b560))
- **formatter:** indent a line block inside a list item ([`35db18a`](https://github.com/jolars/panache/commit/35db18a5e8e2d135355355524057b2cd0e2ed1cc))
- **parser:** keep a quoted definition list intact ([`b361fe0`](https://github.com/jolars/panache/commit/b361fe04a4377ea0c1f5861e687d735e8b3aa82e))
- **parser:** accept a pipe table with no body rows ([`070f20a`](https://github.com/jolars/panache/commit/070f20a5981bcea6689ac7d02a3f37533d70f717))
- **parser:** cap blockquote depth by registry rank ([`fcc0f9f`](https://github.com/jolars/panache/commit/fcc0f9f4ca87d8b277654eb0f3c30f2109aee9e4))
- **parser:** apply the setext same-container rule to pandoc ([`489510e`](https://github.com/jolars/panache/commit/489510e4059922aa234e04df20a3beee1af5ad30))
- **parser:** count underline markers on the raw line ([`7f9e9c3`](https://github.com/jolars/panache/commit/7f9e9c3a91b25af5b3e04d342aeb1e0e4bfafca1))
- **parser:** let the registry's verdict outrank `>` count ([`5d97a32`](https://github.com/jolars/panache/commit/5d97a32b2fc4f1d2e172fded2e0ee1dfa3d9a8a0))
- **parser:** keep div opener whitespace before label ([`864cc90`](https://github.com/jolars/panache/commit/864cc903e6625b48e93f5e8e693596b3540dfa3f))
- **parser:** stop dropping surplus display-math dollars ([`33b6404`](https://github.com/jolars/panache/commit/33b64047b5e39f53f46602942234c61e36d95ec3))
- **parser:** keep `:::` openers from interrupting list items ([`37d95e1`](https://github.com/jolars/panache/commit/37d95e1106bcde0f6e20588f167bec6268f7128f))
- **parser:** match line-block peek to emitted prefix ([`f7d50ee`](https://github.com/jolars/panache/commit/f7d50eeb7b2889072e2b0fa2a5e793457353c768))
- **parser:** emit blockquote setext from stripped lines ([`985aba2`](https://github.com/jolars/panache/commit/985aba26f812dbb2a75a4d1129a1a5ca13b2d79b))
- **parser:** let setext claim a quoted line at top level ([`c60043c`](https://github.com/jolars/panache/commit/c60043cb290958c9d7c7a2bd0dd6a2826f4cb024))
- **parser:** keep refdefs from interrupting list items ([`6f36287`](https://github.com/jolars/panache/commit/6f3628743614dfdbbb078e2161284c21c18ca469))

### Dependencies
- updated crates/panache-formatter to v0.20.5
- updated crates/panache-parser to v0.25.0

## [crates/panache-formatter: 0.20.5](https://github.com/jolars/panache/compare/panache-formatter-v0.20.4...panache-formatter-v0.20.5) (2026-08-07)

### Bug Fixes
- strip a fenced block's own indent from its payload ([`290e3ab`](https://github.com/jolars/panache/commit/290e3abb1f04dbad29451c3abe70aa6a6f8738e0))
- **formatter:** drop a quoted fence's container indent ([`a7d4d4c`](https://github.com/jolars/panache/commit/a7d4d4c490d1d79a7772134a0ea3273855daaef6))
- **parser:** open a line block on a list-marker line ([`5f55d89`](https://github.com/jolars/panache/commit/5f55d89ab91d29ebfa41a9facf6fb469ed05e1ed))
- **parser:** fold a lazy line into its line block ([`7d732b9`](https://github.com/jolars/panache/commit/7d732b91ab4cecb48d6868edb73d78c0b7b6bf5c))
- **formatter:** keep a line block inside its blockquote ([`8bdf53c`](https://github.com/jolars/panache/commit/8bdf53cbed1f296c3e978cbfeb87903facb5b560))
- **formatter:** indent a line block inside a list item ([`35db18a`](https://github.com/jolars/panache/commit/35db18a5e8e2d135355355524057b2cd0e2ed1cc))

### Dependencies
- updated crates/panache-parser to v0.25.0

## [crates/panache-parser: 0.25.0](https://github.com/jolars/panache/compare/panache-parser-v0.24.0...panache-parser-v0.25.0) (2026-08-07)

### Features
- **parser:** decode entities in HTML attributes ([`88103d6`](https://github.com/jolars/panache/commit/88103d64871ad4767916546c529f5f38c8f72eda))

### Bug Fixes
- **parser:** gobble a footnote body's indent ([`6ec04f5`](https://github.com/jolars/panache/commit/6ec04f57851382e2c0c356a6dbac3c3598e8529d))
- **parser:** gobble a definition body's indent ([`f7cdf8a`](https://github.com/jolars/panache/commit/f7cdf8a21c45328c7801c2a247c9623760b47133))
- **parser:** expand a code span's tabs by source column ([`33a5e4a`](https://github.com/jolars/panache/commit/33a5e4a8d02d722e150c055f2454c81382a3fcd0))
- **parser:** gobble a list item's continuation indent ([`42429b0`](https://github.com/jolars/panache/commit/42429b0bb70df7b721b52496fd8bde50790f881b))
- **linter:** make `missing-bibliography-key` more precise ([`362d183`](https://github.com/jolars/panache/commit/362d18317e6a10129b35df7733595519106a0401))
- **parser:** keep an over-indented fence lazy ([`00f5f44`](https://github.com/jolars/panache/commit/00f5f441fb7a104e77b64602863e652c8c2e2e73))
- strip a fenced block's own indent from its payload ([`290e3ab`](https://github.com/jolars/panache/commit/290e3abb1f04dbad29451c3abe70aa6a6f8738e0))
- **parser:** open a lazy fence in a quoted list item ([`ee3167c`](https://github.com/jolars/panache/commit/ee3167ceb37acc3631acc9d723ef45f3482ed740))
- **parser:** strip container prefix from code payloads ([`e31f0b9`](https://github.com/jolars/panache/commit/e31f0b9489619d24783ddb4642d7c6f79bafe084))
- **parser:** loosen a list on a para-breaking block ([`fc14e4f`](https://github.com/jolars/panache/commit/fc14e4f826da2d5d22a582f7f66c484e7042eeaf))
- **parser:** gobble every lazy line in a blockquote ([`354eafe`](https://github.com/jolars/panache/commit/354eafe33086cc0a101e89b085b5760cb999767c))
- **parser:** open a line block on a list-marker line ([`5f55d89`](https://github.com/jolars/panache/commit/5f55d89ab91d29ebfa41a9facf6fb469ed05e1ed))
- **parser:** fold an indented line-block marker ([`e564273`](https://github.com/jolars/panache/commit/e56427397b26ff6d67def2fca15d7b6629b278c6))
- **parser:** gate the setext-after-setext escape ([`729098f`](https://github.com/jolars/panache/commit/729098f4c0a2055560e4a0df39ac2a4f6dbcd098))
- **parser:** fold a lazy line into its blockquote ([`03d1339`](https://github.com/jolars/panache/commit/03d13398d0ead663bad983b7e02ef6e8e6d38575))
- **parser:** fold a lazy line into its line block ([`7d732b9`](https://github.com/jolars/panache/commit/7d732b91ab4cecb48d6868edb73d78c0b7b6bf5c))
- **parser:** keep a quoted definition list intact ([`b361fe0`](https://github.com/jolars/panache/commit/b361fe04a4377ea0c1f5861e687d735e8b3aa82e))
- **parser:** accept a pipe table with no body rows ([`070f20a`](https://github.com/jolars/panache/commit/070f20a5981bcea6689ac7d02a3f37533d70f717))
- **parser:** cap blockquote depth by registry rank ([`fcc0f9f`](https://github.com/jolars/panache/commit/fcc0f9f4ca87d8b277654eb0f3c30f2109aee9e4))
- **parser:** apply the setext same-container rule to pandoc ([`489510e`](https://github.com/jolars/panache/commit/489510e4059922aa234e04df20a3beee1af5ad30))
- **parser:** count underline markers on the raw line ([`7f9e9c3`](https://github.com/jolars/panache/commit/7f9e9c3a91b25af5b3e04d342aeb1e0e4bfafca1))
- **parser:** let the registry's verdict outrank `>` count ([`5d97a32`](https://github.com/jolars/panache/commit/5d97a32b2fc4f1d2e172fded2e0ee1dfa3d9a8a0))
- **parser:** keep div opener whitespace before label ([`864cc90`](https://github.com/jolars/panache/commit/864cc903e6625b48e93f5e8e693596b3540dfa3f))
- **parser:** stop dropping surplus display-math dollars ([`33b6404`](https://github.com/jolars/panache/commit/33b64047b5e39f53f46602942234c61e36d95ec3))
- **parser:** keep `:::` openers from interrupting list items ([`37d95e1`](https://github.com/jolars/panache/commit/37d95e1106bcde0f6e20588f167bec6268f7128f))
- **parser:** match line-block peek to emitted prefix ([`f7d50ee`](https://github.com/jolars/panache/commit/f7d50eeb7b2889072e2b0fa2a5e793457353c768))
- **parser:** emit blockquote setext from stripped lines ([`985aba2`](https://github.com/jolars/panache/commit/985aba26f812dbb2a75a4d1129a1a5ca13b2d79b))
- **parser:** let setext claim a quoted line at top level ([`c60043c`](https://github.com/jolars/panache/commit/c60043cb290958c9d7c7a2bd0dd6a2826f4cb024))
- **parser:** keep refdefs from interrupting list items ([`6f36287`](https://github.com/jolars/panache/commit/6f3628743614dfdbbb078e2161284c21c18ca469))

## [editors/code: 3.3.0](https://github.com/jolars/panache/compare/panache-code-v3.2.0...panache-code-v3.3.0) (2026-08-07)

### Dependencies
- updated panache to v3.3.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).