### PR TITLE
chore(release): v3.8.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,15 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "42e1a2f5ab83a4fbd097727d4452e6828df6404c",
+  "baseline-sha": "b10bdd9c4a1d8302fe15d14b2010e74287a214c7",
   "release-targets": [
     {
       "path": ".",
-      "version": "3.7.0",
-      "tag": "v3.7.0"
+      "version": "3.8.0",
+      "tag": "v3.8.0",
+      "dependencies": [
+        "crates/panache-formatter",
+        "crates/panache-parser"
+      ]
     },
     {
       "path": "crates/panache-dprint",
@@ -14,18 +18,24 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.22.0",
-      "tag": "panache-formatter-v0.22.0"
+      "version": "0.23.0",
+      "tag": "panache-formatter-v0.23.0",
+      "dependencies": [
+        "crates/panache-parser"
+      ]
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.28.0",
-      "tag": "panache-parser-v0.28.0"
+      "version": "0.28.1",
+      "tag": "panache-parser-v0.28.1"
     },
     {
       "path": "editors/code",
-      "version": "3.7.0",
-      "tag": "panache-code-v3.7.0"
+      "version": "3.8.0",
+      "tag": "panache-code-v3.8.0",
+      "dependencies": [
+        "."
+      ]
     },
     {
       "path": "editors/zed",
@@ -36,28 +46,33 @@
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "3.7.0",
-      "tag": "v3.7.0"
+      "version": "3.8.0",
+      "tag": "v3.8.0",
+      "dependencies": [
+        "crates/panache-formatter",
+        "crates/panache-parser"
+      ]
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.22.0",
-      "tag": "panache-formatter-v0.22.0"
+      "version": "0.23.0",
+      "tag": "panache-formatter-v0.23.0",
+      "dependencies": [
+        "crates/panache-parser"
+      ]
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.28.0",
-      "tag": "panache-parser-v0.28.0"
+      "version": "0.28.1",
+      "tag": "panache-parser-v0.28.1"
     },
     {
       "path": "editors/code",
-      "version": "3.7.0",
-      "tag": "panache-code-v3.7.0"
-    },
-    {
-      "path": "editors/zed",
-      "version": "2.36.1",
-      "tag": "panache-zed-v2.36.1"
+      "version": "3.8.0",
+      "tag": "panache-code-v3.8.0",
+      "dependencies": [
+        "."
+      ]
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [3.8.0](https://github.com/jolars/panache/compare/v3.7.0...v3.8.0) (2026-08-31)
+
+### Features
+- **lint:** flag inline math line breaks ([`d486e02`](https://github.com/jolars/panache/commit/d486e02355decbd9caa654039dce3ffe81bde254))
+- **math:** indent top-level environments ([`f222d44`](https://github.com/jolars/panache/commit/f222d448d74a53eb0d939108e244d560c9fc0e2e))
+- **lint:** flag display math blank lines ([`d5b6021`](https://github.com/jolars/panache/commit/d5b6021244aefc725695355ed88aaa2d7b6bd3e0))
+
+### Bug Fixes
+- **math:** report unescaped dollar ([`8083731`](https://github.com/jolars/panache/commit/80837318919cfe318eebd8c8b83a43db13ab2be6))
+- **formatter:** preserve math control spaces at line ends ([`b449e66`](https://github.com/jolars/panache/commit/b449e662644835ae8b62db99afa000e47be281ec))
+- **formatter:** preserve math control spaces ([`85dd96f`](https://github.com/jolars/panache/commit/85dd96f72ae3d924b2efde5c46baa8c70f7a2f60)), fixes [#522](https://github.com/jolars/panache/issues/522)
+- **formatter:** preserve control spaces in math rows ([`2c2e24f`](https://github.com/jolars/panache/commit/2c2e24fc087a6697f4f985d70c5e4478975cddb2)), fixes [#521](https://github.com/jolars/panache/issues/521)
+
+### Dependencies
+- updated crates/panache-formatter to v0.23.0
+- updated crates/panache-parser to v0.28.1
+
 ## [3.7.0](https://github.com/jolars/panache/compare/v3.6.1...v3.7.0) (2026-08-28)
 
 The experimental math formatting option has now been made stable and is activated by default:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,9 +746,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "icu_collections"
@@ -878,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -1250,7 +1250,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "panache"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "badness-formatter",
  "insta",
@@ -1315,7 +1315,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "badness-parser",
  "entities",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "3.7.0"
+version = "3.8.0"
 edition.workspace = true
 rust-version.workspace = true
 # `distill_quarto_schema` is a dev-only vendoring bin (src/bin/); keep bare
@@ -55,11 +55,11 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.22.0", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.23.0", features = [
     "serde",
     "schema",
 ] }
-panache-parser = { path = "crates/panache-parser", version = "0.28.0", features = [
+panache-parser = { path = "crates/panache-parser", version = "0.28.1", features = [
     "serde",
     "schema",
 ] }

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.23.0](https://github.com/jolars/panache/compare/panache-formatter-v0.22.0...panache-formatter-v0.23.0) (2026-08-31)
+
+### Features
+- **math:** indent top-level environments ([`f222d44`](https://github.com/jolars/panache/commit/f222d448d74a53eb0d939108e244d560c9fc0e2e))
+
+### Bug Fixes
+- **formatter:** preserve math control spaces at line ends ([`b449e66`](https://github.com/jolars/panache/commit/b449e662644835ae8b62db99afa000e47be281ec))
+- **formatter:** preserve math control spaces ([`85dd96f`](https://github.com/jolars/panache/commit/85dd96f72ae3d924b2efde5c46baa8c70f7a2f60)), fixes [#522](https://github.com/jolars/panache/issues/522)
+- **formatter:** preserve control spaces in math rows ([`2c2e24f`](https://github.com/jolars/panache/commit/2c2e24fc087a6697f4f985d70c5e4478975cddb2)), fixes [#521](https://github.com/jolars/panache/issues/521)
+
+### Dependencies
+- updated crates/panache-parser to v0.28.1
+
 ## [0.22.0](https://github.com/jolars/panache/compare/panache-formatter-v0.21.3...panache-formatter-v0.22.0) (2026-08-28)
 
 ### Features

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.22.0"
+version = "0.23.0"
 edition.workspace = true
 rust-version.workspace = true
 include = [
@@ -19,7 +19,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.28.0" }
+panache-parser = { path = "../panache-parser", version = "0.28.1" }
 log = { version = "0.4.31", features = ["release_max_level_debug"] }
 rowan = "0.17.0"
 serde = { version = "1.0.228", features = ["derive"], optional = true }

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.28.1](https://github.com/jolars/panache/compare/panache-parser-v0.28.0...panache-parser-v0.28.1) (2026-08-31)
+
+### Bug Fixes
+- **math:** report unescaped dollar ([`8083731`](https://github.com/jolars/panache/commit/80837318919cfe318eebd8c8b83a43db13ab2be6))
+
 ## [0.28.0](https://github.com/jolars/panache/compare/panache-parser-v0.27.2...panache-parser-v0.28.0) (2026-08-28)
 
 ### Features

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.28.0"
+version = "0.28.1"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.8.0](https://github.com/jolars/panache/compare/panache-code-v3.7.0...panache-code-v3.8.0) (2026-08-31)
+
+### Dependencies
+- updated panache to v3.8.0
+
 ## [3.7.0](https://github.com/jolars/panache/compare/panache-code-v3.6.1...panache-code-v3.7.0) (2026-08-28)
 
 ### Bug Fixes

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -311,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         panache = pkgs.rustPlatform.buildRustPackage {
           pname = "panache";
-          version = "3.7.0";
+          version = "3.8.0";
 
           src = ./.;
 

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "3.7.0",
-    "@panache-cli/linux-arm64-gnu": "3.7.0",
-    "@panache-cli/linux-x64-musl": "3.7.0",
-    "@panache-cli/linux-arm64-musl": "3.7.0",
-    "@panache-cli/darwin-x64": "3.7.0",
-    "@panache-cli/darwin-arm64": "3.7.0",
-    "@panache-cli/win32-x64": "3.7.0",
-    "@panache-cli/win32-arm64": "3.7.0"
+    "@panache-cli/linux-x64-gnu": "3.8.0",
+    "@panache-cli/linux-arm64-gnu": "3.8.0",
+    "@panache-cli/linux-x64-musl": "3.8.0",
+    "@panache-cli/linux-arm64-musl": "3.8.0",
+    "@panache-cli/darwin-x64": "3.8.0",
+    "@panache-cli/darwin-arm64": "3.8.0",
+    "@panache-cli/win32-x64": "3.8.0",
+    "@panache-cli/win32-arm64": "3.8.0"
   }
 }


### PR DESCRIPTION
## [panache: 3.8.0](https://github.com/jolars/panache/compare/v3.7.0...v3.8.0) (2026-08-31)

### Features
- **lint:** flag inline math line breaks ([`d486e02`](https://github.com/jolars/panache/commit/d486e02355decbd9caa654039dce3ffe81bde254))
- **math:** indent top-level environments ([`f222d44`](https://github.com/jolars/panache/commit/f222d448d74a53eb0d939108e244d560c9fc0e2e))
- **lint:** flag display math blank lines ([`d5b6021`](https://github.com/jolars/panache/commit/d5b6021244aefc725695355ed88aaa2d7b6bd3e0))

### Bug Fixes
- **math:** report unescaped dollar ([`8083731`](https://github.com/jolars/panache/commit/80837318919cfe318eebd8c8b83a43db13ab2be6))
- **formatter:** preserve math control spaces at line ends ([`b449e66`](https://github.com/jolars/panache/commit/b449e662644835ae8b62db99afa000e47be281ec))
- **formatter:** preserve math control spaces ([`85dd96f`](https://github.com/jolars/panache/commit/85dd96f72ae3d924b2efde5c46baa8c70f7a2f60)), fixes [#522](https://github.com/jolars/panache/issues/522)
- **formatter:** preserve control spaces in math rows ([`2c2e24f`](https://github.com/jolars/panache/commit/2c2e24fc087a6697f4f985d70c5e4478975cddb2)), fixes [#521](https://github.com/jolars/panache/issues/521)

### Dependencies
- updated crates/panache-formatter to v0.23.0
- updated crates/panache-parser to v0.28.1

## [crates/panache-formatter: 0.23.0](https://github.com/jolars/panache/compare/panache-formatter-v0.22.0...panache-formatter-v0.23.0) (2026-08-31)

### Features
- **math:** indent top-level environments ([`f222d44`](https://github.com/jolars/panache/commit/f222d448d74a53eb0d939108e244d560c9fc0e2e))

### Bug Fixes
- **formatter:** preserve math control spaces at line ends ([`b449e66`](https://github.com/jolars/panache/commit/b449e662644835ae8b62db99afa000e47be281ec))
- **formatter:** preserve math control spaces ([`85dd96f`](https://github.com/jolars/panache/commit/85dd96f72ae3d924b2efde5c46baa8c70f7a2f60)), fixes [#522](https://github.com/jolars/panache/issues/522)
- **formatter:** preserve control spaces in math rows ([`2c2e24f`](https://github.com/jolars/panache/commit/2c2e24fc087a6697f4f985d70c5e4478975cddb2)), fixes [#521](https://github.com/jolars/panache/issues/521)

### Dependencies
- updated crates/panache-parser to v0.28.1

## [crates/panache-parser: 0.28.1](https://github.com/jolars/panache/compare/panache-parser-v0.28.0...panache-parser-v0.28.1) (2026-08-31)

### Bug Fixes
- **math:** report unescaped dollar ([`8083731`](https://github.com/jolars/panache/commit/80837318919cfe318eebd8c8b83a43db13ab2be6))

## [editors/code: 3.8.0](https://github.com/jolars/panache/compare/panache-code-v3.7.0...panache-code-v3.8.0) (2026-08-31)

### Dependencies
- updated panache to v3.8.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).