### PR TITLE
docs: lock Cargo install dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ linters on code blocks.
 
 Panache is available from several sources:
 
-- **crates.io**: `cargo install panache`
+- **crates.io**: `cargo install --locked panache`
 - **Homebrew**: `brew install panache`
 - **npm**: `npm install -g @panache-cli/panache` (or `npx @panache-cli/panache`)
 - **PyPI**: `uv tool install panache-cli`/`pipx install panache-cli`

--- a/docs/getting-started.qmd
+++ b/docs/getting-started.qmd
@@ -21,7 +21,7 @@ brew install panache
 Install `panache` with Cargo:
 
 ```bash
-cargo install panache
+cargo install --locked panache
 ```
 
 ### Aqua
@@ -123,7 +123,7 @@ npm install -g @panache-cli/panache
 To install the latest development version, run:
 
 ```bash
-cargo install --git https://github.com/jolars/panache.git panache
+cargo install --locked --git https://github.com/jolars/panache.git panache
 ```
 
 This presumes you have a working and up-to-date Rust toolchain (stable, 2024

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -69,7 +69,7 @@ brew install panache
 Or install with Cargo:
 
 ```bash
-cargo install panache
+cargo install --locked panache
 ```
 
 Format your first document:


### PR DESCRIPTION
## Summary

- add `--locked` to Cargo installation commands
- keep the README, getting-started guide, and docs landing page consistent
- apply the same behavior to development installs from Git

## Rationale

Using the published lockfile ensures Cargo installs the dependency versions tested in CI. This means semver-compatible dependency breakage is caught by CI instead of users and reduces maintenance burden for source-based installations. This is something I've seen in practice across many cli tools.

## Validation

- `cargo run --quiet -- format --check README.md docs/getting-started.qmd docs/index.qmd`
