### PR TITLE
docs(formatter): fix task list example

### DIFF
--- a/docs/guide/formatting.qmd
+++ b/docs/guide/formatting.qmd
@@ -464,8 +464,8 @@ Ordered lists are handled similarly to [unordered lists].
 
 ### Task Lists
 
-GitHub-style task lists use the standardized `-` marker, and indent to the start
-of the text.
+GitHub-style task lists use the standardized `-` marker. Nested items align with
+the parent list item's content column, immediately before its checkbox.
 
 Input
 
@@ -480,8 +480,8 @@ Output
 
 :   ```markdown
     - [ ] Parent task
-           - [ ] Nested unchecked task
-           - [x] Nested checked task
+      - [ ] Nested unchecked task
+      - [x] Nested checked task
     - [x] Another parent task
     ```
 


### PR DESCRIPTION
## Summary

Clarify that nested task-list items align with the parent list item's content column, immediately before its checkbox.

The previous example used seven effective spaces, placing the nested markers under the task description. Panache actually canonicalizes them to two spaces, aligned under the opening `[` of the parent checkbox.

## Verification

The example can be inspected directly:

```bash
cargo run --quiet -- format <<'EOF'
+ [ ] Parent task
   *   [ ] Nested unchecked task
   - [x]   Nested checked task
- [X] Another parent task
EOF
```

Output:

```markdown
- [ ] Parent task
  - [ ] Nested unchecked task
  - [x] Nested checked task
- [x] Another parent task
```

The focused golden test also passes:

```bash
cargo test --test golden_cases lists_task_nested
```
