### PR TITLE
feat(lsp): 文書シンボルを見出しだけに限定可能にする

### DIFF
--- a/docs/guide/lsp.qmd
+++ b/docs/guide/lsp.qmd
@@ -555,6 +555,22 @@ Tables and figures nest under their enclosing heading. The outline appears in:
 
 The outline updates automatically as you edit.
 
+By default, Panache returns all four symbol types. Clients that use the outline
+as a heading navigator can request headings only through LSP initialization
+options:
+
+```json
+{
+  "documentSymbols": "headings"
+}
+```
+
+The accepted values are `all` (default) and `headings`. In both modes, a
+heading's symbol range covers its complete section, while its selection range
+continues to identify only the heading line. This lets clients associate body
+text with the enclosing heading without changing where outline navigation
+places the cursor.
+
 ### Code Actions
 
 Quick fixes and refactorings available at the cursor position:

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -45,9 +45,17 @@ pub struct DocumentState {
     pub salsa_config: crate::salsa::FileConfig,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum DocumentSymbolMode {
+    #[default]
+    All,
+    Headings,
+}
+
 #[derive(Debug, Clone)]
 pub struct LspRuntimeSettings {
     pub experimental_incremental_parsing: bool,
+    pub document_symbols: DocumentSymbolMode,
 }
 
 impl Default for LspRuntimeSettings {
@@ -57,6 +65,7 @@ impl Default for LspRuntimeSettings {
     fn default() -> Self {
         Self {
             experimental_incremental_parsing: true,
+            document_symbols: DocumentSymbolMode::default(),
         }
     }
 }

--- a/src/lsp/dispatch.rs
+++ b/src/lsp/dispatch.rs
@@ -221,6 +221,31 @@ pub(crate) fn runtime_incremental_parsing_from_value(value: &Value) -> Option<bo
     .or_else(|| get_bool(value, &["experimental", "incrementalParsing"]))
 }
 
+/// Read the document-symbol mode from client initialization or workspace
+/// settings. `all` preserves the full Panache outline, while `headings` omits
+/// frontmatter, tables, and figures for clients that present an outline as a
+/// heading navigator.
+pub(crate) fn runtime_document_symbol_mode_from_value(
+    value: &Value,
+) -> Option<crate::lsp::DocumentSymbolMode> {
+    fn get_str<'a>(value: &'a Value, path: &[&str]) -> Option<&'a str> {
+        let mut current = value;
+        for key in path {
+            current = current.get(key)?;
+        }
+        current.as_str()
+    }
+
+    let value = get_str(value, &["settings", "panache", "documentSymbols"])
+        .or_else(|| get_str(value, &["panache", "documentSymbols"]))
+        .or_else(|| get_str(value, &["documentSymbols"]))?;
+    match value {
+        "all" => Some(crate::lsp::DocumentSymbolMode::All),
+        "headings" => Some(crate::lsp::DocumentSymbolMode::Headings),
+        _ => None,
+    }
+}
+
 /// Incremental parsing is on unless something turns it off: the environment
 /// override first, then the client setting, then the default.
 ///
@@ -274,6 +299,14 @@ impl GlobalState {
         log::debug!(
             "lsp runtime setting experimental.incrementalParsing={experimental} (initialize options)"
         );
+
+        let document_symbols = params
+            .initialization_options
+            .as_ref()
+            .and_then(runtime_document_symbol_mode_from_value)
+            .unwrap_or_default();
+        self.runtime_settings.document_symbols = document_symbols;
+        log::debug!("lsp runtime setting documentSymbols={document_symbols:?}");
 
         // Pull diagnostics mode-switch: a client that advertises
         // `textDocument.diagnostic` is served via pull only (push is suppressed).
@@ -949,6 +982,31 @@ mod tests {
             }
             _ => panic!("expected a Task::Response"),
         }
