### PR TITLE
chore(release): v3.10.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "23904a5b46d11029a096b72396165197c483867f",
+  "baseline-sha": "3c63ae4e4b0c5194b966d6520dc02b9354b94c5a",
   "release-targets": [
     {
       "path": ".",
-      "version": "3.9.0",
-      "tag": "v3.9.0",
+      "version": "3.10.0",
+      "tag": "v3.10.0",
       "dependencies": [
         "crates/panache-formatter",
         "crates/panache-parser"
@@ -18,21 +18,21 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.24.0",
-      "tag": "panache-formatter-v0.24.0",
+      "version": "0.24.1",
+      "tag": "panache-formatter-v0.24.1",
       "dependencies": [
         "crates/panache-parser"
       ]
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.29.0",
-      "tag": "panache-parser-v0.29.0"
+      "version": "0.29.1",
+      "tag": "panache-parser-v0.29.1"
     },
     {
       "path": "editors/code",
-      "version": "3.9.0",
-      "tag": "panache-code-v3.9.0",
+      "version": "3.10.0",
+      "tag": "panache-code-v3.10.0",
       "dependencies": [
         "."
       ]
@@ -46,8 +46,8 @@
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "3.9.0",
-      "tag": "v3.9.0",
+      "version": "3.10.0",
+      "tag": "v3.10.0",
       "dependencies": [
         "crates/panache-formatter",
         "crates/panache-parser"
@@ -55,21 +55,21 @@
     },
     {
       "path": "crates/panache-formatter",
-      "version": "0.24.0",
-      "tag": "panache-formatter-v0.24.0",
+      "version": "0.24.1",
+      "tag": "panache-formatter-v0.24.1",
       "dependencies": [
         "crates/panache-parser"
       ]
     },
     {
       "path": "crates/panache-parser",
-      "version": "0.29.0",
-      "tag": "panache-parser-v0.29.0"
+      "version": "0.29.1",
+      "tag": "panache-parser-v0.29.1"
     },
     {
       "path": "editors/code",
-      "version": "3.9.0",
-      "tag": "panache-code-v3.9.0",
+      "version": "3.10.0",
+      "tag": "panache-code-v3.10.0",
       "dependencies": [
         "."
       ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [3.10.0](https://github.com/jolars/panache/compare/v3.9.0...v3.10.0) (2026-09-11)
 
 This release deprecates the `[flavor-overrides`\] section of the configuration,
 which was previously used to override the `flavor` setting on a per-document
@@ -22,6 +22,20 @@ looked like this:
 "CONTRIBUTING.md" = "gfm"
 "docs/index.md" = "pandoc"
 ```
+
+### Features
+- **config:** group paths under flavors ([`2de3bd8`](https://github.com/jolars/panache/commit/2de3bd84802d0681d7d1a04c78be69345a15034c))
+- **linter:** warn on unspaced list markers ([`7ab22b5`](https://github.com/jolars/panache/commit/7ab22b5904f3f8684874845dad038a4851bf4797)), refs [#530](https://github.com/jolars/panache/issues/530)
+
+### Bug Fixes
+- **formatter:** avoid duplicate quote prefixes ([`59fe1ce`](https://github.com/jolars/panache/commit/59fe1ce681cf657493b670473d05ba1638603aac))
+- **parser:** place outdented restricted markers ([`8fe935f`](https://github.com/jolars/panache/commit/8fe935ff3f1d42a8217ffe03dc7021a8aec80397))
+- **formatter:** stabilize semantic list wrapping ([`1346dfa`](https://github.com/jolars/panache/commit/1346dfaa31ca3915f61de2b3e7fa0e58d44a9953))
+- **formatter:** wrap separate math expressions ([`d7685b7`](https://github.com/jolars/panache/commit/d7685b7ee0d18c554814c95462c689d7c793f53a))
+
+### Dependencies
+- updated crates/panache-formatter to v0.24.1
+- updated crates/panache-parser to v0.29.1
 
 ## [3.9.0](https://github.com/jolars/panache/compare/v3.8.0...v3.9.0) (2026-09-06)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,9 +166,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.1"
+version = "2.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+checksum = "3ded4057c258ba199e2d26386d3af3780957ecaee6c4ef4041c6b4b8b97c0b06"
 
 [[package]]
 name = "borrow-or-share"
@@ -309,9 +309,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
-version = "0.16.4"
+version = "0.16.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
+checksum = "e96a4956774c13c126a8b5af4daa79384f4d826534c95a02d76afb39e2ab64e3"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -568,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
+checksum = "52e0387578e845beb7a1acff126228499f26cb18edf12919cc513bb863266464"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -731,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
+checksum = "a596f1b20ed2cc5ecac41a164aaebc7258057060f06c0cf7a2ba3991ee7990fb"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -1250,7 +1250,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "panache"
-version = "3.9.0"
+version = "3.10.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "panache-formatter"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "badness-formatter",
  "insta",
@@ -1315,7 +1315,7 @@ dependencies = [
 
 [[package]]
 name = "panache-parser"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "badness-parser",
  "entities",
@@ -1570,7 +1570,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
 ]
 
 [[package]]
@@ -1699,7 +1699,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2064,9 +2064,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.5+spec-1.1.0"
+version = "1.1.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
+checksum = "920602543f0911ab71da12c50d59701da54c196d1a2bf5cb4b75667f137a406a"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -2164,9 +2164,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.26.0"
+version = "1.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
+checksum = "2ef6dac1e96601b4fb3acccccff2139741fcb757cb9a36089bf5be91cfb285ce"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -2394,18 +2394,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.56"
+version = "0.8.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+checksum = "d35102a9f36d089ccae9e4c6802bc118be4487b80aaffc0ab4e0cf5ce92d2873"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.56"
+version = "0.8.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+checksum = "146c01f5ab44258da43cf276c74a2763db2ff3969c9c652c3f2de07041d0b2bc"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "panache"
-version = "3.9.0"
+version = "3.10.0"
 edition.workspace = true
 rust-version.workspace = true
 # `distill_quarto_schema` is a dev-only vendoring bin (src/bin/); keep bare
@@ -55,11 +55,11 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-panache-formatter = { path = "crates/panache-formatter", version = "0.24.0", features = [
+panache-formatter = { path = "crates/panache-formatter", version = "0.24.1", features = [
     "serde",
     "schema",
 ] }
-panache-parser = { path = "crates/panache-parser", version = "0.29.0", features = [
+panache-parser = { path = "crates/panache-parser", version = "0.29.1", features = [
     "serde",
     "schema",
 ] }

--- a/crates/panache-formatter/CHANGELOG.md
+++ b/crates/panache-formatter/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.24.1](https://github.com/jolars/panache/compare/panache-formatter-v0.24.0...panache-formatter-v0.24.1) (2026-09-11)
+
+### Bug Fixes
+- **formatter:** avoid duplicate quote prefixes ([`59fe1ce`](https://github.com/jolars/panache/commit/59fe1ce681cf657493b670473d05ba1638603aac))
+- **formatter:** stabilize semantic list wrapping ([`1346dfa`](https://github.com/jolars/panache/commit/1346dfaa31ca3915f61de2b3e7fa0e58d44a9953))
+- **formatter:** wrap separate math expressions ([`d7685b7`](https://github.com/jolars/panache/commit/d7685b7ee0d18c554814c95462c689d7c793f53a))
+
+### Performance Improvements
+- **formatter:** cache document sentence profiles ([`c7df8a3`](https://github.com/jolars/panache/commit/c7df8a367d2e38185075e9b06023733c82ff9de4))
+
+### Dependencies
+- updated crates/panache-parser to v0.29.1
+
 ## [0.24.0](https://github.com/jolars/panache/compare/panache-formatter-v0.23.0...panache-formatter-v0.24.0) (2026-09-06)
 
 ### Features

--- a/crates/panache-formatter/Cargo.toml
+++ b/crates/panache-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-formatter"
-version = "0.24.0"
+version = "0.24.1"
 edition.workspace = true
 rust-version.workspace = true
 include = [
@@ -19,7 +19,7 @@ keywords = ["quarto", "pandoc", "markdown", "formatter"]
 categories = ["text-processing"]
 
 [dependencies]
-panache-parser = { path = "../panache-parser", version = "0.29.0" }
+panache-parser = { path = "../panache-parser", version = "0.29.1" }
 log = { version = "0.4.31", features = ["release_max_level_debug"] }
 rowan = "0.17.0"
 serde = { version = "1.0.228", features = ["derive"], optional = true }

--- a/crates/panache-parser/CHANGELOG.md
+++ b/crates/panache-parser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.29.1](https://github.com/jolars/panache/compare/panache-parser-v0.29.0...panache-parser-v0.29.1) (2026-09-11)
+
+### Bug Fixes
+- **parser:** place outdented restricted markers ([`8fe935f`](https://github.com/jolars/panache/commit/8fe935ff3f1d42a8217ffe03dc7021a8aec80397))
+- **formatter:** stabilize semantic list wrapping ([`1346dfa`](https://github.com/jolars/panache/commit/1346dfaa31ca3915f61de2b3e7fa0e58d44a9953))
+
 ## [0.29.0](https://github.com/jolars/panache/compare/panache-parser-v0.28.1...panache-parser-v0.29.0) (2026-09-06)
 
 ### Features

--- a/crates/panache-parser/Cargo.toml
+++ b/crates/panache-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panache-parser"
-version = "0.29.0"
+version = "0.29.1"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.10.0](https://github.com/jolars/panache/compare/panache-code-v3.9.0...panache-code-v3.10.0) (2026-09-11)
+
+### Dependencies
+- updated panache to v3.10.0
+
 ## [3.9.0](https://github.com/jolars/panache/compare/panache-code-v3.8.0...panache-code-v3.9.0) (2026-09-06)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "panache",
   "displayName": "Panache",
   "description": "Language server for Pandoc, Quarto, and R Markdown documents",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.13.1"
+version = "2.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+checksum = "3ded4057c258ba199e2d26386d3af3780957ecaee6c4ef4041c6b4b8b97c0b06"
 
 [[package]]
 name = "cfg-if"

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         panache = pkgs.rustPlatform.buildRustPackage {
           pname = "panache";
-          version = "3.9.0";
+          version = "3.10.0";
 
           src = ./.;
 

--- a/npm/panache-cli/package.json
+++ b/npm/panache-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panache-cli/panache",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "description": "An LSP, formatter, and linter for Pandoc markdown, Quarto, and RMarkdown",
   "keywords": [
     "quarto",
@@ -30,13 +30,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@panache-cli/linux-x64-gnu": "3.9.0",
-    "@panache-cli/linux-arm64-gnu": "3.9.0",
-    "@panache-cli/linux-x64-musl": "3.9.0",
-    "@panache-cli/linux-arm64-musl": "3.9.0",
-    "@panache-cli/darwin-x64": "3.9.0",
-    "@panache-cli/darwin-arm64": "3.9.0",
-    "@panache-cli/win32-x64": "3.9.0",
-    "@panache-cli/win32-arm64": "3.9.0"
+    "@panache-cli/linux-x64-gnu": "3.10.0",
+    "@panache-cli/linux-arm64-gnu": "3.10.0",
+    "@panache-cli/linux-x64-musl": "3.10.0",
+    "@panache-cli/linux-arm64-musl": "3.10.0",
+    "@panache-cli/darwin-x64": "3.10.0",
+    "@panache-cli/darwin-arm64": "3.10.0",
+    "@panache-cli/win32-x64": "3.10.0",
+    "@panache-cli/win32-arm64": "3.10.0"
   }
 }


### PR DESCRIPTION
## [panache: 3.10.0](https://github.com/jolars/panache/compare/v3.9.0...v3.10.0) (2026-09-11)

This release deprecates the `[flavor-overrides`\] section of the configuration,
which was previously used to override the `flavor` setting on a per-document
basis. Instead, we are introducing a new seciont `[flavors]`, which looks like
this:

```toml
[flavors]
gfm = ["TODO.md", "CONTRIBUTING.md"]
pandoc = ["docs/index.md"]
```

Using the now-deprecated `[flavor-overrides]`, the config above would have
looked like this:

```toml
[flavor-overrides]
"TODO.md" = "gfm"
"CONTRIBUTING.md" = "gfm"
"docs/index.md" = "pandoc"
```

### Features
- **config:** group paths under flavors ([`2de3bd8`](https://github.com/jolars/panache/commit/2de3bd84802d0681d7d1a04c78be69345a15034c))
- **linter:** warn on unspaced list markers ([`7ab22b5`](https://github.com/jolars/panache/commit/7ab22b5904f3f8684874845dad038a4851bf4797)), refs [#530](https://github.com/jolars/panache/issues/530)

### Bug Fixes
- **formatter:** avoid duplicate quote prefixes ([`59fe1ce`](https://github.com/jolars/panache/commit/59fe1ce681cf657493b670473d05ba1638603aac))
- **parser:** place outdented restricted markers ([`8fe935f`](https://github.com/jolars/panache/commit/8fe935ff3f1d42a8217ffe03dc7021a8aec80397))
- **formatter:** stabilize semantic list wrapping ([`1346dfa`](https://github.com/jolars/panache/commit/1346dfaa31ca3915f61de2b3e7fa0e58d44a9953))
- **formatter:** wrap separate math expressions ([`d7685b7`](https://github.com/jolars/panache/commit/d7685b7ee0d18c554814c95462c689d7c793f53a))

### Dependencies
- updated crates/panache-formatter to v0.24.1
- updated crates/panache-parser to v0.29.1

## [crates/panache-formatter: 0.24.1](https://github.com/jolars/panache/compare/panache-formatter-v0.24.0...panache-formatter-v0.24.1) (2026-09-11)

### Bug Fixes
- **formatter:** avoid duplicate quote prefixes ([`59fe1ce`](https://github.com/jolars/panache/commit/59fe1ce681cf657493b670473d05ba1638603aac))
- **formatter:** stabilize semantic list wrapping ([`1346dfa`](https://github.com/jolars/panache/commit/1346dfaa31ca3915f61de2b3e7fa0e58d44a9953))
- **formatter:** wrap separate math expressions ([`d7685b7`](https://github.com/jolars/panache/commit/d7685b7ee0d18c554814c95462c689d7c793f53a))

### Performance Improvements
- **formatter:** cache document sentence profiles ([`c7df8a3`](https://github.com/jolars/panache/commit/c7df8a367d2e38185075e9b06023733c82ff9de4))

### Dependencies
- updated crates/panache-parser to v0.29.1

## [crates/panache-parser: 0.29.1](https://github.com/jolars/panache/compare/panache-parser-v0.29.0...panache-parser-v0.29.1) (2026-09-11)

### Bug Fixes
- **parser:** place outdented restricted markers ([`8fe935f`](https://github.com/jolars/panache/commit/8fe935ff3f1d42a8217ffe03dc7021a8aec80397))
- **formatter:** stabilize semantic list wrapping ([`1346dfa`](https://github.com/jolars/panache/commit/1346dfaa31ca3915f61de2b3e7fa0e58d44a9953))

## [editors/code: 3.10.0](https://github.com/jolars/panache/compare/panache-code-v3.9.0...panache-code-v3.10.0) (2026-09-11)

### Dependencies
- updated panache to v3.10.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).