### PR TITLE
fix(lsp): stop watcher events from loading unreferenced files

### DIFF
--- a/src/lsp/documents.rs
+++ b/src/lsp/documents.rs
@@ -41,6 +41,16 @@ pub(crate) fn load_project_files(
         .load_referenced_files(salsa_file, salsa_config, root_path)
 }
 
+/// The on-disk paths of all open documents. An open document's buffer is
+/// authoritative: its path must never be evicted from the database or re-read
+/// from disk, or an unsaved edit would be clobbered (or its text wiped).
+pub(crate) fn open_document_paths(gs: &GlobalState) -> HashSet<PathBuf> {
+    gs.document_map
+        .values()
+        .filter_map(|state| crate::salsa::Db::path_of_id(&gs.salsa, state.file_id))
+        .collect()
+}
+
 /// Reload every open document's project-referenced files on the writer.
 ///
 /// A filesystem change (watcher event, file operation) may have flipped a
@@ -57,11 +67,7 @@ pub(crate) fn reload_open_documents_referenced_files(gs: &mut GlobalState) {
         .collect();
     // A path open as a document has buffer-authoritative content; it must never
     // be re-read from disk below or an unsaved edit would be clobbered.
-    let open_paths: HashSet<PathBuf> = gs
-        .document_map
-        .values()
-        .filter_map(|state| crate::salsa::Db::path_of_id(&gs.salsa, state.file_id))
-        .collect();
+    let open_paths = open_document_paths(gs);
     let mut referenced: HashSet<PathBuf> = HashSet::new();
     for (salsa_file, salsa_config, path) in open_docs {
         referenced.extend(load_project_files(gs, salsa_file, salsa_config, path));

--- a/src/lsp/handlers/file_operations.rs
+++ b/src/lsp/handlers/file_operations.rs
@@ -55,12 +55,17 @@ pub(crate) fn did_create_files(gs: &mut GlobalState, params: CreateFilesParams) 
 /// re-interns it so `project_graph` re-runs and its filesystem probes observe
 /// the absence — broken references in dependents surface on the next settle.
 pub(crate) fn did_delete_files(gs: &mut GlobalState, params: DeleteFilesParams) {
+    // An open document's buffer is authoritative; evicting it would wipe the
+    // text its `DocumentState` still reads. It stays untouched until `didClose`.
+    let open_paths = crate::lsp::documents::open_document_paths(gs);
     for file in &params.files {
         if let Ok(uri) = file.uri.parse::<Uri>() {
             gs.diagnostics
                 .drop_uri(&uri, &gs.sender, gs.supports_pull_diagnostics);
         }
-        if let Some(path) = op_uri_to_path(&file.uri) {
+        if let Some(path) = op_uri_to_path(&file.uri)
+            && !open_paths.contains(&path)
+        {
             gs.salsa.evict_file_text(&path);
             gs.salsa.intern_file(Some(path));
         }
@@ -76,12 +81,17 @@ pub(crate) fn did_delete_files(gs: &mut GlobalState, params: DeleteFilesParams) 
 /// `didClose(old)`/`didOpen(new)` pair; we only re-intern paths and re-lint so
 /// references to the old name break and references to the new name resolve.
 pub(crate) fn did_rename_files(gs: &mut GlobalState, params: RenameFilesParams) {
+    // Same open-document guard as `did_delete_files`: the editor's
+    // `didClose(old)`/`didOpen(new)` pair relocates open buffers.
+    let open_paths = crate::lsp::documents::open_document_paths(gs);
     for rename in &params.files {
         if let Ok(old_uri) = rename.old_uri.parse::<Uri>() {
             gs.diagnostics
                 .drop_uri(&old_uri, &gs.sender, gs.supports_pull_diagnostics);
         }
-        if let Some(old_path) = op_uri_to_path(&rename.old_uri) {
+        if let Some(old_path) = op_uri_to_path(&rename.old_uri)
+            && !open_paths.contains(&old_path)
+        {
             gs.salsa.evict_file_text(&old_path);
             gs.salsa.intern_file(Some(old_path));
         }

--- a/src/lsp/handlers/file_watcher.rs
+++ b/src/lsp/handlers/file_watcher.rs
@@ -1,10 +1,20 @@
-//! File watcher handler for bibliography files.
+//! Handler for `workspace/didChangeWatchedFiles`: keeps already-tracked file
+//! text in sync, releases deleted files' cached text, reloads config, and
+//! re-lints documents referencing a changed bibliography or manifest.
+//!
+//! The watch globs cover every JSON/YAML/TOML/bib/ris file in the workspace,
+//! so events arrive for far more files than any document references (a build
+//! writing artifacts, for one). This handler must therefore never *load* a
+//! file's contents into the database --- referenced files are loaded precisely
+//! by `reload_open_documents_referenced_files`; everything else stays an
+//! absent input, or unbounded watch traffic becomes unbounded memory.
 
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use salsa::Durability;
 
-use lsp_types::{DidChangeWatchedFilesParams, MessageType, Uri};
+use lsp_types::{DidChangeWatchedFilesParams, FileChangeType, MessageType, Uri};
 
 use super::super::helpers;
 use crate::lsp::DocumentState;
@@ -12,15 +22,59 @@ use crate::lsp::global_state::GlobalState;
 use crate::lsp::uri_ext::UriExt;
 
 pub(crate) fn did_change_watched_files(gs: &mut GlobalState, params: DidChangeWatchedFilesParams) {
+    // The last event for a path decides its fate: an atomic save can deliver
+    // DELETED followed by CREATED for the same path within one batch.
+    let mut final_change: HashMap<PathBuf, FileChangeType> = HashMap::new();
+    let mut changed_paths: Vec<PathBuf> = Vec::new();
+    for change in &params.changes {
+        let Some(path) = change.uri.to_file_path().map(|p| p.into_owned()) else {
+            continue;
+        };
+        final_change.insert(path.clone(), change.typ);
+        changed_paths.push(path);
+    }
+
+    // Only files whose contents were already loaded when the event arrived get
+    // the cached-text sync and the deletion eviction below; everything else
+    // stays an absent input, or unbounded watch traffic becomes unbounded
+    // memory. The snapshot must precede
+    // `reload_open_documents_referenced_files`, which loads newly referenced
+    // files: taken afterwards it would fold those in and re-read from disk
+    // what that reload just read.
+    let loaded_paths: HashSet<PathBuf> = changed_paths
+        .iter()
+        .filter(|path| gs.salsa.file_text_is_loaded(path))
+        .cloned()
+        .collect();
+
     // Filesystem probes are not Salsa inputs, so intern changed paths to make
     // newly created references visible to `project_graph` through `FileSet`.
-    let changed_paths: Vec<PathBuf> = params
-        .changes
-        .iter()
-        .filter_map(|change| change.uri.to_file_path().map(|p| p.into_owned()))
-        .collect();
-    for path in &changed_paths {
-        gs.salsa.intern_file(Some(path.clone()));
+    for (path, change_type) in &final_change {
+        if *change_type != FileChangeType::DELETED {
+            gs.salsa.intern_file(Some(path.clone()));
+        }
+    }
+
+    // A deleted file's cached text is released so the database does not retain
+    // it for the life of the process; the path is then re-interned with a
+    // fresh absent input so `project_graph` observes the absence (mirroring
+    // `did_delete_files`). Only a loaded path is evicted: eviction tombstones
+    // the vfs slot and re-interning mints an input salsa never drops, so doing
+    // this for a merely interned path would leak a slot and an input per
+    // delete event --- and rewrite `FileSet` twice, invalidating
+    // `project_graph` for every open document --- to release nothing. An open
+    // document's buffer is authoritative, so its path is never evicted.
+    let open_paths = crate::lsp::documents::open_document_paths(gs);
+    for (path, change_type) in &final_change {
+        if *change_type != FileChangeType::DELETED
+            || open_paths.contains(path)
+            || !loaded_paths.contains(path)
+        {
+            continue;
+        }
+        if gs.salsa.evict_file_text(path) {
+            gs.salsa.intern_file(Some(path.clone()));
+        }
     }
 
     // A `panache.toml`/`.panache.toml` edit changes config for open documents
@@ -58,8 +112,13 @@ pub(crate) fn did_change_watched_files(gs: &mut GlobalState, params: DidChangeWa
             Some("bib") | Some("json") | Some("yaml") | Some("yml") | Some("ris")
         );
 
-        // Always keep salsa's cached file text in sync when possible.
-        if let Ok(contents) = std::fs::read_to_string(&path)
+        // Keep salsa's cached file text in sync --- but only for files whose
+        // contents were already tracked before this event (see `loaded_paths`
+        // above). Everything else stays an absent input: files a document
+        // actually references are loaded precisely by
+        // `reload_open_documents_referenced_files`, never by watch traffic.
+        if loaded_paths.contains(&path)
+            && let Ok(contents) = std::fs::read_to_string(&path)
             && gs.salsa.update_file_text_if_cached_with_durability(
                 &path,
                 contents,

--- a/src/lsp/testing.rs
+++ b/src/lsp/testing.rs
@@ -682,6 +682,21 @@ impl LspTester {
         Some(file.content_or_empty(&self.gs.salsa).to_string())
     }
 
+    /// Whether `path`'s contents are loaded in the database. Sharper than
+    /// [`Self::get_cached_file_text`], which reports an interned-but-unloaded
+    /// file as `Some("")`: a merely interned path answers `false` here. Pins
+    /// the memory contract that watch traffic alone never loads file contents.
+    pub fn file_text_is_loaded(&self, path: &std::path::Path) -> bool {
+        self.gs.salsa.file_text_is_loaded(path)
+    }
+
+    /// How many vfs id slots exist, tombstoned ones included. Pins the bound
+    /// on watch traffic: repeated events for the same path must not mint a new
+    /// id (and with it a salsa input that is never dropped) each time.
+    pub fn vfs_slot_count(&self) -> usize {
+        self.gs.salsa.vfs_slot_count()
+    }
+
     // --- main-loop pumping (publishes + cancel) ---
 
     /// Drain any messages the server has emitted to the client since the

--- a/src/salsa.rs
+++ b/src/salsa.rs
@@ -2727,6 +2727,16 @@ impl SalsaDb {
         self.vfs.input_for_path(path)
     }
 
+    /// Whether `path`'s contents are loaded (`Some` text). A merely interned
+    /// path holds an absent (`None`) input and answers `false`, which
+    /// [`Self::file_text_if_cached`] cannot distinguish --- it returns the
+    /// input either way.
+    pub fn file_text_is_loaded(&self, path: &Path) -> bool {
+        self.vfs
+            .input_for_path(path)
+            .is_some_and(|file| file.text(self).is_some())
+    }
+
     /// The stable [`FileId`] backing a [`FileText`] input, if it is registered.
     /// The LSP keys an open document on this id instead of duplicating its path.
     pub fn file_id_for_input(&self, input: FileText) -> Option<FileId> {
@@ -2998,10 +3008,32 @@ impl SalsaDb {
         self.vfs.cached_paths()
     }
 
+    /// How many vfs id slots exist, tombstoned ones included. Ids are never
+    /// recycled and salsa never drops an input, so an evict/re-intern pair
+    /// grows this permanently --- which is what makes it a memory measure.
+    pub fn vfs_slot_count(&self) -> usize {
+        self.vfs.slot_count()
+    }
+
+    /// Forget `path`'s id/input mapping and release its cached text. Salsa
+    /// never drops an input, so without the explicit `None` write an evicted
+    /// file's contents would stay resident for the life of the process.
+    /// Callers must never evict a path open as a document: the open document
+    /// still reads its text through the `FileText` handle it retains.
     pub fn evict_file_text(&mut self, path: &Path) -> bool {
+        // Grab the input before the mapping goes; `remove_path` tombstones it.
+        let input = self.vfs.input_for_path(path);
         let Some(id) = self.vfs.remove_path(path) else {
             return false;
         };
+        if let Some(input) = input
+            && input.text(self).is_some()
+        {
+            input
+                .set_text(self)
+                .with_durability(Durability::MEDIUM)
+                .to(None);
+        }
         self.remove_file_from_set(id);
         true
     }

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -142,6 +142,13 @@ impl Vfs {
         self.snapshot().path_to_id.keys().cloned().collect()
     }
 
+    /// How many id slots the table holds, tombstones included. Only eviction
+    /// and interning move this number, so it is the direct measure of whether
+    /// a repeated event churns ids instead of reusing them.
+    pub(crate) fn slot_count(&self) -> usize {
+        self.snapshot().files.len()
+    }
+
     /// Register a fresh id for `path`/`input` and return it. Called only by the
     /// single writer. The id is `files.len()` (dense, append-only).
     pub(crate) fn register(&self, path: Option<PathBuf>, input: FileText) -> FileId {

--- a/tests/lsp/test_file_watcher.rs
+++ b/tests/lsp/test_file_watcher.rs
@@ -235,6 +235,176 @@ fn test_bib_change_without_watcher_event_is_picked_up_on_activity() {
 }
 
 #[test]
+fn test_watcher_does_not_load_unreferenced_files() {
+    // Regression for the LSP memory leak (#514): the watch globs cover every
+    // JSON/YAML/TOML file in the workspace, so a build writing artifacts
+    // floods the watcher with events for files no document references. Those
+    // events must not read the files' contents into the database.
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+    let doc_path = root.join("doc.qmd");
+    let json_path = root.join("build-output.json");
+
+    fs::write(&doc_path, "# Heading\n").unwrap();
+    fs::write(&json_path, "{\"artifact\": true}\n").unwrap();
+
+    let mut server = TestLspServer::new();
+    let root_uri = Uri::from_file_path(root).unwrap().to_string();
+    server.initialize(&root_uri);
+    server.open_document(
+        &Uri::from_file_path(&doc_path).unwrap().to_string(),
+        "# Heading\n",
+        "quarto",
+    );
+
+    server.did_change_watched_files(vec![FileEvent {
+        uri: Uri::from_file_path(&json_path).unwrap(),
+        typ: FileChangeType::CREATED,
+    }]);
+    assert!(
+        !server.file_text_is_loaded(&json_path),
+        "a watcher event for an unreferenced file must not load its contents"
+    );
+
+    // The first event interned the path; a second event must not mistake the
+    // now-present (absent) input for a tracked file and load it after all.
+    fs::write(&json_path, "{\"artifact\": false}\n").unwrap();
+    server.did_change_watched_files(vec![FileEvent {
+        uri: Uri::from_file_path(&json_path).unwrap(),
+        typ: FileChangeType::CHANGED,
+    }]);
+    assert!(
+        !server.file_text_is_loaded(&json_path),
+        "repeated watcher events must not load an unreferenced file's contents"
+    );
+}
+
+#[test]
+fn test_watcher_delete_releases_cached_text() {
+    // A referenced file's contents are loaded, but deleting it must release
+    // them: the database otherwise retains the text for the process lifetime.
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+    let bib_path = root.join("refs.bib");
+    let doc_path = root.join("doc.qmd");
+
+    fs::write(&bib_path, "@article{key, title={Title}}\n").unwrap();
+    fs::write(&doc_path, "---\nbibliography: refs.bib\n---\n\nText.\n").unwrap();
+
+    let mut server = TestLspServer::new();
+    let root_uri = Uri::from_file_path(root).unwrap().to_string();
+    server.initialize(&root_uri);
+    server.open_document(
+        &Uri::from_file_path(&doc_path).unwrap().to_string(),
+        &fs::read_to_string(&doc_path).unwrap(),
+        "quarto",
+    );
+    assert!(
+        server.file_text_is_loaded(&bib_path),
+        "a referenced bibliography should be loaded on open"
+    );
+
+    fs::remove_file(&bib_path).unwrap();
+    server.did_change_watched_files(vec![FileEvent {
+        uri: Uri::from_file_path(&bib_path).unwrap(),
+        typ: FileChangeType::DELETED,
+    }]);
+    assert!(
+        !server.file_text_is_loaded(&bib_path),
+        "a DELETED watcher event must release the file's cached text"
+    );
+}
+
+#[test]
+fn test_repeated_delete_of_unreferenced_file_does_not_churn_ids() {
+    // Regression for #514: a build loop that writes and removes an artifact
+    // delivers a DELETED event per iteration. Evicting a path whose contents
+    // were never loaded releases nothing, yet tombstones its vfs slot and
+    // mints a fresh salsa input that is never dropped --- growth unbounded in
+    // the number of events, inside the very handler that bounds memory.
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+    let doc_path = root.join("doc.qmd");
+    let json_path = root.join("build-output.json");
+    fs::write(&doc_path, "# Heading\n").unwrap();
+
+    let mut server = TestLspServer::new();
+    let root_uri = Uri::from_file_path(root).unwrap().to_string();
+    server.initialize(&root_uri);
+    server.open_document(
+        &Uri::from_file_path(&doc_path).unwrap().to_string(),
+        "# Heading\n",
+        "quarto",
+    );
+
+    let json_uri = Uri::from_file_path(&json_path).unwrap();
+    fs::write(&json_path, "{\"artifact\": true}\n").unwrap();
+    server.did_change_watched_files(vec![FileEvent {
+        uri: json_uri.clone(),
+        typ: FileChangeType::CREATED,
+    }]);
+    fs::remove_file(&json_path).unwrap();
+    server.did_change_watched_files(vec![FileEvent {
+        uri: json_uri.clone(),
+        typ: FileChangeType::DELETED,
+    }]);
+
+    // Baseline after one full cycle: the path is interned, nothing is loaded.
+    let baseline = server.vfs_slot_count();
+    for _ in 0..20 {
+        fs::write(&json_path, "{\"artifact\": true}\n").unwrap();
+        server.did_change_watched_files(vec![FileEvent {
+            uri: json_uri.clone(),
+            typ: FileChangeType::CREATED,
+        }]);
+        fs::remove_file(&json_path).unwrap();
+        server.did_change_watched_files(vec![FileEvent {
+            uri: json_uri.clone(),
+            typ: FileChangeType::DELETED,
+        }]);
+    }
+
+    assert_eq!(
+        server.vfs_slot_count(),
+        baseline,
+        "repeated create/delete events for a never-loaded file must reuse its id"
+    );
+    assert!(
+        !server.file_text_is_loaded(&json_path),
+        "the artifact's contents must still never be loaded"
+    );
+}
+
+#[test]
+fn test_watcher_delete_of_open_document_keeps_buffer_text() {
+    // An open document's buffer is authoritative: a DELETED watcher event for
+    // its path (a `git checkout`, an external clean) must not wipe the text
+    // the open buffer still serves from.
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+    let doc_path = root.join("doc.qmd");
+    fs::write(&doc_path, "# Heading\n").unwrap();
+
+    let mut server = TestLspServer::new();
+    let root_uri = Uri::from_file_path(root).unwrap().to_string();
+    let doc_uri = Uri::from_file_path(&doc_path).unwrap().to_string();
+    server.initialize(&root_uri);
+    server.open_document(&doc_uri, "# Heading\n", "quarto");
+
+    fs::remove_file(&doc_path).unwrap();
+    server.did_change_watched_files(vec![FileEvent {
+        uri: doc_uri.parse().unwrap(),
+        typ: FileChangeType::DELETED,
+    }]);
+
+    assert_eq!(
+        server.get_document_content(&doc_uri).as_deref(),
+        Some("# Heading\n"),
+        "deleting an open document on disk must not clear its buffer text"
+    );
+}
+
+#[test]
 fn test_broken_quarto_yml_publishes_on_manifest_uri_not_document() {
     let temp_dir = TempDir::new().unwrap();
     let root = temp_dir.path();


### PR DESCRIPTION
The didChangeWatchedFiles handler interned every changed path before
running its cached-text sync, so the sync's "only update files we
already track" guard always passed and the full contents of every
watched file that changed — every build-generated JSON/YAML/TOML in the
workspace — were read into the salsa database. Nothing ever released
them: salsa never drops an input, eviction only unmapped the path, and
DELETED watcher events were ignored. Memory grew unboundedly (7GB
reported in #514).

- Snapshot which changed paths already have loaded contents before
  interning, and sync only those; referenced files are still loaded
  precisely by reload_open_documents_referenced_files.
- Release cached text on DELETED watcher events (mirroring
  didDeleteFiles), skipping open documents whose buffer is
  authoritative.
- Make evict_file_text write the input's text back to None so eviction
  actually frees the contents instead of only unmapping the path.
- Guard didDeleteFiles/didRenameFiles eviction against open documents,
  since eviction now wipes text.

Fixes #514

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015jWt6NdhHW8GHnrSCYDdow