### PR TITLE
chore(release): v3.5.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "47c8c5245309ff6aa16e49278e0d86d1310f354a",
+  "baseline-sha": "7b1bb0da91e60d0c1339df3a8e9503afdfad4e3b",
   "release-targets": [
     {
       "path": ".",
-      "version": "3.4.0",
-      "tag": "v3.4.0"
+      "version": "3.5.0",
+      "tag": "v3.5.0"
     },
     {
       "path": "crates/panache-dprint",
@@ -14,18 +14,18 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.21.0",
-      "tag": "panache-formatter-v0.21.0"
+      "version": "0.21.1",
+      "tag": "panache-formatter-v0.21.1"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.26.0",
-      "tag": "panache-parser-v0.26.0"
+      "version": "0.27.0",
+      "tag": "panache-parser-v0.27.0"
     },
     {
       "path": "editors/code",
-      "version": "3.4.0",
-      "tag": "panache-code-v3.4.0"
+      "version": "3.5.0",
+      "tag": "panache-code-v3.5.0"
     },
     {
       "path": "editors/zed",
@@ -36,23 +36,23 @@
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "3.4.0",
-      "tag": "v3.4.0"
+      "version": "3.5.0",
+      "tag": "v3.5.0"
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.21.0",
-      "tag": "panache-formatter-v0.21.0"
+      "version": "0.21.1",
+      "tag": "panache-formatter-v0.21.1"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.26.0",
-      "tag": "panache-parser-v0.26.0"
+      "version": "0.27.0",
+      "tag": "panache-parser-v0.27.0"
     },
     {
       "path": "editors/code",
-      "version": "3.4.0",
-      "tag": "panache-code-v3.4.0"
+      "version": "3.5.0",
+      "tag": "panache-code-v3.5.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,50 @@
 # Changelog
 
-## Unreleased
+## [3.5.0](https://github.com/jolars/panache/compare/v3.4.0...v3.5.0) (2026-08-17)
 
 The major new change in this version is that incremental parsing is on by default. It was previously opt-in and controlled by `experimental.incrementalParsing`, but that setting is now true by default and deprecated. Please let me know if you encounter any issues with this change.
+
+### Features
+- **parser:** add a bounded region tier, tried last ([`be854b2`](https://github.com/jolars/panache/commit/be854b2bcc4d6dbbe2c739b65f69a88d111ea898))
+- **lsp:** deprecate `experimental.incrementalParsing` ([`81520e8`](https://github.com/jolars/panache/commit/81520e880bc84c9f96e3caecd7563a2d978530fb))
+- **lsp:** parse incrementally by default ([`72eb2da`](https://github.com/jolars/panache/commit/72eb2da0256887f1badf727211bfb7684ca78ad6))
+
+### Bug Fixes
+- **parser:** decline splices below a retained definition list ([`c60535c`](https://github.com/jolars/panache/commit/c60535c2617cea92b4faddda7d5be32c4131290e))
+- **lsp:** clamp and normalize out-of-range `didChange` ranges ([`4ff7dc0`](https://github.com/jolars/panache/commit/4ff7dc03f937b7c2c37e40152fd58744c1e9f2c2))
+- **lsp:** re-admit the reparse base when config reloads ([`749c3ae`](https://github.com/jolars/panache/commit/749c3aeea01a48a526c24dbfdd770f5afc8b7bc7))
+- **cli:** name the offending file in `io::Error`s ([`70f79db`](https://github.com/jolars/panache/commit/70f79db21a6631c2402e1f6feeede4c5b5a03f52))
+- **cli:** print top-level errors via `Display` ([`f631502`](https://github.com/jolars/panache/commit/f631502487cc67fbacd36591535ee03858d3eceb))
+- **pandoc-ast:** gate smart typography on the flavor ([`23bb54a`](https://github.com/jolars/panache/commit/23bb54a47ca784c5af28389dc58b021dd50cb1ee))
+- **parser:** anchor yaml metadata delimiters at column 0 ([`55e3999`](https://github.com/jolars/panache/commit/55e3999730d4987bc37f369733ed0f420d9e6c40))
+- **config:** disable `auto-identifiers` for `mdsvex` ([`21818ec`](https://github.com/jolars/panache/commit/21818ec918c55d8b38005e2cd279e844dd25891d))
+- gate heading auto-ids on `auto_identifiers` ([`efd4ae0`](https://github.com/jolars/panache/commit/efd4ae053acdad06f0f559ffdff803fd77348bf8))
+- **parser:** gate heading attrs on `header_attributes` ([`1291394`](https://github.com/jolars/panache/commit/1291394ee4edce57b65766119eacd4afd9e509c2))
+- **formatter:** stop trimming heading content hashes ([`cee2dbf`](https://github.com/jolars/panache/commit/cee2dbfe3efa3a240b838aa5dbd4e1f2dba3d1d6))
+- **parser:** read heading attrs after `#` run ([`52147de`](https://github.com/jolars/panache/commit/52147de9874eea75020ebcfd8cbbf5c301745731))
+- **parser:** enable `escaped_line_breaks` for `gfm` ([`6a9c0f6`](https://github.com/jolars/panache/commit/6a9c0f6cd29579158b5c4e429167f393f183df09))
+- **parser:** keep an escaped space out of the attribute gap ([`241310e`](https://github.com/jolars/panache/commit/241310ec9355c4f5ea058f66441015881730e6e7))
+- **parser:** fold whitespace into a backslash line break ([`eaf42a0`](https://github.com/jolars/panache/commit/eaf42a00e77fe3bfda14a01e1568605f5b9c2785))
+- **parser:** read a heading's trailing `\` as a line break ([`3ba1faf`](https://github.com/jolars/panache/commit/3ba1faf1624453560778175341ce6ae9e44f5c27))
+- **parser:** keep trailing `\` literal in CommonMark ([`cab28d3`](https://github.com/jolars/panache/commit/cab28d3a857eb7a85640dc264a95c2c5ab8f9be9))
+- **formatter:** drop trailing whitespace under `wrap = preserve` ([`d3fdd9f`](https://github.com/jolars/panache/commit/d3fdd9fc1e259112462709cbad91e3135010eb63)), closes [#496](https://github.com/jolars/panache/issues/496)
+
+### Performance Improvements
+- **lsp:** publish diagnostics with one line index ([`7b1bb0d`](https://github.com/jolars/panache/commit/7b1bb0da91e60d0c1339df3a8e9503afdfad4e3b))
+- **lsp:** serve one line index to both phases ([`86bea8f`](https://github.com/jolars/panache/commit/86bea8f1a355fdb3e556f2cebc16652766a02bc0))
+- **lsp:** reuse the write phase's line index ([`56beaf5`](https://github.com/jolars/panache/commit/56beaf522bc31607738749f5796f68095ce94f7e))
+- **parser:** promote the region tier ahead of the windows ([`1868fb0`](https://github.com/jolars/panache/commit/1868fb0509ffdeecc713349cabff0bb297e691a9))
+- **bench:** measure the region tier and calibrate its floors ([`9e47933`](https://github.com/jolars/panache/commit/9e479338bd97963244ae149d7548af713e204487))
+- **bench:** calibrate the token tier's floors from a measured gate ([`b5dd291`](https://github.com/jolars/panache/commit/b5dd29149ea5ae65f851f000c4215a3eb9fbf643))
+- **bench:** measure the token tier, and keep the cutoff pair honest ([`6bedeb3`](https://github.com/jolars/panache/commit/6bedeb3e61abf377a02caac725472e0e0c6964bd))
+- **lsp:** splice once through one index per `didChange` ([`4a3588f`](https://github.com/jolars/panache/commit/4a3588ffaec0757dfc32d6e2b9aa381be5d0abe7))
+- **lsp:** index lines over the text instead of a wide-char table ([`0c82fa0`](https://github.com/jolars/panache/commit/0c82fa0ec27b491c87694b045628cd21fbd42b6a))
+- **salsa:** skip writes that store what is already there ([`f44edd9`](https://github.com/jolars/panache/commit/f44edd9f5e65a31424febad6ff4b34c141581d5e))
+- **lsp:** stop resolving config on every keystroke ([`fea6d54`](https://github.com/jolars/panache/commit/fea6d544632c3e4fe9bebe41d176fc2aa96bcacc))
+
+### Dependencies
+- updated crates/panache-formatter to v0.21.1
+- updated crates/panache-parser to v0.27.0
 
 ## [3.4.0](https://github.com/jolars/panache/compare/v3.3.0...v3.4.0) (2026-08-14)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,9 +992,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
  "libc",
 ]
@@ -1203,7 +1203,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "panache"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -1236,7 +1236,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "similar 3.1.2",
+ "similar 3.2.0",
  "similar-asserts",
  "tempfile",
  "toml",
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "insta",
  "log",
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "entities",
  "insta",
@@ -1792,9 +1792,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "similar"
-version = "3.1.2"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ee016af5d736b69fc89e19254540fa4b5f5492853fb5503920f084011c78b6"
+checksum = "4f66ca1f7aca2474dc10c942eb22feffc897735f54cd1db90138c2fddb490987"
 dependencies = [
  "bstr",
  "unicode-segmentation",
@@ -1807,7 +1807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "997e6ca38e97437973fc9f7f50a50d1274cacd874341a4960fea90067291038c"
 dependencies = [
  "console",
- "similar 3.1.2",
+ "similar 3.2.0",
 ]
 
 [[package]]
@@ -2063,9 +2063,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "3.4.0"
+version = "3.5.0"
 edition.workspace = true
 rust-version.workspace = true
 # `distill_quarto_schema` is a dev-only vendoring bin (src/bin/); keep bare
@@ -56,8 +56,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.21.0" }
-panache-parser = { path = "crates/panache-parser", version = "0.26.0", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.21.1" }
+panache-parser = { path = "crates/panache-parser", version = "0.27.0", features = [
     "serde",
     "schema",
 ] }

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.21.1](https://github.com/jolars/panache/compare/panache-formatter-v0.21.0...panache-formatter-v0.21.1) (2026-08-17)
+
+### Bug Fixes
+- **parser:** anchor yaml metadata delimiters at column 0 ([`55e3999`](https://github.com/jolars/panache/commit/55e3999730d4987bc37f369733ed0f420d9e6c40))
+- gate heading auto-ids on `auto_identifiers` ([`efd4ae0`](https://github.com/jolars/panache/commit/efd4ae053acdad06f0f559ffdff803fd77348bf8))
+- **formatter:** stop trimming heading content hashes ([`cee2dbf`](https://github.com/jolars/panache/commit/cee2dbfe3efa3a240b838aa5dbd4e1f2dba3d1d6))
+- **formatter:** keep a load-bearing heading `#` run ([`be48179`](https://github.com/jolars/panache/commit/be481798358fc2722da2a3dbb1241bdb4d27bb80))
+- **parser:** fold whitespace into a backslash line break ([`eaf42a0`](https://github.com/jolars/panache/commit/eaf42a00e77fe3bfda14a01e1568605f5b9c2785))
+- **formatter:** drop trailing whitespace under `wrap = preserve` ([`d3fdd9f`](https://github.com/jolars/panache/commit/d3fdd9fc1e259112462709cbad91e3135010eb63)), closes [#496](https://github.com/jolars/panache/issues/496)
+
+### Dependencies
+- updated crates/panache-parser to v0.27.0
+
 ## [0.21.0](https://github.com/jolars/panache/compare/panache-formatter-v0.20.5...panache-formatter-v0.21.0) (2026-08-14)
 
 ### Features

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.21.0"
+version = "0.21.1"
 edition.workspace = true
 rust-version.workspace = true
 include = [
@@ -19,7 +19,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.26.0" }
+panache-parser = { path = "../panache-parser", version = "0.27.0" }
 log = { version = "0.4.31", features = ["release_max_level_debug"] }
 rowan = "0.17.0"
 serde = { version = "1.0.228", features = ["derive"], optional = true }

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [0.27.0](https://github.com/jolars/panache/compare/panache-parser-v0.26.0...panache-parser-v0.27.0) (2026-08-17)
+
+### Features
+- **parser:** add a bounded region tier, tried last ([`be854b2`](https://github.com/jolars/panache/commit/be854b2bcc4d6dbbe2c739b65f69a88d111ea898))
+- **parser:** add a fragment parse entry point ([`c0c1df4`](https://github.com/jolars/panache/commit/c0c1df4b6d051877ccacbfcf3351853b36aa0c0a))
+- **parser:** splice a single prose `TEXT` token in place ([`4f020ff`](https://github.com/jolars/panache/commit/4f020ff2abd01991357d58c82f5deb3eb1d4e052))
+
+### Bug Fixes
+- **parser:** decline splices below a retained definition list ([`c60535c`](https://github.com/jolars/panache/commit/c60535c2617cea92b4faddda7d5be32c4131290e))
+- **pandoc-ast:** gate smart typography on the flavor ([`23bb54a`](https://github.com/jolars/panache/commit/23bb54a47ca784c5af28389dc58b021dd50cb1ee))
+- **parser:** anchor yaml metadata delimiters at column 0 ([`55e3999`](https://github.com/jolars/panache/commit/55e3999730d4987bc37f369733ed0f420d9e6c40))
+- **config:** disable `auto-identifiers` for `mdsvex` ([`21818ec`](https://github.com/jolars/panache/commit/21818ec918c55d8b38005e2cd279e844dd25891d))
+- gate heading auto-ids on `auto_identifiers` ([`efd4ae0`](https://github.com/jolars/panache/commit/efd4ae053acdad06f0f559ffdff803fd77348bf8))
+- **parser:** gate heading attrs on `header_attributes` ([`1291394`](https://github.com/jolars/panache/commit/1291394ee4edce57b65766119eacd4afd9e509c2))
+- **parser:** close headings on a spaceless `#` run ([`16ce2a0`](https://github.com/jolars/panache/commit/16ce2a0fa9cddd7b3ef39e8041929078dabfe5d8))
+- **parser:** read heading attrs after `#` run ([`52147de`](https://github.com/jolars/panache/commit/52147de9874eea75020ebcfd8cbbf5c301745731))
+- **parser:** enable `escaped_line_breaks` for `gfm` ([`6a9c0f6`](https://github.com/jolars/panache/commit/6a9c0f6cd29579158b5c4e429167f393f183df09))
+- **parser:** keep an escaped space out of the attribute gap ([`241310e`](https://github.com/jolars/panache/commit/241310ec9355c4f5ea058f66441015881730e6e7))
+- **parser:** fold whitespace into a backslash line break ([`eaf42a0`](https://github.com/jolars/panache/commit/eaf42a00e77fe3bfda14a01e1568605f5b9c2785))
+- **parser:** read a heading's trailing `\` as a line break ([`3ba1faf`](https://github.com/jolars/panache/commit/3ba1faf1624453560778175341ce6ae9e44f5c27))
+- **parser:** keep trailing `\` literal in CommonMark ([`cab28d3`](https://github.com/jolars/panache/commit/cab28d3a857eb7a85640dc264a95c2c5ab8f9be9))
+- **parser:** tighten whitespace hard-break rule ([`338743c`](https://github.com/jolars/panache/commit/338743c4c72e364e17802557eccda7e13167955b))
+
+### Performance Improvements
+- **parser:** promote the region tier ahead of the windows ([`1868fb0`](https://github.com/jolars/panache/commit/1868fb0509ffdeecc713349cabff0bb297e691a9))
+- **parser:** stop reading the old text through the whole tree ([`cd1a769`](https://github.com/jolars/panache/commit/cd1a769dcba94dbb8faa96307e479aba32aed363))
+- **bench:** measure the token tier, and keep the cutoff pair honest ([`6bedeb3`](https://github.com/jolars/panache/commit/6bedeb3e61abf377a02caac725472e0e0c6964bd))
+- **parser:** serve backtick and space runs from a static pool ([`050f809`](https://github.com/jolars/panache/commit/050f809fe4ffd6d2e1e53eaa983a097331ab1368))
+- **parser:** reuse the validator's YAML tree in `prepare_yaml_content` ([`7a1533b`](https://github.com/jolars/panache/commit/7a1533bb9293a272bb4f6b3e9626d89f35c0d406))
+- **parser:** byte-gate `try_parse_horizontal_rule` before trim ([`1b7b417`](https://github.com/jolars/panache/commit/1b7b4178bd822c0b680da9b7da2d8723ee3db775))
+
 ## [0.26.0](https://github.com/jolars/panache/compare/panache-parser-v0.25.0...panache-parser-v0.26.0) (2026-08-14)
 
 ### Features

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.26.0"
+version = "0.27.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [3.5.0](https://github.com/jolars/panache/compare/panache-code-v3.4.0...panache-code-v3.5.0) (2026-08-17)
+
+### Features
+- **editors:** mark incremental parsing setting deprecated ([`f0b1935`](https://github.com/jolars/panache/commit/f0b1935daa466842a033961875e8f03bcb94ee91))
+- **editors:** default incremental parsing to on ([`a8b7a3b`](https://github.com/jolars/panache/commit/a8b7a3bf5337118bb93df1349a3b5d6e9769678c))
+
+### Dependencies
+- updated panache to v3.5.0
+
 ## [3.4.0](https://github.com/jolars/panache/compare/panache-code-v3.3.0...panache-code-v3.4.0) (2026-08-14)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         panache = pkgs.rustPlatform.buildRustPackage {
           pname = "panache";
-          version = "3.4.0";
+          version = "3.5.0";
 
           src = ./.;
 

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "3.4.0",
-    "@panache-cli/linux-arm64-gnu": "3.4.0",
-    "@panache-cli/linux-x64-musl": "3.4.0",
-    "@panache-cli/linux-arm64-musl": "3.4.0",
-    "@panache-cli/darwin-x64": "3.4.0",
-    "@panache-cli/darwin-arm64": "3.4.0",
-    "@panache-cli/win32-x64": "3.4.0",
-    "@panache-cli/win32-arm64": "3.4.0"
+    "@panache-cli/linux-x64-gnu": "3.5.0",
+    "@panache-cli/linux-arm64-gnu": "3.5.0",
+    "@panache-cli/linux-x64-musl": "3.5.0",
+    "@panache-cli/linux-arm64-musl": "3.5.0",
+    "@panache-cli/darwin-x64": "3.5.0",
+    "@panache-cli/darwin-arm64": "3.5.0",
+    "@panache-cli/win32-x64": "3.5.0",
+    "@panache-cli/win32-arm64": "3.5.0"
   }
 }


### PR DESCRIPTION
## [panache: 3.5.0](https://github.com/jolars/panache/compare/v3.4.0...v3.5.0) (2026-08-17)

The major new change in this version is that incremental parsing is on by default. It was previously opt-in and controlled by `experimental.incrementalParsing`, but that setting is now true by default and deprecated. Please let me know if you encounter any issues with this change.

### Features
- **parser:** add a bounded region tier, tried last ([`be854b2`](https://github.com/jolars/panache/commit/be854b2bcc4d6dbbe2c739b65f69a88d111ea898))
- **lsp:** deprecate `experimental.incrementalParsing` ([`81520e8`](https://github.com/jolars/panache/commit/81520e880bc84c9f96e3caecd7563a2d978530fb))
- **lsp:** parse incrementally by default ([`72eb2da`](https://github.com/jolars/panache/commit/72eb2da0256887f1badf727211bfb7684ca78ad6))

### Bug Fixes
- **parser:** decline splices below a retained definition list ([`c60535c`](https://github.com/jolars/panache/commit/c60535c2617cea92b4faddda7d5be32c4131290e))
- **lsp:** clamp and normalize out-of-range `didChange` ranges ([`4ff7dc0`](https://github.com/jolars/panache/commit/4ff7dc03f937b7c2c37e40152fd58744c1e9f2c2))
- **lsp:** re-admit the reparse base when config reloads ([`749c3ae`](https://github.com/jolars/panache/commit/749c3aeea01a48a526c24dbfdd770f5afc8b7bc7))
- **cli:** name the offending file in `io::Error`s ([`70f79db`](https://github.com/jolars/panache/commit/70f79db21a6631c2402e1f6feeede4c5b5a03f52))
- **cli:** print top-level errors via `Display` ([`f631502`](https://github.com/jolars/panache/commit/f631502487cc67fbacd36591535ee03858d3eceb))
- **pandoc-ast:** gate smart typography on the flavor ([`23bb54a`](https://github.com/jolars/panache/commit/23bb54a47ca784c5af28389dc58b021dd50cb1ee))
- **parser:** anchor yaml metadata delimiters at column 0 ([`55e3999`](https://github.com/jolars/panache/commit/55e3999730d4987bc37f369733ed0f420d9e6c40))
- **config:** disable `auto-identifiers` for `mdsvex` ([`21818ec`](https://github.com/jolars/panache/commit/21818ec918c55d8b38005e2cd279e844dd25891d))
- gate heading auto-ids on `auto_identifiers` ([`efd4ae0`](https://github.com/jolars/panache/commit/efd4ae053acdad06f0f559ffdff803fd77348bf8))
- **parser:** gate heading attrs on `header_attributes` ([`1291394`](https://github.com/jolars/panache/commit/1291394ee4edce57b65766119eacd4afd9e509c2))
- **formatter:** stop trimming heading content hashes ([`cee2dbf`](https://github.com/jolars/panache/commit/cee2dbfe3efa3a240b838aa5dbd4e1f2dba3d1d6))
- **parser:** read heading attrs after `#` run ([`52147de`](https://github.com/jolars/panache/commit/52147de9874eea75020ebcfd8cbbf5c301745731))
- **parser:** enable `escaped_line_breaks` for `gfm` ([`6a9c0f6`](https://github.com/jolars/panache/commit/6a9c0f6cd29579158b5c4e429167f393f183df09))
- **parser:** keep an escaped space out of the attribute gap ([`241310e`](https://github.com/jolars/panache/commit/241310ec9355c4f5ea058f66441015881730e6e7))
- **parser:** fold whitespace into a backslash line break ([`eaf42a0`](https://github.com/jolars/panache/commit/eaf42a00e77fe3bfda14a01e1568605f5b9c2785))
- **parser:** read a heading's trailing `\` as a line break ([`3ba1faf`](https://github.com/jolars/panache/commit/3ba1faf1624453560778175341ce6ae9e44f5c27))
- **parser:** keep trailing `\` literal in CommonMark ([`cab28d3`](https://github.com/jolars/panache/commit/cab28d3a857eb7a85640dc264a95c2c5ab8f9be9))
- **formatter:** drop trailing whitespace under `wrap = preserve` ([`d3fdd9f`](https://github.com/jolars/panache/commit/d3fdd9fc1e259112462709cbad91e3135010eb63)), closes [#496](https://github.com/jolars/panache/issues/496)

### Performance Improvements
- **lsp:** publish diagnostics with one line index ([`7b1bb0d`](https://github.com/jolars/panache/commit/7b1bb0da91e60d0c1339df3a8e9503afdfad4e3b))
- **lsp:** serve one line index to both phases ([`86bea8f`](https://github.com/jolars/panache/commit/86bea8f1a355fdb3e556f2cebc16652766a02bc0))
- **lsp:** reuse the write phase's line index ([`56beaf5`](https://github.com/jolars/panache/commit/56beaf522bc31607738749f5796f68095ce94f7e))
- **parser:** promote the region tier ahead of the windows ([`1868fb0`](https://github.com/jolars/panache/commit/1868fb0509ffdeecc713349cabff0bb297e691a9))
- **bench:** measure the region tier and calibrate its floors ([`9e47933`](https://github.com/jolars/panache/commit/9e479338bd97963244ae149d7548af713e204487))
- **bench:** calibrate the token tier's floors from a measured gate ([`b5dd291`](https://github.com/jolars/panache/commit/b5dd29149ea5ae65f851f000c4215a3eb9fbf643))
- **bench:** measure the token tier, and keep the cutoff pair honest ([`6bedeb3`](https://github.com/jolars/panache/commit/6bedeb3e61abf377a02caac725472e0e0c6964bd))
- **lsp:** splice once through one index per `didChange` ([`4a3588f`](https://github.com/jolars/panache/commit/4a3588ffaec0757dfc32d6e2b9aa381be5d0abe7))
- **lsp:** index lines over the text instead of a wide-char table ([`0c82fa0`](https://github.com/jolars/panache/commit/0c82fa0ec27b491c87694b045628cd21fbd42b6a))
- **salsa:** skip writes that store what is already there ([`f44edd9`](https://github.com/jolars/panache/commit/f44edd9f5e65a31424febad6ff4b34c141581d5e))
- **lsp:** stop resolving config on every keystroke ([`fea6d54`](https://github.com/jolars/panache/commit/fea6d544632c3e4fe9bebe41d176fc2aa96bcacc))

### Dependencies
- updated crates/panache-formatter to v0.21.1
- updated crates/panache-parser to v0.27.0

## [crates/panache-formatter: 0.21.1](https://github.com/jolars/panache/compare/panache-formatter-v0.21.0...panache-formatter-v0.21.1) (2026-08-17)

### Bug Fixes
- **parser:** anchor yaml metadata delimiters at column 0 ([`55e3999`](https://github.com/jolars/panache/commit/55e3999730d4987bc37f369733ed0f420d9e6c40))
- gate heading auto-ids on `auto_identifiers` ([`efd4ae0`](https://github.com/jolars/panache/commit/efd4ae053acdad06f0f559ffdff803fd77348bf8))
- **formatter:** stop trimming heading content hashes ([`cee2dbf`](https://github.com/jolars/panache/commit/cee2dbfe3efa3a240b838aa5dbd4e1f2dba3d1d6))
- **formatter:** keep a load-bearing heading `#` run ([`be48179`](https://github.com/jolars/panache/commit/be481798358fc2722da2a3dbb1241bdb4d27bb80))
- **parser:** fold whitespace into a backslash line break ([`eaf42a0`](https://github.com/jolars/panache/commit/eaf42a00e77fe3bfda14a01e1568605f5b9c2785))
- **formatter:** drop trailing whitespace under `wrap = preserve` ([`d3fdd9f`](https://github.com/jolars/panache/commit/d3fdd9fc1e259112462709cbad91e3135010eb63)), closes [#496](https://github.com/jolars/panache/issues/496)

### Dependencies
- updated crates/panache-parser to v0.27.0

## [crates/panache-parser: 0.27.0](https://github.com/jolars/panache/compare/panache-parser-v0.26.0...panache-parser-v0.27.0) (2026-08-17)

### Features
- **parser:** add a bounded region tier, tried last ([`be854b2`](https://github.com/jolars/panache/commit/be854b2bcc4d6dbbe2c739b65f69a88d111ea898))
- **parser:** add a fragment parse entry point ([`c0c1df4`](https://github.com/jolars/panache/commit/c0c1df4b6d051877ccacbfcf3351853b36aa0c0a))
- **parser:** splice a single prose `TEXT` token in place ([`4f020ff`](https://github.com/jolars/panache/commit/4f020ff2abd01991357d58c82f5deb3eb1d4e052))

### Bug Fixes
- **parser:** decline splices below a retained definition list ([`c60535c`](https://github.com/jolars/panache/commit/c60535c2617cea92b4faddda7d5be32c4131290e))
- **pandoc-ast:** gate smart typography on the flavor ([`23bb54a`](https://github.com/jolars/panache/commit/23bb54a47ca784c5af28389dc58b021dd50cb1ee))
- **parser:** anchor yaml metadata delimiters at column 0 ([`55e3999`](https://github.com/jolars/panache/commit/55e3999730d4987bc37f369733ed0f420d9e6c40))
- **config:** disable `auto-identifiers` for `mdsvex` ([`21818ec`](https://github.com/jolars/panache/commit/21818ec918c55d8b38005e2cd279e844dd25891d))
- gate heading auto-ids on `auto_identifiers` ([`efd4ae0`](https://github.com/jolars/panache/commit/efd4ae053acdad06f0f559ffdff803fd77348bf8))
- **parser:** gate heading attrs on `header_attributes` ([`1291394`](https://github.com/jolars/panache/commit/1291394ee4edce57b65766119eacd4afd9e509c2))
- **parser:** close headings on a spaceless `#` run ([`16ce2a0`](https://github.com/jolars/panache/commit/16ce2a0fa9cddd7b3ef39e8041929078dabfe5d8))
- **parser:** read heading attrs after `#` run ([`52147de`](https://github.com/jolars/panache/commit/52147de9874eea75020ebcfd8cbbf5c301745731))
- **parser:** enable `escaped_line_breaks` for `gfm` ([`6a9c0f6`](https://github.com/jolars/panache/commit/6a9c0f6cd29579158b5c4e429167f393f183df09))
- **parser:** keep an escaped space out of the attribute gap ([`241310e`](https://github.com/jolars/panache/commit/241310ec9355c4f5ea058f66441015881730e6e7))
- **parser:** fold whitespace into a backslash line break ([`eaf42a0`](https://github.com/jolars/panache/commit/eaf42a00e77fe3bfda14a01e1568605f5b9c2785))
- **parser:** read a heading's trailing `\` as a line break ([`3ba1faf`](https://github.com/jolars/panache/commit/3ba1faf1624453560778175341ce6ae9e44f5c27))
- **parser:** keep trailing `\` literal in CommonMark ([`cab28d3`](https://github.com/jolars/panache/commit/cab28d3a857eb7a85640dc264a95c2c5ab8f9be9))
- **parser:** tighten whitespace hard-break rule ([`338743c`](https://github.com/jolars/panache/commit/338743c4c72e364e17802557eccda7e13167955b))

### Performance Improvements
- **parser:** promote the region tier ahead of the windows ([`1868fb0`](https://github.com/jolars/panache/commit/1868fb0509ffdeecc713349cabff0bb297e691a9))
- **parser:** stop reading the old text through the whole tree ([`cd1a769`](https://github.com/jolars/panache/commit/cd1a769dcba94dbb8faa96307e479aba32aed363))
- **bench:** measure the token tier, and keep the cutoff pair honest ([`6bedeb3`](https://github.com/jolars/panache/commit/6bedeb3e61abf377a02caac725472e0e0c6964bd))
- **parser:** serve backtick and space runs from a static pool ([`050f809`](https://github.com/jolars/panache/commit/050f809fe4ffd6d2e1e53eaa983a097331ab1368))
- **parser:** reuse the validator's YAML tree in `prepare_yaml_content` ([`7a1533b`](https://github.com/jolars/panache/commit/7a1533bb9293a272bb4f6b3e9626d89f35c0d406))
- **parser:** byte-gate `try_parse_horizontal_rule` before trim ([`1b7b417`](https://github.com/jolars/panache/commit/1b7b4178bd822c0b680da9b7da2d8723ee3db775))

## [editors/code: 3.5.0](https://github.com/jolars/panache/compare/panache-code-v3.4.0...panache-code-v3.5.0) (2026-08-17)

### Features
- **editors:** mark incremental parsing setting deprecated ([`f0b1935`](https://github.com/jolars/panache/commit/f0b1935daa466842a033961875e8f03bcb94ee91))
- **editors:** default incremental parsing to on ([`a8b7a3b`](https://github.com/jolars/panache/commit/a8b7a3bf5337118bb93df1349a3b5d6e9769678c))

### Dependencies
- updated panache to v3.5.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).