+    }
+
+    #[test]
+    fn document_symbol_mode_reads_supported_initialization_shapes() {
+        for value in [
+            serde_json::json!({"documentSymbols": "headings"}),
+            serde_json::json!({"panache": {"documentSymbols": "headings"}}),
+            serde_json::json!({"settings": {"panache": {"documentSymbols": "headings"}}}),
+        ] {
+            assert_eq!(
+                runtime_document_symbol_mode_from_value(&value),
+                Some(crate::lsp::DocumentSymbolMode::Headings)
+            );
+        }
+
+        assert_eq!(
+            runtime_document_symbol_mode_from_value(&serde_json::json!({"documentSymbols": "all"})),
+            Some(crate::lsp::DocumentSymbolMode::All)
+        );
+        assert_eq!(
+            runtime_document_symbol_mode_from_value(
+                &serde_json::json!({"documentSymbols": "unknown"})
+            ),
+            None
+        );
     }
 
     fn uri(s: &str) -> Uri {

--- a/src/lsp/global_state.rs
+++ b/src/lsp/global_state.rs
@@ -221,6 +221,7 @@ pub(crate) struct StateSnapshot {
     /// Client capabilities the pull handler needs, copied so it runs off-thread.
     pub(crate) supports_pull_diagnostics: bool,
     pub(crate) supports_related_documents: bool,
+    pub(crate) runtime_settings: LspRuntimeSettings,
     /// The same line-index cache the writer patches, shared by handle. This is
     /// what lets a worker read find the index the last keystroke left behind
     /// instead of rebuilding it: the cache is not part of the salsa revision, so
@@ -671,6 +672,7 @@ impl GlobalState {
             diagnostics: self.diagnostics.shared(),
             supports_pull_diagnostics: self.supports_pull_diagnostics,
             supports_related_documents: self.supports_related_documents,
+            runtime_settings: self.runtime_settings.clone(),
         }
     }
 

--- a/src/lsp/handlers/configuration.rs
+++ b/src/lsp/handlers/configuration.rs
@@ -10,7 +10,9 @@
 use lsp_types::DidChangeConfigurationParams;
 use serde_json::Value;
 
-use crate::lsp::dispatch::runtime_incremental_parsing_from_value;
+use crate::lsp::dispatch::{
+    runtime_document_symbol_mode_from_value, runtime_incremental_parsing_from_value,
+};
 use crate::lsp::documents;
 use crate::lsp::global_state::GlobalState;
 
@@ -51,6 +53,10 @@ pub(crate) fn apply_pulled_configuration(gs: &mut GlobalState, value: Value) {
 /// (`settings.panache.*`) and a section-scoped pull reply (bare `experimental.*`)
 /// — both handled by [`runtime_incremental_parsing_from_value`].
 fn apply_runtime_settings(gs: &mut GlobalState, value: &Value) {
+    if let Some(mode) = runtime_document_symbol_mode_from_value(value) {
+        gs.runtime_settings.document_symbols = mode;
+    }
+
     // The environment override wins over the client, so a suite (or a
     // dogfooding session) forced one way stays that way across a
     // `didChangeConfiguration`.

--- a/src/lsp/handlers/document_symbols.rs
+++ b/src/lsp/handlers/document_symbols.rs
@@ -27,7 +27,12 @@ pub(crate) fn document_symbol(
         .find(|region| region.is_frontmatter());
 
     // Build symbols synchronously (SyntaxNode is not Send).
-    let symbols = build_document_symbols(&syntax_tree, &index, yaml_frontmatter_region);
+    let symbols = build_document_symbols_with_mode(
+        &syntax_tree,
+        &index,
+        yaml_frontmatter_region,
+        snap.runtime_settings.document_symbols,
+    );
 
     log::debug!("Found {} top-level symbols", symbols.len());
     if symbols.is_empty() {
@@ -37,10 +42,25 @@ pub(crate) fn document_symbol(
     }
 }
 
+#[cfg(test)]
 fn build_document_symbols(
     root: &SyntaxNode,
     index: &LineIndex,
     yaml_frontmatter_region: Option<&crate::syntax::ParsedYamlRegionSnapshot>,
+) -> Vec<DocumentSymbol> {
+    build_document_symbols_with_mode(
+        root,
+        index,
+        yaml_frontmatter_region,
+        crate::lsp::DocumentSymbolMode::All,
+    )
+}
+
+fn build_document_symbols_with_mode(
+    root: &SyntaxNode,
+    index: &LineIndex,
+    yaml_frontmatter_region: Option<&crate::syntax::ParsedYamlRegionSnapshot>,
+    mode: crate::lsp::DocumentSymbolMode,
 ) -> Vec<DocumentSymbol> {
     let mut symbols = Vec::new();
     let mut heading_stack: Vec<(usize, DocumentSymbol)> = Vec::new();
@@ -55,27 +75,24 @@ fn build_document_symbols(
         log::warn!("Root is not a DOCUMENT node: {:?}", root.kind());
         return symbols;
     };
-    symbols.extend(
-        yaml_frontmatter_region.and_then(|region| extract_yaml_region_symbol(region, index)),
-    );
+    if mode == crate::lsp::DocumentSymbolMode::All {
+        symbols.extend(
+            yaml_frontmatter_region.and_then(|region| extract_yaml_region_symbol(region, index)),
+        );
+    }
 
     for node in document.blocks() {
         match node.kind() {
             SyntaxKind::HEADING => {
                 if let Some(symbol) = extract_heading_symbol(&node, index) {
                     let level = heading_levels.get(&node.text_range()).copied().unwrap_or(1);
+                    let section_end = offset_to_position(index, node.text_range().start().into());
 
                     while let Some((stack_level, _)) = heading_stack.last() {
                         if *stack_level < level {
                             break;
                         }
-                        let (_, completed) = heading_stack.pop().unwrap();
-
-                        if let Some((_, parent)) = heading_stack.last_mut() {
-                            parent.children.get_or_insert_with(Vec::new).push(completed);
-                        } else {
-                            symbols.push(completed);
-                        }
+                        finish_heading(&mut heading_stack, &mut symbols, section_end);
                     }
 
                     heading_stack.push((level, symbol));
@@ -84,7 +101,9 @@ fn build_document_symbols(
             SyntaxKind::SIMPLE_TABLE
             | SyntaxKind::PIPE_TABLE
             | SyntaxKind::GRID_TABLE
-            | SyntaxKind::MULTILINE_TABLE => {
+            | SyntaxKind::MULTILINE_TABLE
+                if mode == crate::lsp::DocumentSymbolMode::All =>
+            {
                 if let Some(table) = Table::cast(node.clone())
                     && let Some(symbol) = extract_table_symbol(&table, index)
                 {
@@ -96,7 +115,7 @@ fn build_document_symbols(
                     }
                 }
             }
-            SyntaxKind::FIGURE => {
+            SyntaxKind::FIGURE if mode == crate::lsp::DocumentSymbolMode::All => {
                 if let Some(figure) = crate::syntax::Figure::cast(node.clone())
                     && let Some(image) = figure.image()
                     && let Some(symbol) = extract_figure_symbol(image.syntax(), index)
@@ -114,15 +133,26 @@ fn build_document_symbols(
     }
 
     // Flush remaining headings from stack
-    while let Some((_, completed)) = heading_stack.pop() {
-        if let Some((_, parent)) = heading_stack.last_mut() {
-            parent.children.get_or_insert_with(Vec::new).push(completed);
-        } else {
-            symbols.push(completed);
-        }
+    let document_end = offset_to_position(index, index.len());
+    while !heading_stack.is_empty() {
+        finish_heading(&mut heading_stack, &mut symbols, document_end);
     }
 
     symbols
+}
+
+fn finish_heading(
+    heading_stack: &mut Vec<(usize, DocumentSymbol)>,
+    symbols: &mut Vec<DocumentSymbol>,
+    section_end: Position,
+) {
+    let (_, mut completed) = heading_stack.pop().expect("non-empty heading stack");
+    completed.range.end = section_end;
+    if let Some((_, parent)) = heading_stack.last_mut() {
+        parent.children.get_or_insert_with(Vec::new).push(completed);
+    } else {
+        symbols.push(completed);
+    }
 }
 
 fn extract_yaml_region_symbol(
@@ -247,6 +277,7 @@ fn node_to_range(node: &SyntaxNode, index: &LineIndex) -> Option<Range> {
 mod tests {
     use super::*;
     use crate::config::Config;
+    use crate::lsp::DocumentSymbolMode;
 
     #[test]
     fn test_heading_hierarchy() {
@@ -274,6 +305,53 @@ mod tests {
 
         let h1_second = &symbols[1];
         assert_eq!(h1_second.name, "H1 Again");
+    }
+
+    #[test]
+    fn test_heading_ranges_cover_section_bodies() {
+        let content = "# H1\n\nIntro.\n\n## H2\n\nDetails.\n\n# Next\n";
+        let config = Config::default();
+        let tree = crate::parser::parse(content, Some(config));
+        let symbols = build_document_symbols(&tree, &LineIndex::new(content), None);
+
+        let h1 = &symbols[0];
+        assert_eq!(h1.selection_range.start, Position::new(0, 0));
+        assert_eq!(h1.selection_range.end, Position::new(1, 0));
+        assert_eq!(h1.range.start, Position::new(0, 0));
+        assert_eq!(h1.range.end, Position::new(8, 0));
+
+        let h2 = &h1.children.as_ref().unwrap()[0];
+        assert_eq!(h2.selection_range.start, Position::new(4, 0));
+        assert_eq!(h2.selection_range.end, Position::new(5, 0));
+        assert_eq!(h2.range.start, Position::new(4, 0));
+        assert_eq!(h2.range.end, Position::new(8, 0));
+
+        let next = &symbols[1];
+        assert_eq!(next.selection_range.start, Position::new(8, 0));
+        assert_eq!(next.selection_range.end, Position::new(9, 0));
+        assert_eq!(next.range.start, Position::new(8, 0));
+        assert_eq!(next.range.end, Position::new(9, 0));
+    }
+
+    #[test]
+    fn test_headings_mode_omits_non_heading_symbols() {
+        let content = "---\ntitle: Test\n---\n\n# Heading\n\n![Figure caption](image.png)\n";
+        let config = Config::default();
+        let tree = crate::parser::parse(content, Some(config));
+        let parsed = crate::syntax::collect_parsed_yaml_region_snapshots(&tree);
+        let yaml_frontmatter_region = parsed.iter().find(|region| region.is_frontmatter());
+        let symbols = build_document_symbols_with_mode(
+            &tree,
+            &LineIndex::new(content),
+            yaml_frontmatter_region,
+            DocumentSymbolMode::Headings,
+        );
+
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].name, "Heading");
+        assert!(symbols[0].children.as_ref().unwrap().is_empty());
+        assert_eq!(symbols[0].range.start, Position::new(4, 0));
+        assert_eq!(symbols[0].range.end, Position::new(7, 0));
     }
 
     #[test]


### PR DESCRIPTION
## 概要

LSPクライアントが文書アウトラインを見出しナビゲーションとして使えるように, 文書シンボルの表示モードを追加します.

## 変更内容

- 初期化オプションと実行時設定の`documentSymbols`を追加
- `all`を既定値として従来のYAML front matter, 表, 図を含む表示を維持
- `headings`指定時は見出しだけを文書シンボルとして返す
- 見出しの`range`を節末尾まで広げ, `selectionRange`は見出し行のまま維持
- 対応する設定形式と範囲の意味をLSPガイドへ追記
- 見出し階層, 節範囲, 見出し専用モード, 初期化設定のテストを追加

## 利用例

```json
{
  "documentSymbols": "headings"
}
```

## 検証

- `cargo check --locked --workspace`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo +1.94.1 fmt -- --check`
- 文書シンボル対象テスト13件成功
- 初期化設定テスト1件成功
- Panache本体910件とCLI172件を含む検査は成功

## 未通過の環境依存検査

全workspace testでは, この実行環境のESLint結果がfixture期待値と一致せず, 変更対象外の次の3件を完走できませんでした.

- `test_eslint_linter_sync`
- `test_eslint_linter_integration`
- `test_eslint_fix_application_end_to_end`