### PR TITLE
chore(release): v3.6.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "7b1bb0da91e60d0c1339df3a8e9503afdfad4e3b",
+  "baseline-sha": "30392430dc280db6cf31acaa1e8b2248ee38a78b",
   "release-targets": [
     {
       "path": ".",
-      "version": "3.5.0",
-      "tag": "v3.5.0"
+      "version": "3.6.0",
+      "tag": "v3.6.0"
     },
     {
       "path": "crates/panache-dprint",
@@ -14,18 +14,18 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.21.1",
-      "tag": "panache-formatter-v0.21.1"
+      "version": "0.21.2",
+      "tag": "panache-formatter-v0.21.2"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.27.0",
-      "tag": "panache-parser-v0.27.0"
+      "version": "0.27.1",
+      "tag": "panache-parser-v0.27.1"
     },
     {
       "path": "editors/code",
-      "version": "3.5.0",
-      "tag": "panache-code-v3.5.0"
+      "version": "3.6.0",
+      "tag": "panache-code-v3.6.0"
     },
     {
       "path": "editors/zed",
@@ -36,23 +36,23 @@
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "3.5.0",
-      "tag": "v3.5.0"
+      "version": "3.6.0",
+      "tag": "v3.6.0"
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.21.1",
-      "tag": "panache-formatter-v0.21.1"
+      "version": "0.21.2",
+      "tag": "panache-formatter-v0.21.2"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.27.0",
-      "tag": "panache-parser-v0.27.0"
+      "version": "0.27.1",
+      "tag": "panache-parser-v0.27.1"
     },
     {
       "path": "editors/code",
-      "version": "3.5.0",
-      "tag": "panache-code-v3.5.0"
+      "version": "3.6.0",
+      "tag": "panache-code-v3.6.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [3.6.0](https://github.com/jolars/panache/compare/v3.5.0...v3.6.0) (2026-08-20)
+
+### Features
+- **linter:** flag split inline footnotes ([`36429c0`](https://github.com/jolars/panache/commit/36429c00b5dc6a55b532195a15d32806cb1bc6db))
+
+### Bug Fixes
+- **formatter:** preserve R T and F aliases ([`153ea95`](https://github.com/jolars/panache/commit/153ea957138f7be00f3634ec13864da4217fb858))
+- **parser:** trim bare URI punctuation ([`1c468d6`](https://github.com/jolars/panache/commit/1c468d6a3c46a71807726fe7404668f30807cd27))
+- regenerate panache schema ([`d97818d`](https://github.com/jolars/panache/commit/d97818d953fb2b7c82a04441df8aafa0025c68ab))
+
+### Performance Improvements
+- **parser:** share block parser registry ([`7681de4`](https://github.com/jolars/panache/commit/7681de440923900c9ad7805bc63694f7f00c0181))
+- **lsp:** carry edits into reparsing ([`72d86cf`](https://github.com/jolars/panache/commit/72d86cfbbbbe3e2bed4d84fd17a8c0cef5018ab6))
+- **lsp:** defer refdef scans until fallback ([`f0be83a`](https://github.com/jolars/panache/commit/f0be83a1cbd0722cf19b77f42457c442bf148eaa))
+
+### Dependencies
+- updated crates/panache-formatter to v0.21.2
+- updated crates/panache-parser to v0.27.1
+
 ## [3.5.0](https://github.com/jolars/panache/compare/v3.4.0...v3.5.0) (2026-08-17)
 
 The major new change in this version is that incremental parsing is on by default. It was previously opt-in and controlled by `experimental.incrementalParsing`, but that setting is now true by default and deprecated. Please let me know if you encounter any issues with this change.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,7 +1203,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "panache"
-version = "3.5.0"
+version = "3.6.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "insta",
  "log",
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "entities",
  "insta",
@@ -1495,18 +1495,18 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2345,9 +2345,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2356,9 +2356,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
+checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "3.5.0"
+version = "3.6.0"
 edition.workspace = true
 rust-version.workspace = true
 # `distill_quarto_schema` is a dev-only vendoring bin (src/bin/); keep bare
@@ -56,8 +56,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.21.1" }
-panache-parser = { path = "crates/panache-parser", version = "0.27.0", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.21.2" }
+panache-parser = { path = "crates/panache-parser", version = "0.27.1", features = [
     "serde",
     "schema",
 ] }

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.21.2](https://github.com/jolars/panache/compare/panache-formatter-v0.21.1...panache-formatter-v0.21.2) (2026-08-20)
+
+### Bug Fixes
+- **formatter:** preserve R T and F aliases ([`153ea95`](https://github.com/jolars/panache/commit/153ea957138f7be00f3634ec13864da4217fb858))
+
+### Dependencies
+- updated crates/panache-parser to v0.27.1
+
 ## [0.21.1](https://github.com/jolars/panache/compare/panache-formatter-v0.21.0...panache-formatter-v0.21.1) (2026-08-17)
 
 ### Bug Fixes

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.21.1"
+version = "0.21.2"
 edition.workspace = true
 rust-version.workspace = true
 include = [
@@ -19,7 +19,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.27.0" }
+panache-parser = { path = "../panache-parser", version = "0.27.1" }
 log = { version = "0.4.31", features = ["release_max_level_debug"] }
 rowan = "0.17.0"
 serde = { version = "1.0.228", features = ["derive"], optional = true }

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.27.1](https://github.com/jolars/panache/compare/panache-parser-v0.27.0...panache-parser-v0.27.1) (2026-08-20)
+
+### Bug Fixes
+- **formatter:** preserve R T and F aliases ([`153ea95`](https://github.com/jolars/panache/commit/153ea957138f7be00f3634ec13864da4217fb858))
+- **parser:** trim bare URI punctuation ([`1c468d6`](https://github.com/jolars/panache/commit/1c468d6a3c46a71807726fe7404668f30807cd27))
+
+### Performance Improvements
+- **parser:** share block parser registry ([`7681de4`](https://github.com/jolars/panache/commit/7681de440923900c9ad7805bc63694f7f00c0181))
+
 ## [0.27.0](https://github.com/jolars/panache/compare/panache-parser-v0.26.0...panache-parser-v0.27.0) (2026-08-17)
 
 ### Features

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.27.0"
+version = "0.27.1"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.6.0](https://github.com/jolars/panache/compare/panache-code-v3.5.0...panache-code-v3.6.0) (2026-08-20)
+
+### Dependencies
+- updated panache to v3.6.0
+
 ## [3.5.0](https://github.com/jolars/panache/compare/panache-code-v3.4.0...panache-code-v3.5.0) (2026-08-17)
 
 ### Features

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -802,9 +802,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -813,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
+checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         panache = pkgs.rustPlatform.buildRustPackage {
           pname = "panache";
-          version = "3.5.0";
+          version = "3.6.0";
 
           src = ./.;
 

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "3.5.0",
-    "@panache-cli/linux-arm64-gnu": "3.5.0",
-    "@panache-cli/linux-x64-musl": "3.5.0",
-    "@panache-cli/linux-arm64-musl": "3.5.0",
-    "@panache-cli/darwin-x64": "3.5.0",
-    "@panache-cli/darwin-arm64": "3.5.0",
-    "@panache-cli/win32-x64": "3.5.0",
-    "@panache-cli/win32-arm64": "3.5.0"
+    "@panache-cli/linux-x64-gnu": "3.6.0",
+    "@panache-cli/linux-arm64-gnu": "3.6.0",
+    "@panache-cli/linux-x64-musl": "3.6.0",
+    "@panache-cli/linux-arm64-musl": "3.6.0",
+    "@panache-cli/darwin-x64": "3.6.0",
+    "@panache-cli/darwin-arm64": "3.6.0",
+    "@panache-cli/win32-x64": "3.6.0",
+    "@panache-cli/win32-arm64": "3.6.0"
   }
 }


### PR DESCRIPTION
## [panache: 3.6.0](https://github.com/jolars/panache/compare/v3.5.0...v3.6.0) (2026-08-20)

### Features
- **linter:** flag split inline footnotes ([`36429c0`](https://github.com/jolars/panache/commit/36429c00b5dc6a55b532195a15d32806cb1bc6db))

### Bug Fixes
- **formatter:** preserve R T and F aliases ([`153ea95`](https://github.com/jolars/panache/commit/153ea957138f7be00f3634ec13864da4217fb858))
- **parser:** trim bare URI punctuation ([`1c468d6`](https://github.com/jolars/panache/commit/1c468d6a3c46a71807726fe7404668f30807cd27))
- regenerate panache schema ([`d97818d`](https://github.com/jolars/panache/commit/d97818d953fb2b7c82a04441df8aafa0025c68ab))

### Performance Improvements
- **parser:** share block parser registry ([`7681de4`](https://github.com/jolars/panache/commit/7681de440923900c9ad7805bc63694f7f00c0181))
- **lsp:** carry edits into reparsing ([`72d86cf`](https://github.com/jolars/panache/commit/72d86cfbbbbe3e2bed4d84fd17a8c0cef5018ab6))
- **lsp:** defer refdef scans until fallback ([`f0be83a`](https://github.com/jolars/panache/commit/f0be83a1cbd0722cf19b77f42457c442bf148eaa))

### Dependencies
- updated crates/panache-formatter to v0.21.2
- updated crates/panache-parser to v0.27.1

## [crates/panache-formatter: 0.21.2](https://github.com/jolars/panache/compare/panache-formatter-v0.21.1...panache-formatter-v0.21.2) (2026-08-20)

### Bug Fixes
- **formatter:** preserve R T and F aliases ([`153ea95`](https://github.com/jolars/panache/commit/153ea957138f7be00f3634ec13864da4217fb858))

### Dependencies
- updated crates/panache-parser to v0.27.1

## [crates/panache-parser: 0.27.1](https://github.com/jolars/panache/compare/panache-parser-v0.27.0...panache-parser-v0.27.1) (2026-08-20)

### Bug Fixes
- **formatter:** preserve R T and F aliases ([`153ea95`](https://github.com/jolars/panache/commit/153ea957138f7be00f3634ec13864da4217fb858))
- **parser:** trim bare URI punctuation ([`1c468d6`](https://github.com/jolars/panache/commit/1c468d6a3c46a71807726fe7404668f30807cd27))

### Performance Improvements
- **parser:** share block parser registry ([`7681de4`](https://github.com/jolars/panache/commit/7681de440923900c9ad7805bc63694f7f00c0181))

## [editors/code: 3.6.0](https://github.com/jolars/panache/compare/panache-code-v3.5.0...panache-code-v3.6.0) (2026-08-20)

### Dependencies
- updated panache to v3.6.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).