### PR TITLE
chore(release): v3.7.0 (+4 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "ad9c9760e92eac5b4cb0ed750e5354d0af82f326",
+  "baseline-sha": "42e1a2f5ab83a4fbd097727d4452e6828df6404c",
   "release-targets": [
     {
       "path": ".",
-      "version": "3.6.1",
-      "tag": "v3.6.1"
+      "version": "3.7.0",
+      "tag": "v3.7.0"
     },
     {
       "path": "crates/panache-dprint",
@@ -14,45 +14,50 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.21.3",
-      "tag": "panache-formatter-v0.21.3"
+      "version": "0.22.0",
+      "tag": "panache-formatter-v0.22.0"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.27.2",
-      "tag": "panache-parser-v0.27.2"
+      "version": "0.28.0",
+      "tag": "panache-parser-v0.28.0"
     },
     {
       "path": "editors/code",
-      "version": "3.6.1",
-      "tag": "panache-code-v3.6.1"
+      "version": "3.7.0",
+      "tag": "panache-code-v3.7.0"
     },
     {
       "path": "editors/zed",
-      "version": "2.36.0",
-      "tag": "panache-zed-v2.36.0"
+      "version": "2.36.1",
+      "tag": "panache-zed-v2.36.1"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "3.6.1",
-      "tag": "v3.6.1"
+      "version": "3.7.0",
+      "tag": "v3.7.0"
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.21.3",
-      "tag": "panache-formatter-v0.21.3"
+      "version": "0.22.0",
+      "tag": "panache-formatter-v0.22.0"
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.27.2",
-      "tag": "panache-parser-v0.27.2"
+      "version": "0.28.0",
+      "tag": "panache-parser-v0.28.0"
     },
     {
       "path": "editors/code",
-      "version": "3.6.1",
-      "tag": "panache-code-v3.6.1"
+      "version": "3.7.0",
+      "tag": "panache-code-v3.7.0"
+    },
+    {
+      "path": "editors/zed",
+      "version": "2.36.1",
+      "tag": "panache-zed-v2.36.1"
     }
   ]
 }

