### PR TITLE
chore(release): v3.6.1 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "30392430dc280db6cf31acaa1e8b2248ee38a78b",
+  "baseline-sha": "ad9c9760e92eac5b4cb0ed750e5354d0af82f326",
   "release-targets": [
     {
       "path": ".",
-      "version": "3.6.0",
-      "tag": "v3.6.0"
+      "version": "3.6.1",
+      "tag": "v3.6.1"
     },
     {
       "path": "crates/panache-dprint",
@@ -14,18 +14,18 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.21.2",
-      "tag": "panache-formatter-v0.21.2"
+      "version": "0.21.3",
+      "tag": "panache-formatter-v0.21.3"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.27.1",
-      "tag": "panache-parser-v0.27.1"
+      "version": "0.27.2",
+      "tag": "panache-parser-v0.27.2"
     },
     {
       "path": "editors/code",
-      "version": "3.6.0",
-      "tag": "panache-code-v3.6.0"
+      "version": "3.6.1",
+      "tag": "panache-code-v3.6.1"
     },
     {
       "path": "editors/zed",
@@ -36,23 +36,23 @@
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "3.6.0",
-      "tag": "v3.6.0"
+      "version": "3.6.1",
+      "tag": "v3.6.1"
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.21.2",
-      "tag": "panache-formatter-v0.21.2"
+      "version": "0.21.3",
+      "tag": "panache-formatter-v0.21.3"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.27.1",
-      "tag": "panache-parser-v0.27.1"
+      "version": "0.27.2",
+      "tag": "panache-parser-v0.27.2"
     },
     {
       "path": "editors/code",
-      "version": "3.6.0",
-      "tag": "panache-code-v3.6.0"
+      "version": "3.6.1",
+      "tag": "panache-code-v3.6.1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [3.6.1](https://github.com/jolars/panache/compare/v3.6.0...v3.6.1) (2026-08-20)
+
+### Bug Fixes
+- **formatter:** keep trailing citations with sentences ([`9accb4f`](https://github.com/jolars/panache/commit/9accb4f5e7a7db2960ab5787d4be536a5e4b54fc)), fixes [#505](https://github.com/jolars/panache/issues/505)
+- **formatter:** compose embedded math environments ([`43a3b80`](https://github.com/jolars/panache/commit/43a3b801dd463d9f76f7bf759315d2f54f0b2061))
+- **formatter:** preserve starred math commands ([`8e73a5c`](https://github.com/jolars/panache/commit/8e73a5c2ab642d5268825f1c456b3ddd3b491f9c))
+- **config:** discover Windows user config ([`c667947`](https://github.com/jolars/panache/commit/c667947c2836e9a20ec1024f57caca7e62ddb085)), fixes [#503](https://github.com/jolars/panache/issues/503)
+- **formatter:** escape tildes contextually ([`74d82ad`](https://github.com/jolars/panache/commit/74d82ad309869a79d7b0ce96aed0ad0948ccac10)), fixes [#501](https://github.com/jolars/panache/issues/501)
+
+### Dependencies
+- updated crates/panache-formatter to v0.21.3
+- updated crates/panache-parser to v0.27.2
+
 ## [3.6.0](https://github.com/jolars/panache/compare/v3.5.0...v3.6.0) (2026-08-20)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,9 +447,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "email_address"
@@ -1203,7 +1203,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "panache"
-version = "3.6.0"
+version = "3.6.1"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "insta",
  "log",
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.27.1"
+version = "0.27.2"
 dependencies = [
  "entities",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "3.6.0"
+version = "3.6.1"
 edition.workspace = true
 rust-version.workspace = true
 # `distill_quarto_schema` is a dev-only vendoring bin (src/bin/); keep bare
@@ -56,8 +56,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.21.2" }
-panache-parser = { path = "crates/panache-parser", version = "0.27.1", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.21.3" }
+panache-parser = { path = "crates/panache-parser", version = "0.27.2", features = [
     "serde",
     "schema",
 ] }

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.21.3](https://github.com/jolars/panache/compare/panache-formatter-v0.21.2...panache-formatter-v0.21.3) (2026-08-20)
+
+### Bug Fixes
+- **formatter:** keep trailing citations with sentences ([`9accb4f`](https://github.com/jolars/panache/commit/9accb4f5e7a7db2960ab5787d4be536a5e4b54fc)), fixes [#505](https://github.com/jolars/panache/issues/505)
+- **formatter:** compose embedded math environments ([`43a3b80`](https://github.com/jolars/panache/commit/43a3b801dd463d9f76f7bf759315d2f54f0b2061))
+- **formatter:** preserve starred math commands ([`8e73a5c`](https://github.com/jolars/panache/commit/8e73a5c2ab642d5268825f1c456b3ddd3b491f9c))
+- **formatter:** escape tildes contextually ([`74d82ad`](https://github.com/jolars/panache/commit/74d82ad309869a79d7b0ce96aed0ad0948ccac10)), fixes [#501](https://github.com/jolars/panache/issues/501)
+
+### Dependencies
+- updated crates/panache-parser to v0.27.2
+
 ## [0.21.2](https://github.com/jolars/panache/compare/panache-formatter-v0.21.1...panache-formatter-v0.21.2) (2026-08-20)
 
 ### Bug Fixes

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.21.2"
+version = "0.21.3"
 edition.workspace = true
 rust-version.workspace = true
 include = [
@@ -19,7 +19,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.27.1" }
+panache-parser = { path = "../panache-parser", version = "0.27.2" }
 log = { version = "0.4.31", features = ["release_max_level_debug"] }
 rowan = "0.17.0"
 serde = { version = "1.0.228", features = ["derive"], optional = true }

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.27.2](https://github.com/jolars/panache/compare/panache-parser-v0.27.1...panache-parser-v0.27.2) (2026-08-20)
+
+### Bug Fixes
+- **parser:** disambiguate citations from links ([`f12dd2a`](https://github.com/jolars/panache/commit/f12dd2a25575e14dfafe0d7b10c0801ec33c2d40))
+
 ## [0.27.1](https://github.com/jolars/panache/compare/panache-parser-v0.27.0...panache-parser-v0.27.1) (2026-08-20)
 
 ### Bug Fixes

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.27.1"
+version = "0.27.2"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.6.1](https://github.com/jolars/panache/compare/panache-code-v3.6.0...panache-code-v3.6.1) (2026-08-20)
+
+### Dependencies
+- updated panache to v3.6.1
+
 ## [3.6.0](https://github.com/jolars/panache/compare/panache-code-v3.5.0...panache-code-v3.6.0) (2026-08-20)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         panache = pkgs.rustPlatform.buildRustPackage {
           pname = "panache";
-          version = "3.6.0";
+          version = "3.6.1";
 
           src = ./.;
 

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "3.6.0",
-    "@panache-cli/linux-arm64-gnu": "3.6.0",
-    "@panache-cli/linux-x64-musl": "3.6.0",
-    "@panache-cli/linux-arm64-musl": "3.6.0",
-    "@panache-cli/darwin-x64": "3.6.0",
-    "@panache-cli/darwin-arm64": "3.6.0",
-    "@panache-cli/win32-x64": "3.6.0",
-    "@panache-cli/win32-arm64": "3.6.0"
+    "@panache-cli/linux-x64-gnu": "3.6.1",
+    "@panache-cli/linux-arm64-gnu": "3.6.1",
+    "@panache-cli/linux-x64-musl": "3.6.1",
+    "@panache-cli/linux-arm64-musl": "3.6.1",
+    "@panache-cli/darwin-x64": "3.6.1",
+    "@panache-cli/darwin-arm64": "3.6.1",
+    "@panache-cli/win32-x64": "3.6.1",
+    "@panache-cli/win32-arm64": "3.6.1"
   }
 }


### PR DESCRIPTION
## [panache: 3.6.1](https://github.com/jolars/panache/compare/v3.6.0...v3.6.1) (2026-08-20)

### Bug Fixes
- **formatter:** keep trailing citations with sentences ([`9accb4f`](https://github.com/jolars/panache/commit/9accb4f5e7a7db2960ab5787d4be536a5e4b54fc)), fixes [#505](https://github.com/jolars/panache/issues/505)
- **formatter:** compose embedded math environments ([`43a3b80`](https://github.com/jolars/panache/commit/43a3b801dd463d9f76f7bf759315d2f54f0b2061))
- **formatter:** preserve starred math commands ([`8e73a5c`](https://github.com/jolars/panache/commit/8e73a5c2ab642d5268825f1c456b3ddd3b491f9c))
- **config:** discover Windows user config ([`c667947`](https://github.com/jolars/panache/commit/c667947c2836e9a20ec1024f57caca7e62ddb085)), fixes [#503](https://github.com/jolars/panache/issues/503)
- **formatter:** escape tildes contextually ([`74d82ad`](https://github.com/jolars/panache/commit/74d82ad309869a79d7b0ce96aed0ad0948ccac10)), fixes [#501](https://github.com/jolars/panache/issues/501)

### Dependencies
- updated crates/panache-formatter to v0.21.3
- updated crates/panache-parser to v0.27.2

## [crates/panache-formatter: 0.21.3](https://github.com/jolars/panache/compare/panache-formatter-v0.21.2...panache-formatter-v0.21.3) (2026-08-20)

### Bug Fixes
- **formatter:** keep trailing citations with sentences ([`9accb4f`](https://github.com/jolars/panache/commit/9accb4f5e7a7db2960ab5787d4be536a5e4b54fc)), fixes [#505](https://github.com/jolars/panache/issues/505)
- **formatter:** compose embedded math environments ([`43a3b80`](https://github.com/jolars/panache/commit/43a3b801dd463d9f76f7bf759315d2f54f0b2061))
- **formatter:** preserve starred math commands ([`8e73a5c`](https://github.com/jolars/panache/commit/8e73a5c2ab642d5268825f1c456b3ddd3b491f9c))
- **formatter:** escape tildes contextually ([`74d82ad`](https://github.com/jolars/panache/commit/74d82ad309869a79d7b0ce96aed0ad0948ccac10)), fixes [#501](https://github.com/jolars/panache/issues/501)

### Dependencies
- updated crates/panache-parser to v0.27.2

## [crates/panache-parser: 0.27.2](https://github.com/jolars/panache/compare/panache-parser-v0.27.1...panache-parser-v0.27.2) (2026-08-20)

### Bug Fixes
- **parser:** disambiguate citations from links ([`f12dd2a`](https://github.com/jolars/panache/commit/f12dd2a25575e14dfafe0d7b10c0801ec33c2d40))

## [editors/code: 3.6.1](https://github.com/jolars/panache/compare/panache-code-v3.6.0...panache-code-v3.6.1) (2026-08-20)

### Dependencies
- updated panache to v3.6.1

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).