--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "ad9c9760e92eac5b4cb0ed750e5354d0af82f326",
+  "baseline-sha": "5ae83ac856adfb1fcaaaba3ab09e2dbb0baa59ba",
   "release-targets": [
     {
       "path": ".",
-      "version": "3.6.1",
-      "tag": "v3.6.1"
+      "version": "3.6.2",
+      "tag": "v3.6.2"
     },
     {
       "path": "crates/panache-dprint",
@@ -24,8 +24,8 @@
     },
     {
       "path": "editors/code",
-      "version": "3.6.1",
-      "tag": "panache-code-v3.6.1"
+      "version": "3.6.2",
+      "tag": "panache-code-v3.6.2"
     },
     {
       "path": "editors/zed",
@@ -36,23 +36,13 @@
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "3.6.1",
-      "tag": "v3.6.1"
-    },
-    {
-      "path": "crates/panache-formatter",
-      "version": "0.21.3",
-      "tag": "panache-formatter-v0.21.3"
-    },
-    {
-      "path": "crates/panache-parser",
-      "version": "0.27.2",
-      "tag": "panache-parser-v0.27.2"
+      "version": "3.6.2",
+      "tag": "v3.6.2"
     },
     {
       "path": "editors/code",
-      "version": "3.6.1",
-      "tag": "panache-code-v3.6.1"
+      "version": "3.6.2",
+      "tag": "panache-code-v3.6.2"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [3.7.0](https://github.com/jolars/panache/compare/v3.6.1...v3.7.0) (2026-08-28)
 
 The experimental math formatting option has now been made stable and is activated by default:
 
@@ -10,6 +10,51 @@ math = "reflow" # or "preserve", "verbatim", "single-line"
 ```
 
 This means that Panache will now take care of formatting of math content for you, including line breaks, indentation, spacing, and alignment. Please read the documentation for the various options.
+
+### Features
+- put math formatting under `[format]\nmath = "reflow"` etc ([`308188f`](https://github.com/jolars/panache/commit/308188f6e49b6273afe3a82bc67b4f3fde7c6d41))
+- **formatter:** stabilize math formatting ([`c7f7256`](https://github.com/jolars/panache/commit/c7f72568acafed3a46dca15a119708da2107b996))
+- **formatter:** compose grouped environment prefixes ([`3704afd`](https://github.com/jolars/panache/commit/3704afd6e3daa36dbb0f7b8a8e20774d3fd7dd6c))
+- **formatter:** compose delimited environment prefixes ([`2e82b4b`](https://github.com/jolars/panache/commit/2e82b4b5e3109bb2f2ac358eb6fe210fb6f1970c))
+- **formatter:** compose operand environment prefixes ([`940b713`](https://github.com/jolars/panache/commit/940b713ab132a6b31d300b34b8cdc6eed70bc3c7))
+- **formatter:** compose unary environment prefixes ([`37ce18c`](https://github.com/jolars/panache/commit/37ce18c58f9146f43bec07ed22b6297cd490f3d0))
+- **formatter:** format scripted environments ([`8b0c333`](https://github.com/jolars/panache/commit/8b0c33389b0d4fec64c2603aa575d934b092a045))
+- **formatter:** compose environment suffix operators ([`5376765`](https://github.com/jolars/panache/commit/5376765281c1bad674846fb4073793d19edcc8d2))
+- **formatter:** format trailing environment content ([`8d754ef`](https://github.com/jolars/panache/commit/8d754ef74d737c4619ed5fe7441fd035da1f2ea9))
+- **formatter:** format relation-led environments ([`7a1d44c`](https://github.com/jolars/panache/commit/7a1d44c9181789ee90dd68f0898f5280845f65e4))
+- **formatter:** format commented display environments ([`bc26f1d`](https://github.com/jolars/panache/commit/bc26f1d99e8158087f94bdfa47e82a0563e56232))
+- **formatter:** format commented inline environments ([`615bbe9`](https://github.com/jolars/panache/commit/615bbe92e95f21714f19e02acdab7d2d536bc52c))
+- **math:** format punctuated environments ([`5e2adb7`](https://github.com/jolars/panache/commit/5e2adb77bcf288ce1375eb531b1bff11922599fd))
+- **math:** format mixed delimited environments ([`d95a857`](https://github.com/jolars/panache/commit/d95a8579f71d4b0aec8f713c3d18fe9da36bfd08))
+- **math:** lower display definition relations ([`03beb02`](https://github.com/jolars/panache/commit/03beb02ba31f2b7bc2ba326412b09cb01c976ab4))
+- **math:** lower definition relations ([`0cbd359`](https://github.com/jolars/panache/commit/0cbd359d3bf219e63ff0262cb33c85201304804a))
+- **math:** lower display wrapping ([`f7fdb7d`](https://github.com/jolars/panache/commit/f7fdb7db5c041dfae76f00853a3065c32efe7e1c))
+- **msrv:** reduce MSRV to 1.89 ([`d285e6c`](https://github.com/jolars/panache/commit/d285e6c5117220eb16d6a33ed0f4ec058451b5ad))
+- **math:** structure and format TeX math (#513) ([`02aff73`](https://github.com/jolars/panache/commit/02aff73166a9a2e33b0d6d2e71a8024d9cf9f747))
+
+### Bug Fixes
+- **formatter:** trim math line endings ([`42e1a2f`](https://github.com/jolars/panache/commit/42e1a2f5ab83a4fbd097727d4452e6828df6404c))
+- **formatter:** improve math display breaks ([`f834dfe`](https://github.com/jolars/panache/commit/f834dfe7f52456ea92186c2229b6f9c9c5410a1a))
+- **formatter:** preserve signed TeX dimensions ([`b576272`](https://github.com/jolars/panache/commit/b576272bd34ec99e63fa8a73e53ac7988d4eab75))
+- **formatter:** keep array arguments attached ([`ebb9ad2`](https://github.com/jolars/panache/commit/ebb9ad241d554a50c21202d4f7879770d529b78e))
+- **formatter:** preserve postfix limit signs ([`1d824c5`](https://github.com/jolars/panache/commit/1d824c535dae8b1cd7c11283dc453b54bd018a6f))
+- stabilize smoke-test formatting ([`0621456`](https://github.com/jolars/panache/commit/06214564c854e6ae7f399ea4977f1d207e45cc05)), fixes [#520](https://github.com/jolars/panache/issues/520)
+- **formatter:** normalize grid cell continuations ([`5ee03d5`](https://github.com/jolars/panache/commit/5ee03d524531f34b44b388d71869801ed48691fc)), fixes [#518](https://github.com/jolars/panache/issues/518)
+- **math:** format raw TeX environments idempotently ([`e8ea2f7`](https://github.com/jolars/panache/commit/e8ea2f7fb09cd0eb2c5b85c773c348385b80b04e)), fixes [#517](https://github.com/jolars/panache/issues/517)
+- **formatter:** preserve TeX control spaces ([`3f95fa9`](https://github.com/jolars/panache/commit/3f95fa9fe97476f84d7407c3dcb2c746f2d47935)), fixes [#516](https://github.com/jolars/panache/issues/516)
+- **ci:** pin math census to LF ([`a7bcd08`](https://github.com/jolars/panache/commit/a7bcd08ef9117865063262442ee73cca789faaf7))
+- **lsp:** stop watcher events from loading unreferenced files (#515) ([`e615f6a`](https://github.com/jolars/panache/commit/e615f6a21b1ca499c7d0f622565ef5822331ab8a))
+- **formatter:** format inline environment comments ([`afbe920`](https://github.com/jolars/panache/commit/afbe92021bfbd2a4d3c470b9547cfb28504e35ba))
+- **math:** reset tight-grid cell indents ([`d278aff`](https://github.com/jolars/panache/commit/d278aff9b7722939519f64ec380a429357e2785f))
+- **formatter:** stabilize mixed math fallback ([`dcd5fa0`](https://github.com/jolars/panache/commit/dcd5fa03e862e1e80bd2357c7fd45407d84b66ad)), fixes [#510](https://github.com/jolars/panache/issues/510)
+- apply formatter flavor in isolated mode ([`d0fce59`](https://github.com/jolars/panache/commit/d0fce59a197a802142e618b064085c7acc4eba61)), fixes [#509](https://github.com/jolars/panache/issues/509)
+
+### Performance Improvements
+- **lsp:** stop interning definition labels ([`15fbe12`](https://github.com/jolars/panache/commit/15fbe124a2ccbddd9f863fecf9d999314fda443f))
+
+### Dependencies
+- updated crates/panache-formatter to v0.22.0
+- updated crates/panache-parser to v0.28.0
 
 ## [3.6.1](https://github.com/jolars/panache/compare/v3.6.0...v3.6.1) (2026-08-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.6.2](https://github.com/jolars/panache/compare/v3.6.1...v3.6.2) (2026-08-21)
+
+### Performance Improvements
+- **lsp:** stop interning definition labels ([`15fbe12`](https://github.com/jolars/panache/commit/15fbe124a2ccbddd9f863fecf9d999314fda443f))
+
 ## [3.6.1](https://github.com/jolars/panache/compare/v3.6.0...v3.6.1) (2026-08-20)
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,9 +178,9 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "borsh"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
+checksum = "553c5d846a6ba5150c65e3b1b8ec073bcf1abc20f9b7220de384a4443ea4e20a"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -273,7 +273,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -326,9 +326,9 @@ checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -482,7 +482,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -585,12 +585,13 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -819,9 +820,9 @@ checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1038,9 +1039,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
 dependencies = [
  "libc",
 ]
@@ -1068,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lsp-server"
@@ -1121,9 +1122,9 @@ checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -1249,7 +1250,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "panache"
-version = "3.6.1"
+version = "3.7.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -1294,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "badness-formatter",
  "insta",
@@ -1314,7 +1315,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.27.2"
+version = "0.28.0"
 dependencies = [
  "badness-parser",
  "entities",
@@ -1600,7 +1601,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1751,7 +1752,7 @@ checksum = "445be2bfbb2f67cb663225ecd7bc5a25370c0250fca30f9d8cbad9a913650370"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1785,7 +1786,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1821,7 +1822,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1832,7 +1833,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1856,7 +1857,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1974,9 +1975,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2042,7 +2043,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2163,9 +2164,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.1"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -2275,9 +2276,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.5"
+version = "8.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
+checksum = "bae2f2b2b816647a1cab1acc91f5bd20812d53cb344382635ec2181940c8034f"
 dependencies = [
  "libc",
 ]
@@ -2456,14 +2457,20 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,9 +773,9 @@ checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1203,7 +1203,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "panache"
-version = "3.6.1"
+version = "3.6.2"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -2356,9 +2356,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "3.6.1"
+version = "3.7.0"
 edition.workspace = true
 rust-version.workspace = true
 # `distill_quarto_schema` is a dev-only vendoring bin (src/bin/); keep bare
@@ -55,11 +55,11 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.21.3", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.22.0", features = [
     "serde",
     "schema",
 ] }
-panache-parser = { path = "crates/panache-parser", version = "0.27.2", features = [
+panache-parser = { path = "crates/panache-parser", version = "0.28.0", features = [
     "serde",
     "schema",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "3.6.1"
+version = "3.6.2"
 edition.workspace = true
 rust-version.workspace = true
 # `distill_quarto_schema` is a dev-only vendoring bin (src/bin/); keep bare

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## [0.22.0](https://github.com/jolars/panache/compare/panache-formatter-v0.21.3...panache-formatter-v0.22.0) (2026-08-28)
+
+### Features
+- put math formatting under `[format]\nmath = "reflow"` etc ([`308188f`](https://github.com/jolars/panache/commit/308188f6e49b6273afe3a82bc67b4f3fde7c6d41))
+- **formatter:** stabilize math formatting ([`c7f7256`](https://github.com/jolars/panache/commit/c7f72568acafed3a46dca15a119708da2107b996))
+- **formatter:** compose grouped environment prefixes ([`3704afd`](https://github.com/jolars/panache/commit/3704afd6e3daa36dbb0f7b8a8e20774d3fd7dd6c))
+- **formatter:** compose delimited environment prefixes ([`2e82b4b`](https://github.com/jolars/panache/commit/2e82b4b5e3109bb2f2ac358eb6fe210fb6f1970c))
+- **formatter:** compose operand environment prefixes ([`940b713`](https://github.com/jolars/panache/commit/940b713ab132a6b31d300b34b8cdc6eed70bc3c7))
+- **formatter:** compose unary environment prefixes ([`37ce18c`](https://github.com/jolars/panache/commit/37ce18c58f9146f43bec07ed22b6297cd490f3d0))
+- **formatter:** format scripted environments ([`8b0c333`](https://github.com/jolars/panache/commit/8b0c33389b0d4fec64c2603aa575d934b092a045))
+- **formatter:** compose environment suffix operators ([`5376765`](https://github.com/jolars/panache/commit/5376765281c1bad674846fb4073793d19edcc8d2))
+- **formatter:** format trailing environment content ([`8d754ef`](https://github.com/jolars/panache/commit/8d754ef74d737c4619ed5fe7441fd035da1f2ea9))
+- **formatter:** format relation-led environments ([`7a1d44c`](https://github.com/jolars/panache/commit/7a1d44c9181789ee90dd68f0898f5280845f65e4))
+- **formatter:** format commented display environments ([`bc26f1d`](https://github.com/jolars/panache/commit/bc26f1d99e8158087f94bdfa47e82a0563e56232))
+- **formatter:** format commented inline environments ([`615bbe9`](https://github.com/jolars/panache/commit/615bbe92e95f21714f19e02acdab7d2d536bc52c))
+- **math:** format punctuated environments ([`5e2adb7`](https://github.com/jolars/panache/commit/5e2adb77bcf288ce1375eb531b1bff11922599fd))
+- **math:** format mixed delimited environments ([`d95a857`](https://github.com/jolars/panache/commit/d95a8579f71d4b0aec8f713c3d18fe9da36bfd08))
+- **math:** lower display definition relations ([`03beb02`](https://github.com/jolars/panache/commit/03beb02ba31f2b7bc2ba326412b09cb01c976ab4))
+- **math:** lower definition relations ([`0cbd359`](https://github.com/jolars/panache/commit/0cbd359d3bf219e63ff0262cb33c85201304804a))
+- **math:** lower display wrapping ([`f7fdb7d`](https://github.com/jolars/panache/commit/f7fdb7db5c041dfae76f00853a3065c32efe7e1c))
+- **msrv:** reduce MSRV to 1.89 ([`d285e6c`](https://github.com/jolars/panache/commit/d285e6c5117220eb16d6a33ed0f4ec058451b5ad))
+- **math:** structure and format TeX math (#513) ([`02aff73`](https://github.com/jolars/panache/commit/02aff73166a9a2e33b0d6d2e71a8024d9cf9f747))
+
+### Bug Fixes
+- **formatter:** trim math line endings ([`42e1a2f`](https://github.com/jolars/panache/commit/42e1a2f5ab83a4fbd097727d4452e6828df6404c))
+- **formatter:** improve math display breaks ([`f834dfe`](https://github.com/jolars/panache/commit/f834dfe7f52456ea92186c2229b6f9c9c5410a1a))
+- **formatter:** preserve signed TeX dimensions ([`b576272`](https://github.com/jolars/panache/commit/b576272bd34ec99e63fa8a73e53ac7988d4eab75))
+- **formatter:** keep array arguments attached ([`ebb9ad2`](https://github.com/jolars/panache/commit/ebb9ad241d554a50c21202d4f7879770d529b78e))
+- **formatter:** preserve postfix limit signs ([`1d824c5`](https://github.com/jolars/panache/commit/1d824c535dae8b1cd7c11283dc453b54bd018a6f))
+- stabilize smoke-test formatting ([`0621456`](https://github.com/jolars/panache/commit/06214564c854e6ae7f399ea4977f1d207e45cc05)), fixes [#520](https://github.com/jolars/panache/issues/520)
+- **formatter:** normalize grid cell continuations ([`5ee03d5`](https://github.com/jolars/panache/commit/5ee03d524531f34b44b388d71869801ed48691fc)), fixes [#518](https://github.com/jolars/panache/issues/518)
+- **math:** format raw TeX environments idempotently ([`e8ea2f7`](https://github.com/jolars/panache/commit/e8ea2f7fb09cd0eb2c5b85c773c348385b80b04e)), fixes [#517](https://github.com/jolars/panache/issues/517)
+- **formatter:** preserve TeX control spaces ([`3f95fa9`](https://github.com/jolars/panache/commit/3f95fa9fe97476f84d7407c3dcb2c746f2d47935)), fixes [#516](https://github.com/jolars/panache/issues/516)
+- **formatter:** format inline environment comments ([`afbe920`](https://github.com/jolars/panache/commit/afbe92021bfbd2a4d3c470b9547cfb28504e35ba))
+- **math:** reset tight-grid cell indents ([`d278aff`](https://github.com/jolars/panache/commit/d278aff9b7722939519f64ec380a429357e2785f))
+- **formatter:** stabilize mixed math fallback ([`dcd5fa0`](https://github.com/jolars/panache/commit/dcd5fa03e862e1e80bd2357c7fd45407d84b66ad)), fixes [#510](https://github.com/jolars/panache/issues/510)
+
+### Dependencies
+- updated crates/panache-parser to v0.28.0
+
 ## [0.21.3](https://github.com/jolars/panache/compare/panache-formatter-v0.21.2...panache-formatter-v0.21.3) (2026-08-20)
 
 ### Bug Fixes

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.21.3"
+version = "0.22.0"
 edition.workspace = true
 rust-version.workspace = true
 include = [
@@ -19,7 +19,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.27.2" }
+panache-parser = { path = "../panache-parser", version = "0.28.0" }
 log = { version = "0.4.31", features = ["release_max_level_debug"] }
 rowan = "0.17.0"
 serde = { version = "1.0.228", features = ["derive"], optional = true }

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.28.0](https://github.com/jolars/panache/compare/panache-parser-v0.27.2...panache-parser-v0.28.0) (2026-08-28)
+
+### Features
+- **msrv:** reduce MSRV to 1.89 ([`d285e6c`](https://github.com/jolars/panache/commit/d285e6c5117220eb16d6a33ed0f4ec058451b5ad))
+- **math:** structure and format TeX math (#513) ([`02aff73`](https://github.com/jolars/panache/commit/02aff73166a9a2e33b0d6d2e71a8024d9cf9f747))
+
+### Bug Fixes
+- **formatter:** preserve signed TeX dimensions ([`b576272`](https://github.com/jolars/panache/commit/b576272bd34ec99e63fa8a73e53ac7988d4eab75))
+- **formatter:** keep array arguments attached ([`ebb9ad2`](https://github.com/jolars/panache/commit/ebb9ad241d554a50c21202d4f7879770d529b78e))
+- **formatter:** preserve postfix limit signs ([`1d824c5`](https://github.com/jolars/panache/commit/1d824c535dae8b1cd7c11283dc453b54bd018a6f))
+- stabilize smoke-test formatting ([`0621456`](https://github.com/jolars/panache/commit/06214564c854e6ae7f399ea4977f1d207e45cc05)), fixes [#520](https://github.com/jolars/panache/issues/520)
+- **math:** format raw TeX environments idempotently ([`e8ea2f7`](https://github.com/jolars/panache/commit/e8ea2f7fb09cd0eb2c5b85c773c348385b80b04e)), fixes [#517](https://github.com/jolars/panache/issues/517)
+
 ## [0.27.2](https://github.com/jolars/panache/compare/panache-parser-v0.27.1...panache-parser-v0.27.2) (2026-08-20)
 
 ### Bug Fixes

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.27.2"
+version = "0.28.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.7.0](https://github.com/jolars/panache/compare/panache-code-v3.6.1...panache-code-v3.7.0) (2026-08-28)
+
+### Bug Fixes
+- **editors:** pin `@types/vscode` ([`4dc5a17`](https://github.com/jolars/panache/commit/4dc5a17b355535b58923effcc5c7adf4ff46f173))
+
+### Dependencies
+- updated panache to v3.7.0
+
 ## [3.6.1](https://github.com/jolars/panache/compare/panache-code-v3.6.0...panache-code-v3.6.1) (2026-08-20)
 
 ### Dependencies

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.6.2](https://github.com/jolars/panache/compare/panache-code-v3.6.1...panache-code-v3.6.2) (2026-08-21)
+
+### Dependencies
+- updated panache to v3.6.2
+
 ## [3.6.1](https://github.com/jolars/panache/compare/panache-code-v3.6.0...panache-code-v3.6.1) (2026-08-20)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/zed/CHANGELOG.md
+++ b/editors/zed/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.36.1](https://github.com/jolars/panache/compare/panache-zed-v2.36.0...panache-zed-v2.36.1) (2026-08-28)
+
+### Bug Fixes
+- **editors:** resolve zed assets more robustly ([`948969f`](https://github.com/jolars/panache/commit/948969fcb76cbc761cf34b7f242e7ce119d0fd0b))
+
 ## [2.36.0](https://github.com/jolars/panache/compare/panache-zed-v2.35.1...panache-zed-v2.36.0) (2026-06-17)
 
 ### Features

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -40,9 +40,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -55,7 +55,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -66,12 +66,13 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -145,7 +146,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -268,9 +269,9 @@ checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -340,9 +341,9 @@ checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "memchr"
@@ -352,9 +353,9 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -452,7 +453,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -514,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -763,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "zed_panache"
-version = "2.36.0"
+version = "2.36.1"
 dependencies = [
  "zed_extension_api",
 ]
@@ -813,14 +814,20 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -268,9 +268,9 @@ checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -813,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_panache"
-version = "2.36.0"
+version = "2.36.1"
 edition = "2021"
 license = "MIT"
 publish = false

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,7 +1,7 @@
 id = "panache-language-server"
 name = "Panache"
 description = "Language server for Markdown, Quarto, and R Markdown"
-version = "2.36.0"
+version = "2.36.1"
 schema_version = 1
 authors = ["Johan Larsson <johan@jolars.co>"]
 repository = "https://github.com/jolars/panache"

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         panache = pkgs.rustPlatform.buildRustPackage {
           pname = "panache";
-          version = "3.6.1";
+          version = "3.7.0";
 
           src = ./.;
 

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         panache = pkgs.rustPlatform.buildRustPackage {
           pname = "panache";
-          version = "3.6.1";
+          version = "3.6.2";
 
           src = ./.;
 

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "3.6.1",
-    "@panache-cli/linux-arm64-gnu": "3.6.1",
-    "@panache-cli/linux-x64-musl": "3.6.1",
-    "@panache-cli/linux-arm64-musl": "3.6.1",
-    "@panache-cli/darwin-x64": "3.6.1",
-    "@panache-cli/darwin-arm64": "3.6.1",
-    "@panache-cli/win32-x64": "3.6.1",
-    "@panache-cli/win32-arm64": "3.6.1"
+    "@panache-cli/linux-x64-gnu": "3.7.0",
+    "@panache-cli/linux-arm64-gnu": "3.7.0",
+    "@panache-cli/linux-x64-musl": "3.7.0",
+    "@panache-cli/linux-arm64-musl": "3.7.0",
+    "@panache-cli/darwin-x64": "3.7.0",
+    "@panache-cli/darwin-arm64": "3.7.0",
+    "@panache-cli/win32-x64": "3.7.0",
+    "@panache-cli/win32-arm64": "3.7.0"
   }
 }

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "3.6.1",
-    "@panache-cli/linux-arm64-gnu": "3.6.1",
-    "@panache-cli/linux-x64-musl": "3.6.1",
-    "@panache-cli/linux-arm64-musl": "3.6.1",
-    "@panache-cli/darwin-x64": "3.6.1",
-    "@panache-cli/darwin-arm64": "3.6.1",
-    "@panache-cli/win32-x64": "3.6.1",
-    "@panache-cli/win32-arm64": "3.6.1"
+    "@panache-cli/linux-x64-gnu": "3.6.2",
+    "@panache-cli/linux-arm64-gnu": "3.6.2",
+    "@panache-cli/linux-x64-musl": "3.6.2",
+    "@panache-cli/linux-arm64-musl": "3.6.2",
+    "@panache-cli/darwin-x64": "3.6.2",
+    "@panache-cli/darwin-arm64": "3.6.2",
+    "@panache-cli/win32-x64": "3.6.2",
+    "@panache-cli/win32-arm64": "3.6.2"
   }
 }


### PR DESCRIPTION
## [panache: 3.7.0](https://github.com/jolars/panache/compare/v3.6.1...v3.7.0) (2026-08-28)

The experimental math formatting option has now been made stable and is activated by default:

```toml
[format]
math = "reflow" # or "preserve", "verbatim", "single-line"
```

This means that Panache will now take care of formatting of math content for you, including line breaks, indentation, spacing, and alignment. Please read the documentation for the various options.

### Features
- put math formatting under `[format]\nmath = "reflow"` etc ([`308188f`](https://github.com/jolars/panache/commit/308188f6e49b6273afe3a82bc67b4f3fde7c6d41))
- **formatter:** stabilize math formatting ([`c7f7256`](https://github.com/jolars/panache/commit/c7f72568acafed3a46dca15a119708da2107b996))
- **formatter:** compose grouped environment prefixes ([`3704afd`](https://github.com/jolars/panache/commit/3704afd6e3daa36dbb0f7b8a8e20774d3fd7dd6c))
- **formatter:** compose delimited environment prefixes ([`2e82b4b`](https://github.com/jolars/panache/commit/2e82b4b5e3109bb2f2ac358eb6fe210fb6f1970c))
- **formatter:** compose operand environment prefixes ([`940b713`](https://github.com/jolars/panache/commit/940b713ab132a6b31d300b34b8cdc6eed70bc3c7))
- **formatter:** compose unary environment prefixes ([`37ce18c`](https://github.com/jolars/panache/commit/37ce18c58f9146f43bec07ed22b6297cd490f3d0))
- **formatter:** format scripted environments ([`8b0c333`](https://github.com/jolars/panache/commit/8b0c33389b0d4fec64c2603aa575d934b092a045))
- **formatter:** compose environment suffix operators ([`5376765`](https://github.com/jolars/panache/commit/5376765281c1bad674846fb4073793d19edcc8d2))
- **formatter:** format trailing environment content ([`8d754ef`](https://github.com/jolars/panache/commit/8d754ef74d737c4619ed5fe7441fd035da1f2ea9))
- **formatter:** format relation-led environments ([`7a1d44c`](https://github.com/jolars/panache/commit/7a1d44c9181789ee90dd68f0898f5280845f65e4))
- **formatter:** format commented display environments ([`bc26f1d`](https://github.com/jolars/panache/commit/bc26f1d99e8158087f94bdfa47e82a0563e56232))
- **formatter:** format commented inline environments ([`615bbe9`](https://github.com/jolars/panache/commit/615bbe92e95f21714f19e02acdab7d2d536bc52c))
- **math:** format punctuated environments ([`5e2adb7`](https://github.com/jolars/panache/commit/5e2adb77bcf288ce1375eb531b1bff11922599fd))
- **math:** format mixed delimited environments ([`d95a857`](https://github.com/jolars/panache/commit/d95a8579f71d4b0aec8f713c3d18fe9da36bfd08))
- **math:** lower display definition relations ([`03beb02`](https://github.com/jolars/panache/commit/03beb02ba31f2b7bc2ba326412b09cb01c976ab4))
- **math:** lower definition relations ([`0cbd359`](https://github.com/jolars/panache/commit/0cbd359d3bf219e63ff0262cb33c85201304804a))
- **math:** lower display wrapping ([`f7fdb7d`](https://github.com/jolars/panache/commit/f7fdb7db5c041dfae76f00853a3065c32efe7e1c))
- **msrv:** reduce MSRV to 1.89 ([`d285e6c`](https://github.com/jolars/panache/commit/d285e6c5117220eb16d6a33ed0f4ec058451b5ad))
- **math:** structure and format TeX math (#513) ([`02aff73`](https://github.com/jolars/panache/commit/02aff73166a9a2e33b0d6d2e71a8024d9cf9f747))

### Bug Fixes
- **formatter:** trim math line endings ([`42e1a2f`](https://github.com/jolars/panache/commit/42e1a2f5ab83a4fbd097727d4452e6828df6404c))
- **formatter:** improve math display breaks ([`f834dfe`](https://github.com/jolars/panache/commit/f834dfe7f52456ea92186c2229b6f9c9c5410a1a))
- **formatter:** preserve signed TeX dimensions ([`b576272`](https://github.com/jolars/panache/commit/b576272bd34ec99e63fa8a73e53ac7988d4eab75))
- **formatter:** keep array arguments attached ([`ebb9ad2`](https://github.com/jolars/panache/commit/ebb9ad241d554a50c21202d4f7879770d529b78e))
- **formatter:** preserve postfix limit signs ([`1d824c5`](https://github.com/jolars/panache/commit/1d824c535dae8b1cd7c11283dc453b54bd018a6f))
- stabilize smoke-test formatting ([`0621456`](https://github.com/jolars/panache/commit/06214564c854e6ae7f399ea4977f1d207e45cc05)), fixes [#520](https://github.com/jolars/panache/issues/520)
- **formatter:** normalize grid cell continuations ([`5ee03d5`](https://github.com/jolars/panache/commit/5ee03d524531f34b44b388d71869801ed48691fc)), fixes [#518](https://github.com/jolars/panache/issues/518)
- **math:** format raw TeX environments idempotently ([`e8ea2f7`](https://github.com/jolars/panache/commit/e8ea2f7fb09cd0eb2c5b85c773c348385b80b04e)), fixes [#517](https://github.com/jolars/panache/issues/517)
- **formatter:** preserve TeX control spaces ([`3f95fa9`](https://github.com/jolars/panache/commit/3f95fa9fe97476f84d7407c3dcb2c746f2d47935)), fixes [#516](https://github.com/jolars/panache/issues/516)
- **ci:** pin math census to LF ([`a7bcd08`](https://github.com/jolars/panache/commit/a7bcd08ef9117865063262442ee73cca789faaf7))
- **lsp:** stop watcher events from loading unreferenced files (#515) ([`e615f6a`](https://github.com/jolars/panache/commit/e615f6a21b1ca499c7d0f622565ef5822331ab8a))
- **formatter:** format inline environment comments ([`afbe920`](https://github.com/jolars/panache/commit/afbe92021bfbd2a4d3c470b9547cfb28504e35ba))
- **math:** reset tight-grid cell indents ([`d278aff`](https://github.com/jolars/panache/commit/d278aff9b7722939519f64ec380a429357e2785f))
- **formatter:** stabilize mixed math fallback ([`dcd5fa0`](https://github.com/jolars/panache/commit/dcd5fa03e862e1e80bd2357c7fd45407d84b66ad)), fixes [#510](https://github.com/jolars/panache/issues/510)
- apply formatter flavor in isolated mode ([`d0fce59`](https://github.com/jolars/panache/commit/d0fce59a197a802142e618b064085c7acc4eba61)), fixes [#509](https://github.com/jolars/panache/issues/509)

### Performance Improvements
- **lsp:** stop interning definition labels ([`15fbe12`](https://github.com/jolars/panache/commit/15fbe124a2ccbddd9f863fecf9d999314fda443f))

### Dependencies
- updated crates/panache-formatter to v0.22.0
- updated crates/panache-parser to v0.28.0

## [crates/panache-formatter: 0.22.0](https://github.com/jolars/panache/compare/panache-formatter-v0.21.3...panache-formatter-v0.22.0) (2026-08-28)

### Features
- put math formatting under `[format]\nmath = "reflow"` etc ([`308188f`](https://github.com/jolars/panache/commit/308188f6e49b6273afe3a82bc67b4f3fde7c6d41))
- **formatter:** stabilize math formatting ([`c7f7256`](https://github.com/jolars/panache/commit/c7f72568acafed3a46dca15a119708da2107b996))
- **formatter:** compose grouped environment prefixes ([`3704afd`](https://github.com/jolars/panache/commit/3704afd6e3daa36dbb0f7b8a8e20774d3fd7dd6c))
- **formatter:** compose delimited environment prefixes ([`2e82b4b`](https://github.com/jolars/panache/commit/2e82b4b5e3109bb2f2ac358eb6fe210fb6f1970c))
- **formatter:** compose operand environment prefixes ([`940b713`](https://github.com/jolars/panache/commit/940b713ab132a6b31d300b34b8cdc6eed70bc3c7))
- **formatter:** compose unary environment prefixes ([`37ce18c`](https://github.com/jolars/panache/commit/37ce18c58f9146f43bec07ed22b6297cd490f3d0))
- **formatter:** format scripted environments ([`8b0c333`](https://github.com/jolars/panache/commit/8b0c33389b0d4fec64c2603aa575d934b092a045))
- **formatter:** compose environment suffix operators ([`5376765`](https://github.com/jolars/panache/commit/5376765281c1bad674846fb4073793d19edcc8d2))
- **formatter:** format trailing environment content ([`8d754ef`](https://github.com/jolars/panache/commit/8d754ef74d737c4619ed5fe7441fd035da1f2ea9))
- **formatter:** format relation-led environments ([`7a1d44c`](https://github.com/jolars/panache/commit/7a1d44c9181789ee90dd68f0898f5280845f65e4))
- **formatter:** format commented display environments ([`bc26f1d`](https://github.com/jolars/panache/commit/bc26f1d99e8158087f94bdfa47e82a0563e56232))
- **formatter:** format commented inline environments ([`615bbe9`](https://github.com/jolars/panache/commit/615bbe92e95f21714f19e02acdab7d2d536bc52c))
- **math:** format punctuated environments ([`5e2adb7`](https://github.com/jolars/panache/commit/5e2adb77bcf288ce1375eb531b1bff11922599fd))
- **math:** format mixed delimited environments ([`d95a857`](https://github.com/jolars/panache/commit/d95a8579f71d4b0aec8f713c3d18fe9da36bfd08))
- **math:** lower display definition relations ([`03beb02`](https://github.com/jolars/panache/commit/03beb02ba31f2b7bc2ba326412b09cb01c976ab4))
- **math:** lower definition relations ([`0cbd359`](https://github.com/jolars/panache/commit/0cbd359d3bf219e63ff0262cb33c85201304804a))
- **math:** lower display wrapping ([`f7fdb7d`](https://github.com/jolars/panache/commit/f7fdb7db5c041dfae76f00853a3065c32efe7e1c))
- **msrv:** reduce MSRV to 1.89 ([`d285e6c`](https://github.com/jolars/panache/commit/d285e6c5117220eb16d6a33ed0f4ec058451b5ad))
- **math:** structure and format TeX math (#513) ([`02aff73`](https://github.com/jolars/panache/commit/02aff73166a9a2e33b0d6d2e71a8024d9cf9f747))

### Bug Fixes
- **formatter:** trim math line endings ([`42e1a2f`](https://github.com/jolars/panache/commit/42e1a2f5ab83a4fbd097727d4452e6828df6404c))
- **formatter:** improve math display breaks ([`f834dfe`](https://github.com/jolars/panache/commit/f834dfe7f52456ea92186c2229b6f9c9c5410a1a))
- **formatter:** preserve signed TeX dimensions ([`b576272`](https://github.com/jolars/panache/commit/b576272bd34ec99e63fa8a73e53ac7988d4eab75))
- **formatter:** keep array arguments attached ([`ebb9ad2`](https://github.com/jolars/panache/commit/ebb9ad241d554a50c21202d4f7879770d529b78e))
- **formatter:** preserve postfix limit signs ([`1d824c5`](https://github.com/jolars/panache/commit/1d824c535dae8b1cd7c11283dc453b54bd018a6f))
- stabilize smoke-test formatting ([`0621456`](https://github.com/jolars/panache/commit/06214564c854e6ae7f399ea4977f1d207e45cc05)), fixes [#520](https://github.com/jolars/panache/issues/520)
- **formatter:** normalize grid cell continuations ([`5ee03d5`](https://github.com/jolars/panache/commit/5ee03d524531f34b44b388d71869801ed48691fc)), fixes [#518](https://github.com/jolars/panache/issues/518)
- **math:** format raw TeX environments idempotently ([`e8ea2f7`](https://github.com/jolars/panache/commit/e8ea2f7fb09cd0eb2c5b85c773c348385b80b04e)), fixes [#517](https://github.com/jolars/panache/issues/517)
- **formatter:** preserve TeX control spaces ([`3f95fa9`](https://github.com/jolars/panache/commit/3f95fa9fe97476f84d7407c3dcb2c746f2d47935)), fixes [#516](https://github.com/jolars/panache/issues/516)
- **formatter:** format inline environment comments ([`afbe920`](https://github.com/jolars/panache/commit/afbe92021bfbd2a4d3c470b9547cfb28504e35ba))
- **math:** reset tight-grid cell indents ([`d278aff`](https://github.com/jolars/panache/commit/d278aff9b7722939519f64ec380a429357e2785f))
- **formatter:** stabilize mixed math fallback ([`dcd5fa0`](https://github.com/jolars/panache/commit/dcd5fa03e862e1e80bd2357c7fd45407d84b66ad)), fixes [#510](https://github.com/jolars/panache/issues/510)

### Dependencies
- updated crates/panache-parser to v0.28.0

## [crates/panache-parser: 0.28.0](https://github.com/jolars/panache/compare/panache-parser-v0.27.2...panache-parser-v0.28.0) (2026-08-28)

### Features
- **msrv:** reduce MSRV to 1.89 ([`d285e6c`](https://github.com/jolars/panache/commit/d285e6c5117220eb16d6a33ed0f4ec058451b5ad))
- **math:** structure and format TeX math (#513) ([`02aff73`](https://github.com/jolars/panache/commit/02aff73166a9a2e33b0d6d2e71a8024d9cf9f747))

### Bug Fixes
- **formatter:** preserve signed TeX dimensions ([`b576272`](https://github.com/jolars/panache/commit/b576272bd34ec99e63fa8a73e53ac7988d4eab75))
- **formatter:** keep array arguments attached ([`ebb9ad2`](https://github.com/jolars/panache/commit/ebb9ad241d554a50c21202d4f7879770d529b78e))
- **formatter:** preserve postfix limit signs ([`1d824c5`](https://github.com/jolars/panache/commit/1d824c535dae8b1cd7c11283dc453b54bd018a6f))
- stabilize smoke-test formatting ([`0621456`](https://github.com/jolars/panache/commit/06214564c854e6ae7f399ea4977f1d207e45cc05)), fixes [#520](https://github.com/jolars/panache/issues/520)
- **math:** format raw TeX environments idempotently ([`e8ea2f7`](https://github.com/jolars/panache/commit/e8ea2f7fb09cd0eb2c5b85c773c348385b80b04e)), fixes [#517](https://github.com/jolars/panache/issues/517)

## [editors/code: 3.7.0](https://github.com/jolars/panache/compare/panache-code-v3.6.1...panache-code-v3.7.0) (2026-08-28)

### Bug Fixes
- **editors:** pin `@types/vscode` ([`4dc5a17`](https://github.com/jolars/panache/commit/4dc5a17b355535b58923effcc5c7adf4ff46f173))

### Dependencies
- updated panache to v3.7.0

## [editors/zed: 2.36.1](https://github.com/jolars/panache/compare/panache-zed-v2.36.0...panache-zed-v2.36.1) (2026-08-28)

### Bug Fixes
- **editors:** resolve zed assets more robustly ([`948969f`](https://github.com/jolars/panache/commit/948969fcb76cbc761cf34b7f242e7ce119d0fd0b))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).